### PR TITLE
🎨 Palette: Improve modal accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-28 - Manual Modal Focus Management
+**Learning:** Vanilla JS modals require explicit focus management (trap, restore, escape) which is often overlooked compared to using libraries.
+**Action:** Always implement `keydown` listeners for Tab/Escape and store/restore `document.activeElement` when building custom modals.

--- a/ui/index.html
+++ b/ui/index.html
@@ -404,11 +404,11 @@
     </div>
 
     <!-- Modal evidence -->
-    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
+    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
       <div
         class="w-full max-w-3xl bg-white dark:bg-[#111418] rounded-xl border border-border-soft dark:border-border-dark shadow-lg">
         <div class="flex items-center justify-between p-4 border-b border-border-soft dark:border-border-dark">
-          <div class="font-bold text-text-primary dark:text-white">Evidence</div>
+          <div id="modalTitle" class="font-bold text-text-primary dark:text-white">Evidence</div>
           <button id="closeModal"
             class="px-3 py-2 text-sm font-semibold border border-border-soft dark:border-border-dark rounded-lg bg-white dark:bg-gray-800 text-text-primary dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700 transition">
             Close
@@ -672,7 +672,37 @@
       return false;
     }
 
+    let previousActiveElement;
+
+    function handleModalKeydown(e) {
+      if (e.key === 'Escape') {
+        closeModal();
+        return;
+      }
+
+      if (e.key === 'Tab') {
+        const focusableElements = $("modal").querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        if (focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === firstElement) {
+            e.preventDefault();
+            lastElement.focus();
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            e.preventDefault();
+            firstElement.focus();
+          }
+        }
+      }
+    }
+
     function openModal(evidenceItems) {
+      previousActiveElement = document.activeElement;
       const body = $("modalBody");
       body.innerHTML = "";
 
@@ -711,11 +741,20 @@
 
       $("modal").classList.remove("hidden");
       $("modal").classList.add("flex");
+
+      document.addEventListener('keydown', handleModalKeydown);
+      const closeBtn = $("closeModal");
+      if (closeBtn) closeBtn.focus();
     }
 
     function closeModal() {
       $("modal").classList.add("hidden");
       $("modal").classList.remove("flex");
+
+      document.removeEventListener('keydown', handleModalKeydown);
+      if (previousActiveElement) {
+        previousActiveElement.focus();
+      }
     }
 
     function renderRequirements(visa) {


### PR DESCRIPTION
💡 What: Added `role="dialog"`, `aria-modal="true"`, and focus trapping logic to the Evidence modal.
🎯 Why: The modal was inaccessible to keyboard and screen reader users (no focus trap, no ARIA roles).
♿ Accessibility:
- Added `role="dialog"` and `aria-modal="true"`.
- Implemented `handleModalKeydown` to trap focus within the modal and close on Escape.
- Restores focus to the triggering element on close.
- Sets initial focus to the Close button.
Also normalized line endings in `ui/index.html` to LF.

---
*PR created automatically by Jules for task [4479314256089666790](https://jules.google.com/task/4479314256089666790) started by @W73QB*