### PR TITLE
🎨 Palette: Add explicit labels to form selects

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-15 - Explicit form labels required for flex-col layouts
+**Learning:** In flex-col layouts where inputs and their labels are visually grouped but structurally separated in the DOM, implicit labeling (wrapping input inside label) is not always used. Screen readers will fail to associate them.
+**Action:** Always use explicit `for` attributes on labels pointing to the `id` of the input, and ensure helper texts are associated via `aria-describedby` on the input element.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
* 💡 What: Added explicit `for` attributes to the region and product selection labels, and `aria-describedby` attributes to the corresponding `<select>` elements.
* 🎯 Why: In a flex-col layout, the labels and inputs were visually grouped but structurally disconnected in the DOM. Without explicit links, screen reader users wouldn't know which label corresponded to which dropdown.
* 📸 Before/After: No visual change, strictly an accessibility improvement.
* ♿ Accessibility: Screen readers now accurately read the label and the descriptive helper text when the select inputs receive focus.

---
*PR created automatically by Jules for task [9312948053730251215](https://jules.google.com/task/9312948053730251215) started by @W73QB*