### PR TITLE
Improve Evidence Modal Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-12 - Accessible Modal Pattern
+**Learning:** This codebase uses vanilla JS for interactivity. Implementing accessible modals requires manual focus management (trap focus, restore focus) and ARIA attributes.
+**Action:** Use the `handleModalKeydown` pattern for future modals to ensure keyboard accessibility without external libraries.

--- a/ui/index.html
+++ b/ui/index.html
@@ -424,11 +424,11 @@
     </div>
 
     <!-- Modal evidence -->
-    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
+    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
       <div
         class="w-full max-w-3xl bg-white dark:bg-[#111418] rounded-xl border border-border-soft dark:border-border-dark shadow-lg">
         <div class="flex items-center justify-between p-4 border-b border-border-soft dark:border-border-dark">
-          <div class="font-bold text-text-primary dark:text-white">Evidence</div>
+          <div id="modalTitle" class="font-bold text-text-primary dark:text-white">Evidence</div>
           <button id="closeModal"
             class="px-3 py-2 text-sm font-semibold border border-border-soft dark:border-border-dark rounded-lg bg-white dark:bg-gray-800 text-text-primary dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700 transition">
             Close
@@ -601,6 +601,7 @@
 
 
     let INDEX = null;
+    let lastFocusedElement = null;
 
     // Supports both ui_index.json shapes:
     // 1) denormalized: visas_by_id/products_by_id/mappings_by_key/sources_by_id
@@ -729,6 +730,32 @@
       return false;
     }
 
+
+    function handleModalKeydown(e) {
+      const modal = $("modal");
+      if (e.key === "Escape") {
+        closeModal();
+        return;
+      }
+      if (e.key === "Tab") {
+        const focusable = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            last.focus();
+            e.preventDefault();
+          }
+        } else {
+          if (document.activeElement === last) {
+            first.focus();
+            e.preventDefault();
+          }
+        }
+      }
+    }
+
     function openModal(evidenceItems) {
       const body = $("modalBody");
       body.innerHTML = "";
@@ -768,11 +795,22 @@
 
       $("modal").classList.remove("hidden");
       $("modal").classList.add("flex");
+      $("modal").setAttribute("aria-hidden", "false");
+      lastFocusedElement = document.activeElement;
+      const closeBtn = $("closeModal");
+      if (closeBtn) closeBtn.focus();
+      document.addEventListener("keydown", handleModalKeydown);
     }
 
     function closeModal() {
       $("modal").classList.add("hidden");
       $("modal").classList.remove("flex");
+      $("modal").setAttribute("aria-hidden", "true");
+      document.removeEventListener("keydown", handleModalKeydown);
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
     }
 
     function renderRequirements(visa) {


### PR DESCRIPTION
This change improves the accessibility of the Evidence modal in `ui/index.html`. 

It adds standard ARIA attributes (`role="dialog"`, `aria-modal="true"`) and implements focus management (trapping focus inside the modal when open, restoring focus to the triggering element when closed) using vanilla JavaScript. It also adds support for closing the modal with the Escape key.

Verified with Playwright and screen reader simulation (via attributes check).

---
*PR created automatically by Jules for task [9941336816680865059](https://jules.google.com/task/9941336816680865059) started by @W73QB*