### PR TITLE
🎨 Palette: Improve Evidence modal accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Accessible Modal Pattern
+**Learning:** Implemented a robust focus trap and ARIA attributes for the Evidence modal. This pattern (saving active element, trapping Tab/Shift+Tab, restoring focus on close) is essential for keyboard accessibility in vanilla JS overlays.
+**Action:** Reuse `handleModalKeydown` logic for any future overlay components (e.g., custom dropdowns, side panels).

--- a/ui/index.html
+++ b/ui/index.html
@@ -424,11 +424,11 @@
     </div>
 
     <!-- Modal evidence -->
-    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
+    <div id="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
       <div
         class="w-full max-w-3xl bg-white dark:bg-[#111418] rounded-xl border border-border-soft dark:border-border-dark shadow-lg">
         <div class="flex items-center justify-between p-4 border-b border-border-soft dark:border-border-dark">
-          <div class="font-bold text-text-primary dark:text-white">Evidence</div>
+          <div id="modalTitle" class="font-bold text-text-primary dark:text-white">Evidence</div>
           <button id="closeModal"
             class="px-3 py-2 text-sm font-semibold border border-border-soft dark:border-border-dark rounded-lg bg-white dark:bg-gray-800 text-text-primary dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700 transition">
             Close
@@ -601,6 +601,7 @@
 
 
     let INDEX = null;
+    let lastFocusedElement = null;
 
     // Supports both ui_index.json shapes:
     // 1) denormalized: visas_by_id/products_by_id/mappings_by_key/sources_by_id
@@ -729,7 +730,42 @@
       return false;
     }
 
+
+    function handleModalKeydown(e) {
+      const modal = $("modal");
+      if (modal.classList.contains("hidden")) return;
+
+      if (e.key === "Escape") {
+        closeModal();
+        e.preventDefault();
+        return;
+      }
+
+      if (e.key === "Tab") {
+        const focusableElements = modal.querySelectorAll(
+          'a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select'
+        );
+        if (focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === firstElement) {
+            lastElement.focus();
+            e.preventDefault();
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            firstElement.focus();
+            e.preventDefault();
+          }
+        }
+      }
+    }
+
     function openModal(evidenceItems) {
+      lastFocusedElement = document.activeElement;
       const body = $("modalBody");
       body.innerHTML = "";
 
@@ -768,11 +804,16 @@
 
       $("modal").classList.remove("hidden");
       $("modal").classList.add("flex");
+      const closeBtn = $("closeModal");
+      if (closeBtn) closeBtn.focus();
+      document.addEventListener("keydown", handleModalKeydown);
     }
 
     function closeModal() {
       $("modal").classList.add("hidden");
       $("modal").classList.remove("flex");
+      document.removeEventListener("keydown", handleModalKeydown);
+      if (lastFocusedElement) lastFocusedElement.focus();
     }
 
     function renderRequirements(visa) {


### PR DESCRIPTION
💡 What: Enhanced the "Evidence" modal in `ui/index.html` to be fully accessible.
🎯 Why: The modal previously trapped keyboard users (no focus management) and lacked semantic ARIA roles, making it difficult for screen reader users.
📸 Before/After: The visual appearance is unchanged, but the interactive behavior now supports keyboard navigation (Tab/Escape) and screen readers.
♿ Accessibility: Added `role="dialog"`, `aria-modal`, focus trapping, and focus restoration.

---
*PR created automatically by Jules for task [522341861333162179](https://jules.google.com/task/522341861333162179) started by @W73QB*