### PR TITLE
🎨 Palette: Link form labels to inputs and associate helper text with ARIA

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-20 - Form Inputs Accessibility with Flex Layout
+**Learning:** In Tailwind interfaces using `flex-col` layout, input labels and the inputs themselves are visually grouped but separated structurally. This makes explicit `for` attributes on labels absolutely critical, otherwise screen readers and pointer devices cannot associate the label with the input. Similarly, hint/helper text placed alongside inputs requires `aria-describedby` on the input to be programmatically associated for assistive tech.
+**Action:** Always add explicit `for="id"` and `aria-describedby="hintId"` attributes to form fields, particularly when structural separation (like `div` wrappers or flex layouts) exists between labels, inputs, and hints.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 What: Added explicit `for` attributes to the "I am applying for" and "I want to use" select inputs, allowing users to focus the inputs by clicking their labels. Linked helper text using `aria-describedby` with proper `id` matching.

🎯 Why: In Tailwind's `flex-col` layout, labels and inputs are visually grouped but structurally separated, breaking implicit label wrapping. This update makes the select fields properly accessible to screen readers and increases the hit area for all users.

📸 Before/After: Visuals unchanged (accessibility enhancement).

♿ Accessibility: 
- `for="visaSelect"` and `for="productSelect"` added to the `<label>` elements.
- `aria-describedby` added to the `<select>` elements, pointing to the hint texts below them.
- `id="visaHint"` and `id="productHint"` are correctly targeted for ARIA descriptions.

---
*PR created automatically by Jules for task [15453638734831974792](https://jules.google.com/task/15453638734831974792) started by @W73QB*