### PR TITLE
fix: unblock daily auto-blog sitemap fetch and workflow alerts

### DIFF
--- a/.github/workflows/daily-auto-blog.yml
+++ b/.github/workflows/daily-auto-blog.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 concurrency:
   group: daily-auto-blog
@@ -62,6 +63,27 @@ jobs:
             --runs-dir docs/ops/daily-auto-blog/runs \
             --sitemap https://visafact.org/sitemap.xml \
             --draft-fixture tools/tests/fixtures/daily_auto_blog/draft.md
+
+      - name: Print run manifest summary
+        run: |
+          python - <<'PY'
+          import datetime
+          import json
+          from pathlib import Path
+
+          run_date = datetime.datetime.utcnow().strftime('%Y-%m-%d')
+          path = Path(f'docs/ops/daily-auto-blog/runs/{run_date}/run_manifest.json')
+          if not path.exists():
+              print('[daily-auto-blog] run_manifest not found')
+          else:
+              manifest = json.loads(path.read_text(encoding='utf-8'))
+              print(f"[daily-auto-blog] status={manifest.get('status', 'FAIL')}")
+              print(f"[daily-auto-blog] select_reason={manifest.get('select_reason', '')}")
+              print(f"[daily-auto-blog] write_failure_rc={manifest.get('write_failure_rc', '')}")
+              steps = manifest.get('steps', [])
+              if steps:
+                  print(f"[daily-auto-blog] last_step={steps[-1]}")
+          PY
 
       - name: Determine run status
         id: status
@@ -170,6 +192,7 @@ jobs:
           PY
 
       - name: Open issue on consecutive non-pass
+        continue-on-error: true
         if: steps.streak.outputs.alert == 'true' || steps.stale.outputs.stale_snapshots != '0' || steps.pr_aging.outputs.aged_prs != '0'
         uses: peter-evans/create-issue-from-file@v5
         with:

--- a/tools/daily_auto_blog.py
+++ b/tools/daily_auto_blog.py
@@ -55,10 +55,22 @@ BANNED_WORDS = [
     "surely",
 ]
 
+DEFAULT_HTTP_USER_AGENT = (
+    "Mozilla/5.0 (compatible; DailyAutoBlog/1.0; +https://visafact.org)"
+)
+
 
 def read_text(path_or_url: str) -> str:
     if path_or_url.startswith("http://") or path_or_url.startswith("https://"):
-        with urlopen(path_or_url, timeout=30) as resp:
+        user_agent = os.environ.get("DAILY_AUTO_BLOG_USER_AGENT", "").strip()
+        req = Request(
+            path_or_url,
+            headers={
+                "User-Agent": user_agent or DEFAULT_HTTP_USER_AGENT,
+                "Accept": "application/xml,text/xml;q=0.9,*/*;q=0.8",
+            },
+        )
+        with urlopen(req, timeout=30) as resp:
             return resp.read().decode("utf-8", errors="replace")
     return Path(path_or_url).read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- add an explicit HTTP `User-Agent` and `Accept` header when fetching sitemap URLs in `daily_auto_blog.py` to avoid 403 responses from default urllib requests
- grant `issues: write` in the daily auto-blog workflow and make issue creation non-blocking so monitoring alerts do not fail the entire run
- print a compact run manifest summary (status, selection reason, write failure code, last step) to speed up run triage

## Verification
- `pwsh -NoProfile -File tools/tests/daily_auto_blog_tests.ps1`
- `pwsh -NoProfile -File tools/tests/daily_auto_blog_workflow_tests.ps1`
- `python3 tools/daily_auto_blog.py index --sitemap https://visafact.org/sitemap.xml --output /tmp/daily-index-test.json`