### PR TITLE
🎨 Palette: Improve Evidence Modal Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Modal Accessibility Gaps
+**Learning:** Custom modals in `ui/index.html` were implemented without focus management (no trap, no escape key support, no focus restoration).
+**Action:** When modifying or adding modals, ensure `role="dialog"`, `aria-modal="true"`, and implement focus trapping and keyboard listeners (Escape).

--- a/ui/index.html
+++ b/ui/index.html
@@ -414,11 +414,11 @@
     </div>
 
     <!-- Modal evidence -->
-    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
+    <div id="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
       <div
         class="w-full max-w-3xl bg-white dark:bg-[#111418] rounded-xl border border-border-soft dark:border-border-dark shadow-lg">
         <div class="flex items-center justify-between p-4 border-b border-border-soft dark:border-border-dark">
-          <div class="font-bold text-text-primary dark:text-white">Evidence</div>
+          <div id="modalTitle" class="font-bold text-text-primary dark:text-white">Evidence</div>
           <button id="closeModal"
             class="px-3 py-2 text-sm font-semibold border border-border-soft dark:border-border-dark rounded-lg bg-white dark:bg-gray-800 text-text-primary dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700 transition">
             Close
@@ -719,7 +719,37 @@
       return false;
     }
 
+    let lastFocusedElement = null;
+
+    function handleModalKeydown(e) {
+      const modal = $("modal");
+      if (e.key === "Escape") {
+        closeModal();
+        return;
+      }
+      if (e.key === "Tab") {
+        const focusable = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    }
+
     function openModal(evidenceItems) {
+      lastFocusedElement = document.activeElement;
       const body = $("modalBody");
       body.innerHTML = "";
 
@@ -758,11 +788,20 @@
 
       $("modal").classList.remove("hidden");
       $("modal").classList.add("flex");
+
+      const closeBtn = $("closeModal");
+      if (closeBtn) closeBtn.focus();
+      document.addEventListener("keydown", handleModalKeydown);
     }
 
     function closeModal() {
       $("modal").classList.add("hidden");
       $("modal").classList.remove("flex");
+      document.removeEventListener("keydown", handleModalKeydown);
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
     }
 
     function renderRequirements(visa) {


### PR DESCRIPTION
Implemented focus management and ARIA attributes for the Evidence modal to improve accessibility.
- Added `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` to the modal container.
- Implemented focus trapping to keep keyboard navigation within the modal.
- Added Escape key support to close the modal.
- Ensured focus is restored to the triggering element upon closing.
- Documented the learning in `.jules/palette.md`.

---
*PR created automatically by Jules for task [6808710699452837972](https://jules.google.com/task/6808710699452837972) started by @W73QB*