### PR TITLE
feat(ui): improve modal accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-01 - Vanilla JS Modal Accessibility
+**Learning:** The project uses a single HTML file with vanilla JS for UI. Modals are implemented manually without a library, requiring explicit implementation of accessibility features like `role="dialog"`, `aria-modal="true"`, focus trapping, and Escape key handling.
+**Action:** When modifying or adding interactive components in `ui/index.html`, always manually verify and implement keyboard accessibility and ARIA attributes, as there is no framework to handle this automatically. Use Playwright for verification as existing tests are static.

--- a/tools/tests/ui_compliance_tests.ps1
+++ b/tools/tests/ui_compliance_tests.ps1
@@ -28,6 +28,8 @@ $ui = $ui.TrimStart([char]0xFEFF)
 
 Assert-True ($ui -like "*application/ld+json*") "UI includes JSON-LD structured data"
 Assert-True ($ui -like "*aria-live*") "UI has aria-live region"
+Assert-True ($ui -like "*role=`"dialog`"*") "UI modal has role dialog"
+Assert-True ($ui -like "*aria-modal=`"true`"*") "UI modal has aria-modal true"
 Assert-True ($ui -like "*Skip to main content*") "UI has skip link"
 Assert-True ($ui -like "*Needs Review*") "UI includes needs review badge"
 Assert-True ($ui -like "*Last Verified*") "UI includes last verified label"

--- a/ui/index.html
+++ b/ui/index.html
@@ -414,11 +414,12 @@
     </div>
 
     <!-- Modal evidence -->
-    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
+    <div id="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle"
+      class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
       <div
         class="w-full max-w-3xl bg-white dark:bg-[#111418] rounded-xl border border-border-soft dark:border-border-dark shadow-lg">
         <div class="flex items-center justify-between p-4 border-b border-border-soft dark:border-border-dark">
-          <div class="font-bold text-text-primary dark:text-white">Evidence</div>
+          <div id="modalTitle" class="font-bold text-text-primary dark:text-white">Evidence</div>
           <button id="closeModal"
             class="px-3 py-2 text-sm font-semibold border border-border-soft dark:border-border-dark rounded-lg bg-white dark:bg-gray-800 text-text-primary dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700 transition">
             Close
@@ -719,7 +720,41 @@
       return false;
     }
 
+    let lastFocusedElement = null;
+
+    function handleModalKeydown(e) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeModal();
+        return;
+      }
+      if (e.key === "Tab") {
+        const modal = $("modal");
+        const focusable = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        if (focusable.length === 0) {
+          e.preventDefault();
+          return;
+        }
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    }
+
     function openModal(evidenceItems) {
+      lastFocusedElement = document.activeElement;
       const body = $("modalBody");
       body.innerHTML = "";
 
@@ -758,11 +793,18 @@
 
       $("modal").classList.remove("hidden");
       $("modal").classList.add("flex");
+      $("closeModal").focus();
+      document.addEventListener("keydown", handleModalKeydown);
     }
 
     function closeModal() {
       $("modal").classList.add("hidden");
       $("modal").classList.remove("flex");
+      document.removeEventListener("keydown", handleModalKeydown);
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
     }
 
     function renderRequirements(visa) {


### PR DESCRIPTION
Implemented accessibility improvements for the "Evidence" modal in `ui/index.html`. 

Changes include:
- Adding `role="dialog"`, `aria-modal="true"`, and `aria-labelledby` attributes to the modal container.
- Implementing a `handleModalKeydown` function to trap focus within the modal (Tab/Shift+Tab) and close the modal on Escape.
- Updating `openModal` to save the previously focused element and `closeModal` to restore focus to it.
- Updating `tools/tests/ui_compliance_tests.ps1` to include checks for the new ARIA attributes.
- Documenting the lack of a JS framework and the need for manual accessibility implementation in `.jules/palette.md`.

Verified using a custom Playwright script and static analysis tests.

---
*PR created automatically by Jules for task [16535135093323600573](https://jules.google.com/task/16535135093323600573) started by @W73QB*