### PR TITLE
🎨 Palette: [Improve label-select associations]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-15 - [Form Label Associations in Flex Layouts]
+**Learning:** Using flex-col layouts often creates visual separation between labels and inputs, masking missing programmatic associations. Inputs (like select) require explicit `for` and `id` linking for screen readers to properly associate the visual label with the input element.
+**Action:** Always verify `for` attributes on form labels exist and map to a valid input `id`, regardless of visual proximity. Also, ensure helper text is explicitly linked to form controls via `aria-describedby` since visual grouping alone is not accessible.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 **What:** Added `for` attributes to the "I am applying for" and "I want to use" `<label>` elements, linking them explicitly to their respective `<select>` element IDs (`visaSelect` and `productSelect`). Added `aria-describedby` to link the selects to their hint texts.
🎯 **Why:** In a `flex-col` layout, labels and inputs are visually separated. For screen readers and clickability, explicit association is required. Now, clicking the label text will properly focus the select dropdown, and screen readers will announce the hint text when focusing the select.
📸 **Before/After:** No visual changes, purely semantic DOM improvements.
♿ **Accessibility:** Fixes two orphaned labels and provides accessible descriptions for two complex inputs.

---
*PR created automatically by Jules for task [10506802050832223041](https://jules.google.com/task/10506802050832223041) started by @W73QB*