### PR TITLE
🎨 Palette: Form and modal accessibility enhancements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-11 - Modal & Form Accessibility Enhancements
+**Learning:** This app uses native Tailwind-styled `<select>` elements which visually separate labels from inputs using flexbox, requiring explicit `for` and `aria-describedby` attributes to associate them properly for screen readers. Modals here are custom DOM elements, not native `<dialog>`, so they lack built-in focus restoration and Escape key support, which must be added manually for full accessibility.
+**Action:** Ensure all custom modal implementations manage focus restoration (`lastFocusedElement`), support the `Escape` key, and explicitly add `role="dialog"` and `aria-modal="true"`. Use `for` attributes on all separated labels.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>
@@ -424,11 +424,11 @@
     </div>
 
     <!-- Modal evidence -->
-    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
+    <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
       <div
         class="w-full max-w-3xl bg-white dark:bg-[#111418] rounded-xl border border-border-soft dark:border-border-dark shadow-lg">
         <div class="flex items-center justify-between p-4 border-b border-border-soft dark:border-border-dark">
-          <div class="font-bold text-text-primary dark:text-white">Evidence</div>
+          <div id="modalTitle" class="font-bold text-text-primary dark:text-white">Evidence</div>
           <button id="closeModal"
             class="px-3 py-2 text-sm font-semibold border border-border-soft dark:border-border-dark rounded-lg bg-white dark:bg-gray-800 text-text-primary dark:text-white hover:bg-gray-50 dark:hover:bg-gray-700 transition">
             Close
@@ -729,7 +729,9 @@
       return false;
     }
 
+    let lastFocusedElement = null;
     function openModal(evidenceItems) {
+      lastFocusedElement = document.activeElement;
       const body = $("modalBody");
       body.innerHTML = "";
 
@@ -773,6 +775,9 @@
     function closeModal() {
       $("modal").classList.add("hidden");
       $("modal").classList.remove("flex");
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+      }
     }
 
     function renderRequirements(visa) {
@@ -1115,6 +1120,7 @@
 
         $("closeModal").addEventListener("click", closeModal);
         $("modal").addEventListener("click", (e) => { if (e.target.id === "modal") closeModal(); });
+        document.addEventListener("keydown", (e) => { if (e.key === "Escape" && !$("modal").classList.contains("hidden")) closeModal(); });
 
         updateHints();
 


### PR DESCRIPTION
🎨 **Palette: Form & Modal Accessibility Enhancement**

**💡 What:** 
Added core accessibility enhancements to `ui/index.html` by associating disjointed input labels, providing ARIA connection to context hints, enforcing a strict ARIA `dialog` model for the evidence modal, and implementing focus restoration and Escape key cancellation.

**🎯 Why:**
Native semantic HTML properties like `<label>` don't automatically connect with form inputs separated by `div` blocks and `flex-col` stylings. Keyboard/screen reader users need explicit `for` associations. Custom DOM modals require explicit ARIA properties, focus retention, and standard keyboard dismissal bindings (`Escape`) to behave predictably for all users.

**📸 Before/After:**
*(See included visual verification Playwright screenshots and videos)*

**♿ Accessibility:**
- Added `for` mapping to `visaSelect` and `productSelect`.
- Added `aria-describedby` for field hints.
- Added `role="dialog"`, `aria-modal="true"`, `aria-labelledby` to `#modal`.
- Enabled `Escape` key listener for closing the modal.
- Captured `document.activeElement` when modal opens and restored `.focus()` on close.

---
*PR created automatically by Jules for task [10800558421239676038](https://jules.google.com/task/10800558421239676038) started by @W73QB*