### PR TITLE
feat: set GTM ID for GA4 analytics

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -9,7 +9,6 @@
     content="Check if your insurance meets official visa requirements. Evidence-backed results verified against primary sources. No source = UNKNOWN.">
   <meta name="keywords" content="visa insurance, compliance checker, Spain DNV, evidence-based">
   <meta name="gtm-id" content="GTM-N4JLPLC2">
-  <meta name="gtm-id" content="">
   <meta property="og:title" content="VisaFact - Visa Insurance Compliance Checker">
   <meta property="og:description" content="Evidence-backed compliance checking against official visa requirements.">
   <!-- Privacy-first analytics: add Plausible/Fathom/SimpleAnalytics here if needed -->


### PR DESCRIPTION
## Summary
- Set GTM ID to `GTM-N4JLPLC2` in ui/index.html meta tag
- Fixed duplicate gtm-id meta tag issue from previous commit

## Test plan
- [ ] Verify single `<meta name="gtm-id" content="GTM-N4JLPLC2">` in HTML
- [ ] Verify GTM loads in browser Network tab
- [ ] Verify dataLayer events fire in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)