### PR TITLE
🎨 Palette: Form select accessibility improvements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - Form Select Accessibility
+**Learning:** In the VisaFact UI, form `<select>` elements (`#visaSelect`, `#productSelect`) were missing proper associations with their labels (using `for` attributes on `<label>`) and with their hint text (using `aria-describedby` on `<select>`). The `#checkBtn` was also missing the `aria-disabled` property reflecting its disabled state.
+**Action:** Added `for` attributes to the labels, `aria-describedby` to the `<select>` elements linking to the hint text IDs, and `aria-disabled` toggling on the `checkBtn` when its disabled state changes to ensure full accessibility for screen readers.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>
@@ -209,7 +209,7 @@
       </div>
 
       <div class="mt-10 flex justify-center">
-        <button id="checkBtn" disabled
+        <button id="checkBtn" disabled aria-disabled="true"
           class="group flex items-center gap-3 px-8 py-3.5 bg-primary/50 text-white text-lg font-bold rounded-lg transition-all shadow-md cursor-not-allowed">
           <span class="material-symbols-outlined group-hover:scale-110 transition-transform">check_circle</span>
           Check Compliance
@@ -650,6 +650,7 @@
       const ok = $("visaSelect").value && $("productSelect").value;
       const btn = $("checkBtn");
       btn.disabled = !ok;
+      btn.setAttribute("aria-disabled", !ok ? "true" : "false");
       btn.className = ok
         ? "group flex items-center gap-3 px-8 py-3.5 bg-primary hover:bg-primary-hover text-white text-lg font-bold rounded-lg transition-all shadow-md hover:shadow-lg hover:-translate-y-0.5 active:translate-y-0"
         : "group flex items-center gap-3 px-8 py-3.5 bg-primary/50 text-white text-lg font-bold rounded-lg transition-all shadow-md cursor-not-allowed";


### PR DESCRIPTION
### 💡 What
- Added missing `for` attributes to `<label>` elements pointing to the `visaSelect` and `productSelect` elements.
- Added `aria-describedby` to the select elements to correctly associate them with their helper hint texts.
- Added logic to explicitly toggle the `aria-disabled` property on the submit button alongside the native HTML `disabled` attribute.

### 🎯 Why
These form controls had disconnected labels and hint texts visually, but were not programmatically associated, meaning screen reader users would not receive context about what the dropdowns were for or what their requirements were. The submit button relied only on HTML `disabled`, which some screen readers handle poorly; adding `aria-disabled` provides robust feedback.

### 📸 Before/After
(Visuals unchanged, semantic HTML improved. Screenshots captured in Playwright verification.)

### ♿ Accessibility
This PR improves keyboard navigation and screen reader semantics for the core input form of the tool, fulfilling the Palette persona's requirement for micro-UX/a11y improvements. The change ensures the main `<select>` tags have explicitly connected descriptors, and the disabled state is unambiguously communicated.

---
*PR created automatically by Jules for task [2886947656033530821](https://jules.google.com/task/2886947656033530821) started by @W73QB*