### PR TITLE
🎨 Palette: Add for attributes to select labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-22 - Missing 'for' attributes on labels
+**Learning:** Found `<label>` elements without `for` attributes in `ui/index.html` referencing `<select>` elements (`#visaSelect` and `#productSelect`). The `flex-col` layout separates labels from inputs visually, so programmatic linkage is important.
+**Action:** Adding explicit `for` attributes to connect labels to their corresponding inputs for improved accessibility.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,7 +173,7 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
@@ -190,7 +190,7 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span


### PR DESCRIPTION
Added explicit `for` attributes to the `<label>` elements for `#visaSelect` and `#productSelect` in `ui/index.html` to improve programmatic accessibility for the form dropdowns, along with a journal entry documenting the missing attribute observation.

---
*PR created automatically by Jules for task [4859101447644792453](https://jules.google.com/task/4859101447644792453) started by @W73QB*