### PR TITLE
🎨 Palette: Accessible Evidence Modal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Custom Modal Accessibility
+**Learning:** Custom modal implementations often lack invisible accessibility features like focus trapping and keyboard navigation (Escape key), making them unusable for keyboard-only users.
+**Action:** Always wrap custom modals with `role="dialog"`, `aria-modal="true"`, and implement explicit focus management (trap + restore) and Escape key listeners.

--- a/ui/index.html
+++ b/ui/index.html
@@ -414,11 +414,11 @@
     </div>
 
     <!-- Modal evidence -->
-    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
+    <div id="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
       <div
         class="w-full max-w-3xl bg-white dark:bg-[#111418] rounded-xl border border-border-soft dark:border-border-dark shadow-lg">
         <div class="flex items-center justify-between p-4 border-b border-border-soft dark:border-border-dark">
-          <div class="font-bold text-text-primary dark:text-white">Evidence</div>
+          <div id="modalTitle" class="font-bold text-text-primary dark:text-white">Evidence</div>
           <button id="closeModal"
             class="px-3 py-2 text-sm font-semibold border border-border-soft dark:border-border-dark rounded-lg bg-white dark:bg-gray-800 text-text-primary dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700 transition">
             Close
@@ -719,7 +719,39 @@
       return false;
     }
 
+    let lastFocusedElement = null;
+
+    function handleModalKeydown(e) {
+      if (e.key === "Escape") {
+        closeModal();
+        return;
+      }
+      if (e.key === "Tab") {
+        const modal = $("modal");
+        const focusable = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    }
+
     function openModal(evidenceItems) {
+      lastFocusedElement = document.activeElement;
+      window.addEventListener("keydown", handleModalKeydown);
+
       const body = $("modalBody");
       body.innerHTML = "";
 
@@ -758,11 +790,20 @@
 
       $("modal").classList.remove("hidden");
       $("modal").classList.add("flex");
+
+      const closeBtn = $("closeModal");
+      if (closeBtn) closeBtn.focus();
     }
 
     function closeModal() {
+      window.removeEventListener("keydown", handleModalKeydown);
       $("modal").classList.add("hidden");
       $("modal").classList.remove("flex");
+
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
     }
 
     function renderRequirements(visa) {


### PR DESCRIPTION
This PR enhances the accessibility of the evidence modal in `ui/index.html`. It addresses critical accessibility gaps for keyboard and screen reader users by implementing standard modal behaviors: focus trapping, Escape key support, proper ARIA roles, and focus restoration.

**Changes:**
- `ui/index.html`: Added accessibility attributes and JavaScript logic for focus management.
- `.jules/palette.md`: Initialized UX journal with learnings on custom modal accessibility.

**Verification:**
- Verified using a Playwright script that checks for ARIA attributes, focus containment (tab cycle), and close behavior (Escape key).
- Visually verified modal appearance and focus states.

---
*PR created automatically by Jules for task [4075597974740721984](https://jules.google.com/task/4075597974740721984) started by @W73QB*