### PR TITLE
🎨 Palette: Add explicit label and hint associations for select fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Explicit Label and Hint Associations for Screen Readers
+**Learning:** In Tailwind UI layouts using flex-col where labels and inputs are visually separated, implicit wrapping (<label><input/></label>) is often impractical. Using explicit `for` and `id` mapping ensures screen readers maintain context. Similarly, associating helper text with inputs using `aria-describedby` provides critical context to assistive technologies.
+**Action:** Always map separated labels to their inputs using `for="inputId"` and link helper text (like hints) to the input using `aria-describedby="hintId"`.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
Added explicit `for` attributes to the "visaSelect" and "productSelect" labels, and `aria-describedby` attributes to their respective select inputs, linking them to existing hint paragraphs. Also documented this learning in `.jules/palette.md`.

In flex-col layouts where labels and inputs are visually separated, implicit wrapping is impractical. Explicit associations ensure screen readers maintain context and users can click labels to focus the inputs. Linking helper text via `aria-describedby` provides critical context to assistive technologies.

---
*PR created automatically by Jules for task [16365982269226514329](https://jules.google.com/task/16365982269226514329) started by @W73QB*