### PR TITLE
🎨 Palette: Improve form label accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-05 - Flex-col Layouts and Input Labels
+**Learning:** In Tailwind designs, using `flex-col` to vertically stack labels and inputs visually disconnects them. This completely breaks implicit click-to-focus behavior for `<label>` elements unless an explicit `for` attribute maps directly to the input's `id`.
+**Action:** Always ensure an explicit `for` attribute is added to `<label>` elements when they are separated from their inputs via block or flex wrappers.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 **What**: Added explicit `for` attributes to the primary form labels and `aria-describedby` attributes to the form inputs.
🎯 **Why**: The Tailwind `flex-col` layout visually separates the labels from the inputs, which breaks implicit click-to-focus behavior and screen reader association. This change restores keyboard accessibility and screen reader support for the main form.
♿ **Accessibility**: 
- Added `for="visaSelect"` and `for="productSelect"` to labels.
- Added `aria-describedby="visaHint"` and `aria-describedby="productHint"` to inputs.

---
*PR created automatically by Jules for task [17144009877883211315](https://jules.google.com/task/17144009877883211315) started by @W73QB*