### PR TITLE
🎨 Palette: Fix form label accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-19 - Explicit Form Labels
+**Learning:** Found critical form inputs (`visaSelect`, `productSelect`) with visual labels that lacked programmatic association (`for` attribute). This breaks screen reader support despite looking correct visually.
+**Action:** When auditing forms, programmatically verify `label[for]` matches `input[id]`, do not rely on visual proximity or DOM nesting alone.

--- a/ui/index.html
+++ b/ui/index.html
@@ -163,7 +163,7 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
@@ -180,7 +180,7 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span


### PR DESCRIPTION
🎨 **Palette: Accessibility Improvement**

💡 **What:** Added `for="visaSelect"` and `for="productSelect"` to the descriptive labels in the main UI form.
🎯 **Why:** Screen readers and assistive technologies require explicit association between labels and inputs. Visually the labels looked correct, but programmatically they were disconnected. This also improves usability for all users by allowing them to click the label to focus the dropdown.
♿ **Accessibility:** Fixes "Label controls" relationship for the two main interaction points.
📸 **Verification:** Verified with Playwright script that clicking the label now correctly focuses the input.

---
*PR created automatically by Jules for task [1732913194144676215](https://jules.google.com/task/1732913194144676215) started by @W73QB*