### PR TITLE
🎨 Palette: Add explicit form label associations and aria attributes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-18 - Explicit Label Associations in Flex Layouts
+**Learning:** In responsive designs where labels and inputs are separated visually (e.g., using `flex-col` with gaps), screen reader users and those navigating by touch lose the contextual association. Wrapping inputs in labels isn't always possible when using complex wrapper divs for icons.
+**Action:** Always use explicit `for` and `id` pairing on forms, and ensure hint text is explicitly associated via `aria-describedby`, particularly when custom styling separates the semantic flow.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,16 +173,19 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
+              aria-hidden="true"
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
             <select id="visaSelect"
+              aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
             <span
+              aria-hidden="true"
               class="material-symbols-outlined absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">expand_more</span>
           </div>
           <p id="visaHint" class="text-xs text-text-secondary dark:text-gray-500 pl-1">Choose a visa record (route +
@@ -190,16 +193,19 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
+              aria-hidden="true"
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
             <select id="productSelect"
+              aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>
             <span
+              aria-hidden="true"
               class="material-symbols-outlined absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">expand_more</span>
           </div>
           <p id="productHint" class="text-xs text-text-secondary dark:text-gray-500 pl-1">Choose a product record


### PR DESCRIPTION
💡 What: Added explicit `for` attributes to form labels, `aria-describedby` to `<select>` inputs, and `aria-hidden="true"` to purely decorative Material Symbols in `ui/index.html`. Also created a `.jules/palette.md` file noting the importance of explicit label-to-input associations in flex-col layouts.
🎯 Why: In responsive layouts, input labels are often separated from their respective inputs structurally (using wrappers like `div.relative` for icons). This removes the implicit association that assistive technologies rely on. Explicit attributes (`for` and `id` pairing, `aria-describedby` for hints) fix this accessibility issue. Purely decorative icons must also be hidden so they aren't read aloud unnecessarily.
📸 Before/After: Visuals are unchanged (verified with screenshot). The HTML DOM structure now has proper ARIA relationships.
♿ Accessibility: Ensures that screen reader and keyboard-only users can properly navigate and understand the form inputs, hearing the correct labels and hint text, while ignoring decorative icons.

---
*PR created automatically by Jules for task [1351310117156148140](https://jules.google.com/task/1351310117156148140) started by @W73QB*