### PR TITLE
🎨 Palette: Add explicit label association to select inputs

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -173,13 +173,13 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
             <select id="visaSelect"
-              class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
+              class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600" aria-describedby="visaHint">
               <option value="">Select visa route (authority)</option>
             </select>
             <span
@@ -190,13 +190,13 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
             <select id="productSelect"
-              class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
+              class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600" aria-describedby="productHint">
               <option value="">Select an insurance product</option>
             </select>
             <span


### PR DESCRIPTION
💡 **What**: Added `for` attributes to the "I am applying for" and "I want to use" labels so they correctly target their respective `<select>` inputs (`#visaSelect` and `#productSelect`). Also added `aria-describedby` attributes to both `<select>` elements so they programmatically associate with the hint text beneath them (`#visaHint` and `#productHint`).

🎯 **Why**: Screen readers need explicit programmatic associations between labels and form controls to announce them accurately. Without the `for` attribute, screen readers might not announce the label when the user tabs to the dropdown. In addition, `aria-describedby` provides users with the crucial hint text necessary to understand the purpose of the control. Furthermore, providing a correct `for` attribute means the user can click the label text to focus the `<select>`, increasing the effective clickable area, which is a subtle but helpful UX enhancement.

♿ **Accessibility**: Improved form controls mapping to labels and hints for screen reader devices and increased clickable target area.

*Change is under 50 lines and correctly implemented via Python string replacement preserving CRLF endings.*

---
*PR created automatically by Jules for task [13130383726790206946](https://jules.google.com/task/13130383726790206946) started by @W73QB*