### PR TITLE
🎨 Palette: Improve accessibility of form inputs and buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-04-10 - Form Labels & Disabled State Accessibility
+**Learning:** In `ui/index.html`, inputs like `<select>` elements and `<button>` elements had missing or misconfigured accessibility attributes. The visual labels for `<select>` lacked `for` attributes connecting them to the inputs, and the select inputs themselves lacked `aria-describedby` connecting them to their helper hints. The disabled "Check Compliance" button lacked `aria-disabled="true"`.
+**Action:** Always ensure `for` attributes are set on labels mapping to input `id`s, attach `aria-describedby` to inputs referring to their hint elements, and maintain `aria-disabled="true"` in sync with the `disabled` property via JS to improve screen reader communication for inactive states.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>
@@ -209,7 +209,7 @@
       </div>
 
       <div class="mt-10 flex justify-center">
-        <button id="checkBtn" disabled
+        <button id="checkBtn" disabled aria-disabled="true"
           class="group flex items-center gap-3 px-8 py-3.5 bg-primary/50 text-white text-lg font-bold rounded-lg transition-all shadow-md cursor-not-allowed">
           <span class="material-symbols-outlined group-hover:scale-110 transition-transform">check_circle</span>
           Check Compliance
@@ -650,6 +650,7 @@
       const ok = $("visaSelect").value && $("productSelect").value;
       const btn = $("checkBtn");
       btn.disabled = !ok;
+      btn.setAttribute("aria-disabled", !ok ? "true" : "false");
       btn.className = ok
         ? "group flex items-center gap-3 px-8 py-3.5 bg-primary hover:bg-primary-hover text-white text-lg font-bold rounded-lg transition-all shadow-md hover:shadow-lg hover:-translate-y-0.5 active:translate-y-0"
         : "group flex items-center gap-3 px-8 py-3.5 bg-primary/50 text-white text-lg font-bold rounded-lg transition-all shadow-md cursor-not-allowed";


### PR DESCRIPTION
🎨 Palette: Improve accessibility of form inputs and buttons

💡 What:
- Added explicit `for` attributes to the "I am applying for" and "I want to use" labels linking them to their select inputs.
- Added `aria-describedby` to the visa and product select inputs linking them to their corresponding hint paragraphs.
- Added `aria-disabled="true"` to the initially disabled "Check Compliance" button.
- Updated `setCheckBtnEnabled` to toggle `aria-disabled` matching the native disabled state.
- Formatted `.jules/palette.md` to record learnings on proper a11y bindings.

🎯 Why:
Users relying on screen readers need programmatically associated labels and hint text to understand input purpose. Ensuring `aria-disabled` matches native disabled state provides clearer intent when a form action is restricted.

📸 Before/After: Visuals verified via Playwright scripts checking DOM a11y properties.

♿ Accessibility: Ensures WCAG adherence for form control identification and disabled state communication.

---
*PR created automatically by Jules for task [13629221786488494044](https://jules.google.com/task/13629221786488494044) started by @W73QB*