### PR TITLE
🎨 Palette: Improve accessibility and modal interaction

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+## 2026-05-22 - Accessibility Gaps in Custom Modals
+**Learning:** Custom modal implementations often miss critical accessibility features like `aria-modal="true"`, `role="dialog"`, focus management (trap/restore), and Escape key handling, making them inaccessible to keyboard and screen reader users.
+**Action:** Always verify custom interactive components (like modals) against WAI-ARIA authoring practices and ensure focus management is implemented explicitly.
+
+## 2026-05-22 - Form Label Association
+**Learning:** Visual labels near form inputs are insufficient for accessibility; explicit `for` attributes linking `label` to `input` ID are mandatory for screen readers.
+**Action:** Verify all form inputs have associated labels using automated checks or code review.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,7 +173,7 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
@@ -190,7 +190,7 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
@@ -424,11 +424,11 @@
     </div>
 
     <!-- Modal evidence -->
-    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
+    <div id="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
       <div
         class="w-full max-w-3xl bg-white dark:bg-[#111418] rounded-xl border border-border-soft dark:border-border-dark shadow-lg">
         <div class="flex items-center justify-between p-4 border-b border-border-soft dark:border-border-dark">
-          <div class="font-bold text-text-primary dark:text-white">Evidence</div>
+          <h2 id="modalTitle" class="font-bold text-text-primary dark:text-white">Evidence</h2>
           <button id="closeModal"
             class="px-3 py-2 text-sm font-semibold border border-border-soft dark:border-border-dark rounded-lg bg-white dark:bg-gray-800 text-text-primary dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700 transition">
             Close
@@ -729,7 +729,10 @@
       return false;
     }
 
+    let lastFocusedElement;
+
     function openModal(evidenceItems) {
+      lastFocusedElement = document.activeElement;
       const body = $("modalBody");
       body.innerHTML = "";
 
@@ -768,11 +771,19 @@
 
       $("modal").classList.remove("hidden");
       $("modal").classList.add("flex");
+      $("closeModal").focus();
+      document.addEventListener("keydown", handleModalKeydown);
     }
 
     function closeModal() {
       $("modal").classList.add("hidden");
       $("modal").classList.remove("flex");
+      document.removeEventListener("keydown", handleModalKeydown);
+      if (lastFocusedElement) lastFocusedElement.focus();
+    }
+
+    function handleModalKeydown(e) {
+      if (e.key === "Escape") closeModal();
     }
 
     function renderRequirements(visa) {


### PR DESCRIPTION
💡 What: Improved the accessibility of the Evidence Modal and Select inputs in `ui/index.html`.
🎯 Why: To comply with WAI-ARIA standards and improve keyboard navigation and screen reader experience.
♿ Accessibility:
- Added `role="dialog"`, `aria-modal="true"`, `aria-labelledby` to modal.
- Added `id="modalTitle"` to modal title.
- Implemented focus management: focus moves to Close button on open, restores to trigger on close.
- Added Escape key handler to close modal.
- Added `for` attributes to Visa and Product labels.

---
*PR created automatically by Jules for task [3638292905858487937](https://jules.google.com/task/3638292905858487937) started by @W73QB*