### PR TITLE
🎨 Palette: Add explicit labels and ARIA to select inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-25 - Explicit Label Associations in Flex Layouts
+**Learning:** In the visa-compliance-d app, labels and select inputs are often visually separated by nested `div` elements for flex/grid layouts. This layout pattern makes it crucial to use explicit `for` attributes on `<label>` elements and `aria-describedby` on `<select>` elements to properly associate them with helper text, ensuring screen readers can announce the correct context.
+**Action:** When adding new forms or fields using similar flex layouts, proactively add `for` and `aria-describedby` attributes to maintain accessibility standards.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
**💡 What:** Added explicit `for` and `aria-describedby` attributes to the main form controls.
**🎯 Why:** The labels and select inputs in the main form are visually separated using a flex column layout. Without explicit connections, screen readers might not announce the label or hint text when focusing the input.
**♿ Accessibility:** Improves screen reader context and allows clicking the label to focus the input natively.
**📸 Before/After:** See attached Playwright verification recording.

---
*PR created automatically by Jules for task [17794681951536197919](https://jules.google.com/task/17794681951536197919) started by @W73QB*