### PR TITLE
🎨 Palette: Form label and hint accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-04 - Form Labels and Hints Accessibility
+**Learning:** In the VisaFact app, complex layout using `flex-col` separated native `<label>` elements from their corresponding input elements visually, making programmatic association crucial. The inputs were missing explicit `for` attributes on labels and `aria-describedby` for their hints (`#visaHint` and `#productHint`). This structure fails accessibility audits without proper manual linking.
+**Action:** When designing or refactoring forms in this application, explicitly associate labels using the `for` attribute (e.g., `for="visaSelect"`) and provide context via `aria-describedby` pointing to the helper text IDs (e.g., `aria-describedby="visaHint"`), even if they appear adjacent in the layout.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 What: Explicitly associated labels and hint text with the main select inputs (`#visaSelect` and `#productSelect`) using `for` and `aria-describedby` attributes. Also added a journal entry logging this accessibility learning about visually separate native elements via layout.
🎯 Why: Due to the `flex-col` layout, native `<label>` elements were visually separated from their corresponding inputs, which fails programmatic accessibility without explicit linking. This makes the form far easier to navigate for screen reader users by properly associating context.
📸 Before/After: Visuals are identical as this is a purely semantic/accessibility change. Verified via Playwright screenshots and video.
♿ Accessibility: Improved screen reader support significantly for the primary interaction elements of the app.

---
*PR created automatically by Jules for task [15785123674727339626](https://jules.google.com/task/15785123674727339626) started by @W73QB*