### PR TITLE
🎨 Palette: Fix label association for select inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-29 - Fixed Label-to-Input Association for Selects
+**Learning:** The `flex-col` layout visually separates labels from inputs, but screen readers require explicit programmatic association. Relying on visual proximity is insufficient for accessibility, particularly for form components like `<select>`.
+**Action:** Always ensure that inputs, particularly those in `flex-col` or visually distinct layouts, have explicit `for` attributes on their corresponding `<label>` elements and utilize `aria-describedby` to link any associated hint or helper text.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,13 +173,13 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
             <select id="visaSelect"
-              class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
+              class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600" aria-describedby="visaHint">
               <option value="">Select visa route (authority)</option>
             </select>
             <span
@@ -190,13 +190,13 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
             <select id="productSelect"
-              class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
+              class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600" aria-describedby="productHint">
               <option value="">Select an insurance product</option>
             </select>
             <span


### PR DESCRIPTION
🎨 Palette: Fix label association for select inputs

💡 What: Added `for` attributes to the "I am applying for" and "I want to use" labels, pointing them to `visaSelect` and `productSelect` respectively. Added `aria-describedby` attributes to both selects pointing to their respective hint texts.
🎯 Why: In a `flex-col` layout, labels and inputs are visually separated. Explicit programmatic association is required so screen readers can correctly announce the inputs and their hints.
♿ Accessibility: Improved screen reader navigation for the primary form elements.

---
*PR created automatically by Jules for task [10329473561890447078](https://jules.google.com/task/10329473561890447078) started by @W73QB*