### PR TITLE
🎨 Palette: Form Accessibility Improvements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-13 - Add Accessible Associations to Form Elements
+**Learning:** The flex-col layout in this app causes labels to be visually disconnected from select menus, requiring explicit `for` attributes and `aria-describedby` hints for screen readers to properly context-switch into the complex interactive controls.
+**Action:** When adding or updating custom `<select>` menus inside `.flex-col` containers, always pair `<label for="[id]">` and set `aria-describedby="[hint_id]"` on the interactive element.

--- a/ui/index.html
+++ b/ui/index.html
@@ -100,7 +100,7 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+        aria-label="Toggle menu" aria-expanded="false" aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>
@@ -209,7 +209,7 @@
       </div>
 
       <div class="mt-10 flex justify-center">
-        <button id="checkBtn" disabled
+        <button id="checkBtn" disabled aria-disabled="true"
           class="group flex items-center gap-3 px-8 py-3.5 bg-primary/50 text-white text-lg font-bold rounded-lg transition-all shadow-md cursor-not-allowed">
           <span class="material-symbols-outlined group-hover:scale-110 transition-transform">check_circle</span>
           Check Compliance
@@ -650,6 +650,7 @@
       const ok = $("visaSelect").value && $("productSelect").value;
       const btn = $("checkBtn");
       btn.disabled = !ok;
+      btn.setAttribute("aria-disabled", !ok ? "true" : "false");
       btn.className = ok
         ? "group flex items-center gap-3 px-8 py-3.5 bg-primary hover:bg-primary-hover text-white text-lg font-bold rounded-lg transition-all shadow-md hover:shadow-lg hover:-translate-y-0.5 active:translate-y-0"
         : "group flex items-center gap-3 px-8 py-3.5 bg-primary/50 text-white text-lg font-bold rounded-lg transition-all shadow-md cursor-not-allowed";
@@ -1142,9 +1143,10 @@
     $("mobileMenuBtn")?.addEventListener("click", () => {
       const menu = $("mobileMenu");
       const btn = $("mobileMenuBtn");
-      const isOpen = !menu.classList.contains("hidden");
+      const isOpen = menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
-      btn.querySelector("span").textContent = isOpen ? "menu" : "close";
+      btn.querySelector("span").textContent = isOpen ? "close" : "menu";
+      btn.setAttribute("aria-expanded", isOpen);
     });
 
     init().catch(err => {


### PR DESCRIPTION
🎨 Palette: Form Accessibility Improvements

💡 What:
- Added explicit `for` attributes to the "I am applying for" and "I want to use" labels, linking them to their respective `<select>` inputs (`visaSelect` and `productSelect`).
- Added `aria-describedby` attributes to both `<select>` inputs to associate them with their helper text hints.
- Added dynamic `aria-disabled` toggling to the primary "Check Compliance" button.
- Added dynamic `aria-expanded` and static `aria-controls` to the mobile menu toggle button.
- Added a journal entry to `.jules/palette.md` noting the explicit labeling requirement for flex-col layouts.

🎯 Why:
- The flex-col layout creates visual separation between labels and inputs, requiring explicit programmatic association (via `for` and `id`) to ensure screen readers correctly identify the interactive controls.
- The helper text below the select dropdowns was previously unassociated; `aria-describedby` provides critical context for AT users entering the form fields.
- Toggling the native `disabled` property on the check button visually deactivated it, but explicitly toggling `aria-disabled` provides better context to screen readers regarding its state.
- The mobile menu lacked state communication, meaning keyboard/screen reader users wouldn't know if the menu was open or closed.

♿ Accessibility:
- Improves label-to-input associations.
- Adds contextual hints to inputs.
- Improves state communication for buttons and menus.

---
*PR created automatically by Jules for task [10628965632862912519](https://jules.google.com/task/10628965632862912519) started by @W73QB*