### PR TITLE
🎨 Palette: Improve accessibility of form inputs in flex-col layout

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-12 - [Accessible Form Inputs in flex-col Layouts]
+**Learning:** Due to the visual separation caused by `flex-col` and nested div structures in the form UI, screen readers and pointer devices struggle to associate labels with `<select>` or `<input>` elements unless explicit `for` attributes (on the label) matching the input's `id` are used. Similarly, helper text must be explicitly linked via `aria-describedby` to provide full context to assistive tech.
+**Action:** Always ensure that form labels utilize the `for` attribute and that hint/helper text elements are programmatically associated using `aria-describedby` across all forms in this application.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 What: Added explicit `for` attributes to main form labels and `aria-describedby` attributes to `<select>` inputs to link them to their helper texts. Created a `.jules/palette.md` journal to document this learning.
🎯 Why: Because the form uses a `flex-col` layout, the labels and helper texts were visually separated and not programmatically associated with the input fields. Assistive technologies and pointer devices couldn't reliably interact with the inputs via their labels.
♿ Accessibility: The changes enable screen readers to announce the labels when the inputs receive focus, allow users to click the labels to focus the inputs, and ensure screen readers read the helper text associated with the inputs.

---
*PR created automatically by Jules for task [8392002390972228985](https://jules.google.com/task/8392002390972228985) started by @W73QB*