### PR TITLE
🎨 Palette: Enhance Evidence modal accessibility with focus trap and ARIA roles

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -424,11 +424,11 @@
     </div>
 
     <!-- Modal evidence -->
-    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
+    <div id="modal" role="dialog" aria-modal="true" aria-labelledby="modalTitle" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
       <div
         class="w-full max-w-3xl bg-white dark:bg-[#111418] rounded-xl border border-border-soft dark:border-border-dark shadow-lg">
         <div class="flex items-center justify-between p-4 border-b border-border-soft dark:border-border-dark">
-          <div class="font-bold text-text-primary dark:text-white">Evidence</div>
+          <div id="modalTitle" class="font-bold text-text-primary dark:text-white">Evidence</div>
           <button id="closeModal"
             class="px-3 py-2 text-sm font-semibold border border-border-soft dark:border-border-dark rounded-lg bg-white dark:bg-gray-800 text-text-primary dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700 transition">
             Close
@@ -601,6 +601,7 @@
 
 
     let INDEX = null;
+    let lastFocusedElement = null;
 
     // Supports both ui_index.json shapes:
     // 1) denormalized: visas_by_id/products_by_id/mappings_by_key/sources_by_id
@@ -729,6 +730,30 @@
       return false;
     }
 
+    function handleModalKeydown(e) {
+      if (e.key === "Escape") {
+        closeModal();
+        return;
+      }
+      if (e.key === "Tab") {
+        const focusable = $("modal").querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    }
+
     function openModal(evidenceItems) {
       const body = $("modalBody");
       body.innerHTML = "";
@@ -768,11 +793,20 @@
 
       $("modal").classList.remove("hidden");
       $("modal").classList.add("flex");
+      lastFocusedElement = document.activeElement;
+      const closeBtn = $("closeModal");
+      if (closeBtn) closeBtn.focus();
+      document.addEventListener("keydown", handleModalKeydown);
     }
 
     function closeModal() {
       $("modal").classList.add("hidden");
       $("modal").classList.remove("flex");
+      document.removeEventListener("keydown", handleModalKeydown);
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+        lastFocusedElement = null;
+      }
     }
 
     function renderRequirements(visa) {


### PR DESCRIPTION
Enhanced the accessibility of the Evidence modal in `ui/index.html` by adding proper ARIA attributes (`role="dialog"`, `aria-modal="true"`) and implementing a keyboard focus trap. The modal now correctly manages focus (moves to close button on open, traps Tab cycle, restores focus on close) and supports the Escape key for closing. These changes ensure compliance with WAI-ARIA authoring practices for modal dialogs. Verified using Playwright and existing compliance checks.

---
*PR created automatically by Jules for task [12026656641952410125](https://jules.google.com/task/12026656641952410125) started by @W73QB*