### PR TITLE
🎨 Palette: Add accessible labels and hints to form selects

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-28 - Adding accessible labels and descriptive hints for Flex-Col inputs
+**Learning:** In responsive layouts using `flex-col`, visual proximity between a label, input, and hint text is often broken for screen readers. Explicitly linking `<label for="[id]">` and using `aria-describedby` to associate helper text with the input (`<select id="[id]" aria-describedby="[hint-id]">`) is critical to ensure screen readers announce the input correctly along with its helpful context.
+**Action:** Always include explicit `for` and `aria-describedby` attributes when designing custom forms, particularly when relying on structural Tailwind layout classes like `flex-col` which visually detach elements.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
🎨 Palette: Add accessible labels and hints to form selects

💡 What: Added explicit `for` attributes to the "I am applying for" and "I want to use" labels, linking them to their respective `<select>` inputs (`#visaSelect`, `#productSelect`). Added `aria-describedby` to the `<select>` inputs to link them to their respective hint texts.
🎯 Why: In a `flex-col` layout, visual proximity is often lost for screen readers. Explicit associations ensure that screen readers announce the input along with its label and helpful context.
♿ Accessibility: Improved screen reader navigation and increased the clickable area of the labels, making it easier for all users to focus the inputs.

---
*PR created automatically by Jules for task [17647095406274710808](https://jules.google.com/task/17647095406274710808) started by @W73QB*