### PR TITLE
🎨 Palette: Add explicit input labels and aria-describedby

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+## 2026-04-06 - Explicit Input Labels in Flex-Col Layouts & ARIA DescribedBy
+
+**Learning:** When inputs are grouped with their text labels inside a `flex-col` container (meaning they are not physically wrapped by the `<label>` tag), explicit `for` attributes on the `<label>` matched to the input's `id` are strictly necessary for accessibility. Without this, screen readers may not associate the text with the input, and clicking the label will not focus the input. Additionally, providing supplementary helper text (like hints) below form inputs is common, but screen readers may skip this text unless explicitly associated using `aria-describedby` on the input element pointing to the hint's `id`.
+**Action:** Always use explicit `for="id"` attributes on `<label>` elements when separating label text and inputs via layout containers. Consistently use `aria-describedby="hintId"` on input elements to ensure helper text is announced by screen readers.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 What: Added explicit `for="id"` attributes to the "I am applying for" and "I want to use" labels, linking them to their respective native `<select>` elements (`visaSelect` and `productSelect`). Additionally, linked the hint text below the inputs using `aria-describedby` on the select elements.
🎯 Why: In a `flex-col` layout where labels do not physically wrap inputs, explicit `for` attributes are required for screen readers to associate the text label with the input. This also allows users to click the text label to focus the input element, which improves usability, particularly on touch devices or smaller screens. Adding `aria-describedby` ensures screen readers announce the helpful hint text that appears below the input.
♿ Accessibility: Improved screen reader association for primary selection inputs and enabled label-click-to-focus behavior.

---
*PR created automatically by Jules for task [3303519117087173520](https://jules.google.com/task/3303519117087173520) started by @W73QB*