### PR TITLE
🎨 Palette: Enhance form accessibility and screen reader experience

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-02 - [Form Accessibility Improvements]
+**Learning:** Found an accessibility issue pattern specific to this app's main form components: `<select>` inputs lacked explicit label associations (`for` attributes pointing to IDs) despite having labels, and complex helper text wasn't programmatically linked to the inputs. Furthermore, Google Material Symbols (implemented as ligatures in `<span>` tags) were being read aloud by screen readers because they lacked `aria-hidden="true"`.
+**Action:** Always ensure `for` attributes connect labels to input IDs. Use `aria-describedby` to link inputs to their helper text. Always add `aria-hidden="true"` to decorative Google Material Symbols ligatures to prevent them from confusing screen readers.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,16 +173,16 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
-            <span
+            <span aria-hidden="true"
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
-            <span
+            <span aria-hidden="true"
               class="material-symbols-outlined absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">expand_more</span>
           </div>
           <p id="visaHint" class="text-xs text-text-secondary dark:text-gray-500 pl-1">Choose a visa record (route +
@@ -190,16 +190,16 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
-            <span
+            <span aria-hidden="true"
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>
-            <span
+            <span aria-hidden="true"
               class="material-symbols-outlined absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">expand_more</span>
           </div>
           <p id="productHint" class="text-xs text-text-secondary dark:text-gray-500 pl-1">Choose a product record


### PR DESCRIPTION
This PR is submitted on behalf of the "Palette" UX persona, and focuses on essential accessibility improvements for the main form in `ui/index.html`. 

### 💡 What: 
- Added explicit `for` attributes linking the "I am applying for" and "I want to use" labels to their respective `<select>` inputs (`#visaSelect` and `#productSelect`).
- Added `aria-describedby` attributes to link the `<select>` elements to their descriptive helper texts (`#visaHint` and `#productHint`).
- Added `aria-hidden="true"` to decorative Google Material Symbols ligatures embedded inside the `select` containers.
- Added a new journal entry to `.jules/palette.md` to document the learnings on applying form accessibility to this project.

### 🎯 Why:
This solves multiple accessibility failures:
1. Without `for` attributes, screen reader users might not know what input the visual label corresponds to.
2. The helper text ("Choose a visa record", "Choose a product record") provides critical context for making selections but wasn't programmatically available to assistive technology.
3. Google Material Symbols are implemented as ligatures (e.g., `<span class="material-symbols-outlined">health_and_safety</span>`). Without `aria-hidden="true"`, screen readers will read the text "health and safety" verbatim to the user, causing confusion.

### ♿ Accessibility
This change is 100% focused on accessibility and creates a much smoother screen-reader experience when interacting with the primary form on the page.

All changes are strictly contained within `ui/index.html` (alongside the `.jules/palette.md` doc) and do not introduce any new dependencies, CSS variables, or visual regressions. Tested and verified locally with Playwright.

---
*PR created automatically by Jules for task [15769524167227692441](https://jules.google.com/task/15769524167227692441) started by @W73QB*