### PR TITLE
🎨 Palette: Form label associations and dynamic helper text accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-04-05 - Dynamic Select Input Helper Text Accessibility
+**Learning:** In a UI where select elements have dynamic helper texts that update based on user choices, `aria-describedby` must be used to link the `<select>` element to its helper `<p>` text to provide context to screen reader users when navigating form elements. Additionally, for inputs with separate label elements, explicit `for` attributes are critical for establishing programmatic associations, especially when styled in flex columns where labels and inputs might not be implicitly nested.
+**Action:** Always verify `aria-describedby` when a helper text block is structurally near an input but not semantically connected, and ensure `<label>` elements use explicit `for` mappings matching the input `id`.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 **What:** Added `for` attributes to explicitly associate `<label>`s with their `<select>` inputs (`visaSelect` and `productSelect`). Additionally, added `aria-describedby` attributes to those select elements connecting them to their respective helper text elements (`visaHint` and `productHint`).
🎯 **Why:** To improve accessibility for screen readers. Explicit `for` mappings handle cases where implicit label associations fall short due to flexible layout structures. `aria-describedby` provides critical context when helper text underneath inputs is dynamically updated.
♿ **Accessibility:** Improvements target screen reader users navigating forms to establish proper element relationships and announce dynamically updated contextual hints.

---
*PR created automatically by Jules for task [14060136514073503074](https://jules.google.com/task/14060136514073503074) started by @W73QB*