### PR TITLE
🎨 Palette: Accessibility improvements for form labels and icons

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -95,13 +95,13 @@
     class="sticky top-0 z-50 w-full bg-surface-light dark:bg-[#111418] border-b border-border-soft dark:border-border-dark backdrop-blur-md bg-opacity-95 dark:bg-opacity-95">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 h-16 flex items-center justify-between">
       <div class="flex items-center gap-2.5 hover:opacity-80 transition-opacity cursor-pointer">
-        <span class="material-symbols-outlined text-primary text-3xl icon-filled">verified_user</span>
+        <span aria-hidden="true" class="material-symbols-outlined text-primary text-3xl icon-filled">verified_user</span>
         <span class="text-text-primary dark:text-white text-xl font-bold tracking-tight">VisaFact</span>
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
         aria-label="Toggle menu">
-        <span class="material-symbols-outlined text-2xl">menu</span>
+        <span aria-hidden="true" class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
         <a class="text-sm font-medium text-text-primary dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors"
@@ -128,7 +128,7 @@
       </div>
       <button
         class="bg-primary hover:bg-primary-hover text-white text-sm font-semibold px-5 py-2.5 rounded-lg transition-all shadow-sm flex items-center gap-2">
-        <span class="material-symbols-outlined text-sm">support_agent</span>
+        <span aria-hidden="true" class="material-symbols-outlined text-sm">support_agent</span>
         Support
       </button>
     </div>
@@ -173,16 +173,16 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
-            <span
+            <span aria-hidden="true"
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
             <select id="visaSelect"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
-            <span
+            <span aria-hidden="true"
               class="material-symbols-outlined absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">expand_more</span>
           </div>
           <p id="visaHint" class="text-xs text-text-secondary dark:text-gray-500 pl-1">Choose a visa record (route +
@@ -190,16 +190,16 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
-            <span
+            <span aria-hidden="true"
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
             <select id="productSelect"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>
-            <span
+            <span aria-hidden="true"
               class="material-symbols-outlined absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">expand_more</span>
           </div>
           <p id="productHint" class="text-xs text-text-secondary dark:text-gray-500 pl-1">Choose a product record
@@ -211,7 +211,7 @@
       <div class="mt-10 flex justify-center">
         <button id="checkBtn" disabled
           class="group flex items-center gap-3 px-8 py-3.5 bg-primary/50 text-white text-lg font-bold rounded-lg transition-all shadow-md cursor-not-allowed">
-          <span class="material-symbols-outlined group-hover:scale-110 transition-transform">check_circle</span>
+          <span aria-hidden="true" class="material-symbols-outlined group-hover:scale-110 transition-transform">check_circle</span>
           Check Compliance
         </button>
       </div>
@@ -444,7 +444,7 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 py-12">
       <div class="flex flex-col md:flex-row justify-between items-center gap-8">
         <div class="flex items-center gap-2 opacity-80">
-          <span class="material-symbols-outlined text-2xl text-primary icon-filled">verified_user</span>
+          <span aria-hidden="true" class="material-symbols-outlined text-2xl text-primary icon-filled">verified_user</span>
           <span class="font-bold text-lg text-text-primary dark:text-white">VisaFact</span>
         </div>
         <div class="flex flex-wrap justify-center gap-8 text-sm font-medium text-text-secondary dark:text-gray-400">


### PR DESCRIPTION
This change improves the accessibility of the main compliance checker form in `ui/index.html` by:
1.  Explicitly associating labels with their `<select>` inputs using `for` attributes. This ensures screen readers announce the label when the input is focused and allows clicking the label to focus the input.
2.  Adding `aria-hidden="true"` to decorative Google Material Symbol icons. These icons are implemented as ligatures (text inside spans), so without `aria-hidden`, screen readers would announce the icon name (e.g., "gavel", "expand_more"), which is confusing.

No visual changes were made, and file integrity (CRLF line endings) was preserved. Verified with a Playwright script checking for the presence of these attributes.

---
*PR created automatically by Jules for task [11692231987981139190](https://jules.google.com/task/11692231987981139190) started by @W73QB*