### PR TITLE
🎨 Palette: Fix a11y label associations for visa inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - explicit label-to-select association for a11y
+**Learning:** In the VisaFact app, form layouts utilizing Tailwind `flex-col` decouple labels visually from input fields. Screen readers fail to connect native `<select>` dropdowns to their helper texts or headers unless `for` and `aria-describedby` are explicitly added. The layout hides this broken association from sighted users.
+**Action:** When adding any new form input, especially dropdowns nested inside `relative` wrappers with trailing helper paragraphs, always explicitly assign `id`s to the inputs, match them to `for` attributes on labels, and use `aria-describedby` pointing to the helper paragraph's `id`.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 **What:** Added `for` attributes to the "I am applying for" and "I want to use" labels, linking them explicitly to `#visaSelect` and `#productSelect`. Also added `aria-describedby` to the `<select>` elements to properly associate them with their respective helper texts (`#visaHint` and `#productHint`).
🎯 **Why:** Due to the `flex-col` layout, the visual grouping of the label, input, and hint text is apparent to sighted users, but completely disconnected for screen readers. Explicit `for` and `aria-describedby` attributes are required to programmatically link these elements, improving accessibility.
♿ **Accessibility:**
- Screen readers will now announce the label text when the dropdown receives focus.
- Screen readers will now announce the hint text when the dropdown receives focus.
- Clicking the label text will now transfer focus to the select element.

A critical learning regarding this pattern in the app's layout was added to `.jules/palette.md`.

---
*PR created automatically by Jules for task [2967548273955791470](https://jules.google.com/task/2967548273955791470) started by @W73QB*