### PR TITLE
🎨 Palette: Form labels and aria-describedby for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-17 - Added label 'for' and 'aria-describedby' to ui/index.html forms
+**Learning:** Due to the flex-col layout in this app separating labels visually from inputs, clicking a label without a 'for' attribute fails to focus the select input, and screen readers fail to associate helper text due to missing 'aria-describedby' attributes on selects.
+**Action:** When working on form inputs here, specifically `<select>` wrapped with icons/styling, ensure explicit `for="id"` and `aria-describedby="hintId"` links are present.

--- a/ui/index.html
+++ b/ui/index.html
@@ -156,14 +156,14 @@
       <div class="flex flex-col md:flex-row items-center justify-center gap-3">
         <label for="vf-region-select"
           class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">Region</label>
-        <select id="vf-region-select"
+        <select id="vf-region-select" aria-describedby="regionHint"
           class="h-10 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white px-3 text-sm font-medium">
           <option value="us">United States</option>
           <option value="eu-uk">EU + UK</option>
           <option value="ca">Canada</option>
           <option value="apac">AU/JP/SG/KR</option>
         </select>
-        <span class="text-xs text-text-secondary dark:text-gray-500">Used for legal disclosures.</span>
+        <span id="regionHint" class="text-xs text-text-secondary dark:text-gray-500">Used for legal disclosures.</span>
       </div>
     </div>
 
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 What: Added explicit `for` attributes connecting text labels to dynamic `<select>` inputs, and `aria-describedby` linking the inputs to helper text.
🎯 Why: Due to flex-box layouts and wrappers separating elements, clicking visual labels wasn't focusing the inputs, and screen-reader context (helper hints) was detached. This micro-ux improves interaction bounds and accessibility.
📸 Before/After: Visual changes were non-existent, but functionally, labels now trigger inputs. (Tested via Playwright).
♿ Accessibility: ARIA references and `for` bindings resolved.
📝 Journal entry added in `.jules/palette.md` for learning pattern.

---
*PR created automatically by Jules for task [5682198287597017356](https://jules.google.com/task/5682198287597017356) started by @W73QB*