### PR TITLE
fix: enable GTM loading via CSP whitelist and Hugo partial

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -17,6 +17,8 @@ canonifyURLs = true
   [params.analytics]
     src = ""
     id = ""
+  [params.gtm]
+    id = "GTM-N4JLPLC2"
   [params.giscus]
     repo = ""
     repo_id = ""

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -3,6 +3,7 @@
 <link rel="stylesheet" href="{{ "pagefind/pagefind-ui.css" | relURL }}" />
 <script src="{{ "pagefind/pagefind-ui.js" | relURL }}"></script>
 {{ partial "analytics.html" . }}
+{{ partial "gtm.html" . }}
 <script>
   (function () {
     try {

--- a/layouts/partials/gtm.html
+++ b/layouts/partials/gtm.html
@@ -1,0 +1,24 @@
+{{- $gtmId := site.Params.gtm.id | default "" -}}
+{{- if $gtmId -}}
+<script>
+(function(){
+  var gtmId = {{ $gtmId }};
+  window.GTM_ID = gtmId;
+  window.dataLayer = window.dataLayer || [];
+  window.trackEvent = function(eventName, params) {
+    if (!window.GTM_ID) return;
+    window.dataLayer.push(Object.assign({ event: eventName }, params || {}));
+  };
+  (function(w,d,s,l,i){
+    w[l]=w[l]||[];
+    w[l].push({"gtm.start": new Date().getTime(), event:"gtm.js"});
+    var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),
+        dl=l!="dataLayer"?"&l="+l:"";
+    j.async=true;
+    j.src="https://www.googletagmanager.com/gtm.js?id="+i+dl;
+    f.parentNode.insertBefore(j,f);
+  })(window,document,"script","dataLayer",gtmId);
+})();
+</script>
+{{- end -}}

--- a/ops/headers/_headers
+++ b/ops/headers/_headers
@@ -3,4 +3,4 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; base-uri 'self'; frame-ancestors 'none'; object-src 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data: https://www.google-analytics.com; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com https://analytics.google.com; base-uri 'self'; frame-ancestors 'none'; object-src 'none'


### PR DESCRIPTION
## Summary
- CSP was blocking `googletagmanager.com` scripts - whitelisted GTM/GA4 domains
- Hugo pages lacked GTM loader (only `ui/index.html` had it) - added Hugo partial

## Test plan
- [ ] Deploy to production
- [ ] Network tab: filter `gtm.js` - should see request to `googletagmanager.com/gtm.js?id=GTM-N4JLPLC2`
- [ ] Console: `window.dataLayer` and `window.GTM_ID` exist
- [ ] Tag Assistant Preview detects container

🤖 Generated with [Claude Code](https://claude.ai/code)