### PR TITLE
🎨 Palette: Improve accessibility of form select inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-09 - Accessible Form Selects
+**Learning:** In the flex-col layout used for form groups (where labels visually precede `<select>` elements but are not wrapping them), explicit `for` attributes on the `<label>` elements are required to trigger focus. Furthermore, dynamic native `<select>` dropdowns must use `aria-describedby` to programmatically associate themselves with their helper/hint text elements for full screen reader accessibility.
+**Action:** Always verify that layout-separated labels have `for` attributes pointing to input `id`s, and ensure descriptive helper text is linked using `aria-describedby`.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 **What:** Added `for` attributes to the "I am applying for" and "I want to use" `<label>` elements, linking them to their corresponding `<select>` inputs (`visaSelect` and `productSelect`). Additionally, added `aria-describedby` to the `<select>` inputs to programmatically associate them with their hint/helper text paragraphs (`visaHint` and `productHint`).
🎯 **Why:** In the `flex-col` layout, the labels visually appear before the inputs but do not wrap them, which requires explicit `for` attributes so screen readers correctly identify the label and clicking the label focuses the input. The helper texts provide critical context but were unlinked, meaning screen reader users wouldn't hear them when navigating the form fields.
♿ **Accessibility:** Fixes WCAG criteria related to labels or instructions and name, role, value by ensuring form inputs have explicit accessible names and descriptions.

---
*PR created automatically by Jules for task [5914802502339790096](https://jules.google.com/task/5914802502339790096) started by @W73QB*