### PR TITLE
🎨 Palette: Add explicit labels and aria-descriptions to form selects

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Form Select Accessibility Improvements
+**Learning:** Found that custom-styled native `<select>` elements in the main form lacked explicit `<label for="...">` associations and `aria-describedby` links to their helper hints, reducing screen reader utility and violating accessibility standards. Form inputs grouped physically but separated functionally require explicit semantic linkage.
+**Action:** Always ensure that `<label>` elements have a corresponding `for` attribute and that hint text (`<p id="...">`) is linked via `aria-describedby` to its input element.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 What: Added `for` attributes to the main form labels and `aria-describedby` to the `select` inputs linking them to their hint text. Added a critical learning journal entry.
🎯 Why: Without explicit label association, screen readers may not read out the input name correctly since the label and input are physically grouped but structurally separate. `aria-describedby` links necessary context (the hints) for AT users.
📸 Before/After: Visual presentation remains exactly the same, but the semantic structure is now robust.
♿ Accessibility: Improved form label association and provided descriptive text linkages for custom-styled native `<select>` dropdowns.

---
*PR created automatically by Jules for task [14450465663660243696](https://jules.google.com/task/14450465663660243696) started by @W73QB*