### PR TITLE
🎨 Palette: Improve modal accessibility (focus trap, ARIA)

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - Manual Modal Accessibility
+**Learning:** The application uses a custom vanilla JS modal without `dialog` element or accessibility libraries. Manual implementation of `role="dialog"`, `aria-modal`, and focus trap is required for every modal.
+**Action:** When creating or modifying modals in `ui/index.html`, explicitly implement `handleModalKeydown` for Tab (focus trap) and Escape (close), and manage `document.activeElement` restore.

--- a/ui/index.html
+++ b/ui/index.html
@@ -414,11 +414,11 @@
     </div>
 
     <!-- Modal evidence -->
-    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
+    <div id="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
       <div
         class="w-full max-w-3xl bg-white dark:bg-[#111418] rounded-xl border border-border-soft dark:border-border-dark shadow-lg">
         <div class="flex items-center justify-between p-4 border-b border-border-soft dark:border-border-dark">
-          <div class="font-bold text-text-primary dark:text-white">Evidence</div>
+          <div id="modalTitle" class="font-bold text-text-primary dark:text-white">Evidence</div>
           <button id="closeModal"
             class="px-3 py-2 text-sm font-semibold border border-border-soft dark:border-border-dark rounded-lg bg-white dark:bg-gray-800 text-text-primary dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700 transition">
             Close
@@ -719,7 +719,42 @@
       return false;
     }
 
+    let lastFocusedElement = null;
+
+    function handleModalKeydown(e) {
+      if ($("modal").classList.contains("hidden")) return;
+
+      if (e.key === "Escape") {
+        closeModal();
+        e.preventDefault();
+        return;
+      }
+
+      if (e.key === "Tab") {
+        const focusable = $("modal").querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            last.focus();
+            e.preventDefault();
+          }
+        } else {
+          if (document.activeElement === last) {
+            first.focus();
+            e.preventDefault();
+          }
+        }
+      }
+    }
+
     function openModal(evidenceItems) {
+      lastFocusedElement = document.activeElement;
       const body = $("modalBody");
       body.innerHTML = "";
 
@@ -758,11 +793,20 @@
 
       $("modal").classList.remove("hidden");
       $("modal").classList.add("flex");
+
+      document.addEventListener("keydown", handleModalKeydown);
+      const closeBtn = $("closeModal");
+      if (closeBtn) closeBtn.focus();
     }
 
     function closeModal() {
       $("modal").classList.add("hidden");
       $("modal").classList.remove("flex");
+      document.removeEventListener("keydown", handleModalKeydown);
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
     }
 
     function renderRequirements(visa) {


### PR DESCRIPTION
# 🎨 Palette: Improve modal accessibility (focus trap, ARIA)

## 💡 What
Improved the "Evidence" modal in `ui/index.html` by adding proper ARIA attributes and managing keyboard focus.

## 🎯 Why
The previous implementation was a basic div overlay that was invisible to screen readers as a dialog and allowed keyboard focus to drift outside the modal (no focus trap). It also didn't handle the Escape key or restore focus on close, making navigation difficult for keyboard users.

## ♿ Accessibility
- **ARIA:** Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby="modalTitle"`.
- **Focus Trap:** `Tab` / `Shift+Tab` now cycles focus only within the modal elements.
- **Keyboard Navigation:** `Escape` key closes the modal.
- **Focus Management:** Focus is set to the "Close" button on open, and restored to the previous element on close.

## 📸 Verification
Verified using a Playwright script that asserts:
- Presence of ARIA attributes.
- Focus is trapped.
- Escape closes modal.
- Focus is restored.
- Visual screenshot confirms modal opens correctly.

---
*PR created automatically by Jules for task [17981178133226323868](https://jules.google.com/task/17981178133226323868) started by @W73QB*