### PR TITLE
🎨 Palette: Add explicit labels and aria-descriptions for form selects

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2025-02-28 - [Accessible Labels and Descriptions for Flex-Col Dynamic Selects]
+**Learning:** Due to the `flex-col` layout visually separating the label, dynamic `<select>` input, and helper text, implicit label wrapping is insufficient. Explicit `for` attributes on the `<label>` and `aria-describedby` attributes on the `<select>` referencing the helper text ID are critical to ensure screen readers properly announce the input purpose and context before the dynamic options are fully populated.
+**Action:** When creating dynamic form inputs (especially selects) with associated helper text and separated visual layouts, always explicitly bind labels with `for` and helper hints with `aria-describedby`.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 **What:** Added explicit `for` attributes to labels and `aria-describedby` attributes to dynamic `<select>` elements for the Visa and Product dropdowns in `ui/index.html`.
🎯 **Why:** To improve accessibility. Because the labels, selects, and helper texts are separated visually using a flex-col layout, explicit connections are necessary to ensure screen readers announce the input purpose and context properly before dynamic options populate.
♿ **Accessibility:** Form fields are now explicitly linked to their corresponding labels and hints.

---
*PR created automatically by Jules for task [16702300341679267470](https://jules.google.com/task/16702300341679267470) started by @W73QB*