### PR TITLE
🎨 Palette: Improve accessibility of form selects in ui/index.html

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-03 - Form Labels in Flex Layouts
+**Learning:** In Tailwind flex-col layouts (or any CSS layout where labels and inputs are visually separated or ordered non-sequentially), standard visual association breaks down for screen readers. Form inputs (like `visaSelect` and `productSelect`) must explicitly use `for` attributes on labels and `aria-describedby` for helper text (`#visaHint`, `#productHint`) to ensure reliable accessibility.
+**Action:** Always ensure `for` attributes point correctly to input IDs and bind helper text with `aria-describedby` when building or reviewing forms, especially those with custom flex layouts.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 What: Added `for` attributes to the "I am applying for" and "I want to use" labels, linking them explicitly to the `#visaSelect` and `#productSelect` inputs. Also added `aria-describedby` attributes to both select elements linking them to their hint text.
🎯 Why: Due to the flex-col layout styling in `ui/index.html`, the labels and inputs are visually separated. Without explicit `for` bindings, screen readers fail to reliably associate the label with its input. This change guarantees form accessibility.
♿ Accessibility:
- Forms correctly read out their intended purpose due to explicit `for="[id]"` attributes.
- Helper hints correctly associate to the select form fields via `aria-describedby`.
- Passes the UI structural tests in `tools/tests/ui_compliance_tests.ps1`.
- Logged flex-col specific accessibility pattern in `.jules/palette.md`.

---
*PR created automatically by Jules for task [7504137989905013982](https://jules.google.com/task/7504137989905013982) started by @W73QB*