### PR TITLE
🎨 Palette: Improve modal accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-29 - Modal Accessibility Pattern
+**Learning:** Vanilla JS modals (div-based) require explicit management of focus (trap within modal, restore to trigger, set initial focus) and ARIA attributes (`role="dialog"`, `aria-modal="true"`) to be accessible. Toggling CSS classes alone leaves keyboard users stranded.
+**Action:** Always implement `keydown` listeners for Escape (close) and Tab (trap) when building custom modals. Consider refactoring to native `<dialog>` element for simpler browser-native accessibility in the future.

--- a/ui/index.html
+++ b/ui/index.html
@@ -404,11 +404,11 @@
     </div>
 
     <!-- Modal evidence -->
-    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
+    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
       <div
         class="w-full max-w-3xl bg-white dark:bg-[#111418] rounded-xl border border-border-soft dark:border-border-dark shadow-lg">
         <div class="flex items-center justify-between p-4 border-b border-border-soft dark:border-border-dark">
-          <div class="font-bold text-text-primary dark:text-white">Evidence</div>
+          <div id="modalTitle" class="font-bold text-text-primary dark:text-white">Evidence</div>
           <button id="closeModal"
             class="px-3 py-2 text-sm font-semibold border border-border-soft dark:border-border-dark rounded-lg bg-white dark:bg-gray-800 text-text-primary dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700 transition">
             Close
@@ -672,7 +672,39 @@
       return false;
     }
 
+
+    let lastFocusedElement = null;
+
+    function handleModalKeydown(e) {
+      const modal = $("modal");
+      if (e.key === "Escape") {
+        closeModal();
+        e.preventDefault();
+        return;
+      }
+      if (e.key === "Tab") {
+        const focusable = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            last.focus();
+            e.preventDefault();
+          }
+        } else {
+          if (document.activeElement === last) {
+            first.focus();
+            e.preventDefault();
+          }
+        }
+      }
+    }
+
     function openModal(evidenceItems) {
+      lastFocusedElement = document.activeElement;
       const body = $("modalBody");
       body.innerHTML = "";
 
@@ -709,13 +741,22 @@
         body.appendChild(card);
       });
 
-      $("modal").classList.remove("hidden");
-      $("modal").classList.add("flex");
+      const modal = $("modal");
+      modal.classList.remove("hidden");
+      modal.classList.add("flex");
+
+      const closeBtn = $("closeModal");
+      if (closeBtn) closeBtn.focus();
+
+      window.addEventListener("keydown", handleModalKeydown);
     }
 
     function closeModal() {
-      $("modal").classList.add("hidden");
-      $("modal").classList.remove("flex");
+      const modal = $("modal");
+      modal.classList.add("hidden");
+      modal.classList.remove("flex");
+      window.removeEventListener("keydown", handleModalKeydown);
+      if (lastFocusedElement) lastFocusedElement.focus();
     }
 
     function renderRequirements(visa) {


### PR DESCRIPTION
💡 What: Added ARIA attributes and focus management to the evidence modal in `ui/index.html`.
🎯 Why: To ensure keyboard users and screen readers can navigate and close the modal effectively, as standard modals require explicit focus trapping and ARIA roles.
♿ Accessibility:
- Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby`.
- Implemented focus trap (Tab key cycles inside modal).
- Implemented Escape key to close.
- Restores focus to the triggering element on close.

---
*PR created automatically by Jules for task [1593509780757274890](https://jules.google.com/task/1593509780757274890) started by @W73QB*