### PR TITLE
🎨 Palette: Enhance form accessibility with explicit ARIA attributes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-08 - Explicit ARIA Description for Select Inputs
+**Learning:** In responsive forms with flex layouts where labels are separated from inputs, explicit `aria-describedby` attributes are needed on native `<select>` elements to properly associate them with helper/hint text. Additionally, disabled buttons must have `aria-disabled="true"` correctly synced alongside the native `disabled` attribute to communicate status cleanly to screen readers.
+**Action:** Ensure all form controls actively reference their corresponding descriptive text using ARIA attributes, and dynamic states (like disabled buttons) are mirrored in the accessibility tree via ARIA.

--- a/ui/index.html
+++ b/ui/index.html
@@ -178,7 +178,7 @@
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -195,7 +195,7 @@
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>
@@ -209,7 +209,7 @@
       </div>
 
       <div class="mt-10 flex justify-center">
-        <button id="checkBtn" disabled
+        <button id="checkBtn" disabled aria-disabled="true"
           class="group flex items-center gap-3 px-8 py-3.5 bg-primary/50 text-white text-lg font-bold rounded-lg transition-all shadow-md cursor-not-allowed">
           <span class="material-symbols-outlined group-hover:scale-110 transition-transform">check_circle</span>
           Check Compliance
@@ -650,6 +650,7 @@
       const ok = $("visaSelect").value && $("productSelect").value;
       const btn = $("checkBtn");
       btn.disabled = !ok;
+      btn.setAttribute("aria-disabled", !ok ? "true" : "false");
       btn.className = ok
         ? "group flex items-center gap-3 px-8 py-3.5 bg-primary hover:bg-primary-hover text-white text-lg font-bold rounded-lg transition-all shadow-md hover:shadow-lg hover:-translate-y-0.5 active:translate-y-0"
         : "group flex items-center gap-3 px-8 py-3.5 bg-primary/50 text-white text-lg font-bold rounded-lg transition-all shadow-md cursor-not-allowed";


### PR DESCRIPTION
- Added `aria-describedby="visaHint"` to `#visaSelect`
- Added `aria-describedby="productHint"` to `#productSelect`
- Added dynamic `aria-disabled` toggle in `setCheckBtnEnabled` to correctly map the native `disabled` state to the accessibility tree.
- Recorded UX learnings in `.jules/palette.md`

---
*PR created automatically by Jules for task [18213500430418590122](https://jules.google.com/task/18213500430418590122) started by @W73QB*