### PR TITLE
🎨 Palette: [Add explicit label-to-input association and ARIA descriptions for main selectors]

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-21 - [Form Labels & ARIA Context]
+**Learning:** Found that `<label>`s for standard inputs inside flex columns lack explicit `for` attributes and missing `aria-describedby` relations, failing to link label interaction and helpful context texts correctly for assistive technologies.
+**Action:** Always verify explicit `for` bindings are present and connect contextual hints using `aria-describedby` instead of relying merely on visual proximity, specifically in this app's Tailwind-styled input wrappers.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 **What**: Added explicit `for` attributes connecting the labels to `#visaSelect` and `#productSelect` inputs, and added `aria-describedby` referencing `#visaHint` and `#productHint`. Added `.jules/palette.md` noting the critical learning about form wrappers.
🎯 **Why**: Standard `flex-col` wrappers separate labels and inputs visually, breaking screen reader association. Users need to be able to click labels to focus the input natively and properly hear contextual helper texts.
📸 **Before/After**: See verification screenshot.
♿ **Accessibility**: Complete label-to-input linkage (`for`/`id`) and field hint association (`aria-describedby`) for primary interactive controls.

---
*PR created automatically by Jules for task [12087507944227956345](https://jules.google.com/task/12087507944227956345) started by @W73QB*