### PR TITLE
🎨 Palette: Make evidence modal fully accessible

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-04 - Accessible Modal Implementation
+**Learning:** Vanilla JS modals require manual focus management (trap focus, restore focus) and ARIA attributes (`role="dialog"`, `aria-modal="true"`) to be accessible. Simply showing/hiding a div is insufficient for screen readers and keyboard users.
+**Action:** Always implement a `handleKeydown` function for `Tab` (trap) and `Escape` (close) when building custom modals, and ensure focus is restored to the triggering element on close.

--- a/ui/index.html
+++ b/ui/index.html
@@ -414,11 +414,11 @@
     </div>
 
     <!-- Modal evidence -->
-    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
+    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
       <div
         class="w-full max-w-3xl bg-white dark:bg-[#111418] rounded-xl border border-border-soft dark:border-border-dark shadow-lg">
         <div class="flex items-center justify-between p-4 border-b border-border-soft dark:border-border-dark">
-          <div class="font-bold text-text-primary dark:text-white">Evidence</div>
+          <div id="modalTitle" class="font-bold text-text-primary dark:text-white">Evidence</div>
           <button id="closeModal"
             class="px-3 py-2 text-sm font-semibold border border-border-soft dark:border-border-dark rounded-lg bg-white dark:bg-gray-800 text-text-primary dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700 transition">
             Close
@@ -719,7 +719,37 @@
       return false;
     }
 
+        let lastFocusedElement = null;
+
+    function handleModalKeydown(e) {
+      const modal = $("modal");
+      if (e.key === "Escape") {
+        closeModal();
+        return;
+      }
+      if (e.key === "Tab") {
+        const focusable = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            last.focus();
+            e.preventDefault();
+          }
+        } else {
+          if (document.activeElement === last) {
+            first.focus();
+            e.preventDefault();
+          }
+        }
+      }
+    }
+
     function openModal(evidenceItems) {
+      lastFocusedElement = document.activeElement;
       const body = $("modalBody");
       body.innerHTML = "";
 
@@ -756,13 +786,22 @@
         body.appendChild(card);
       });
 
-      $("modal").classList.remove("hidden");
-      $("modal").classList.add("flex");
+      const modal = $("modal");
+      modal.classList.remove("hidden");
+      modal.classList.add("flex");
+      modal.addEventListener("keydown", handleModalKeydown);
+      $("closeModal").focus();
     }
 
     function closeModal() {
-      $("modal").classList.add("hidden");
-      $("modal").classList.remove("flex");
+      const modal = $("modal");
+      modal.classList.add("hidden");
+      modal.classList.remove("flex");
+      modal.removeEventListener("keydown", handleModalKeydown);
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
     }
 
     function renderRequirements(visa) {


### PR DESCRIPTION
💡 What: Enhanced the 'Evidence' modal in `ui/index.html` to be fully accessible.
🎯 Why: The previous modal was just a visual overlay, trapping keyboard users and failing to announce itself to screen readers.
♿ Accessibility:
- Added `role='dialog'`, `aria-modal='true'`, and `aria-labelledby='modalTitle'`.
- Implemented focus trapping to keep tab navigation inside the modal.
- Added `Escape` key support to close the modal.
- Restores focus to the triggering element upon closing.
- Keyboard navigation now cycles correctly within the modal.

---
*PR created automatically by Jules for task [12304973857902883790](https://jules.google.com/task/12304973857902883790) started by @W73QB*