### PR TITLE
🎨 Palette: Improve form accessibility and native disabled state semantics

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-11 - Semantic Forms and Disabled States
+**Learning:** Found an accessibility issue pattern where inputs using Tailwind's layout properties (e.g. `flex-col`) visually separate labels from inputs, which makes it less obvious that `for` and `id` mapping is missing. Further, disabled buttons relying entirely on the native `disabled` property do not communicate their semantic "disabled" state fully to screen readers.
+**Action:** Ensure all form `<label>`s have explicit `for` attributes connecting them to the target `<input>`/`<select>`, and add `aria-disabled="true"` to natively disabled buttons (along with JavaScript logic to toggle it on/off).

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>
@@ -209,7 +209,7 @@
       </div>
 
       <div class="mt-10 flex justify-center">
-        <button id="checkBtn" disabled
+        <button id="checkBtn" disabled aria-disabled="true"
           class="group flex items-center gap-3 px-8 py-3.5 bg-primary/50 text-white text-lg font-bold rounded-lg transition-all shadow-md cursor-not-allowed">
           <span class="material-symbols-outlined group-hover:scale-110 transition-transform">check_circle</span>
           Check Compliance
@@ -650,6 +650,7 @@
       const ok = $("visaSelect").value && $("productSelect").value;
       const btn = $("checkBtn");
       btn.disabled = !ok;
+      btn.setAttribute("aria-disabled", !ok ? "true" : "false");
       btn.className = ok
         ? "group flex items-center gap-3 px-8 py-3.5 bg-primary hover:bg-primary-hover text-white text-lg font-bold rounded-lg transition-all shadow-md hover:shadow-lg hover:-translate-y-0.5 active:translate-y-0"
         : "group flex items-center gap-3 px-8 py-3.5 bg-primary/50 text-white text-lg font-bold rounded-lg transition-all shadow-md cursor-not-allowed";


### PR DESCRIPTION
💡 **What:** The UX enhancement added:
- Explicit `for` mappings on the main form labels (`visaSelect`, `productSelect`).
- Explicit `aria-describedby` pointing to the helper hint text.
- Dynamic `aria-disabled` logic corresponding to the native disabled state on `#checkBtn`.

🎯 **Why:** The user problem it solves:
- The input labels and input elements were disconnected in the DOM structure (separated visually using Tailwind flex/absolute positioning). A user with a screen reader needs programmatic linkage to know what input belongs to what label.
- A disabled button using only the native HTML `disabled` attribute can sometimes fail to fully express its state/context to screen readers, pairing it with `aria-disabled` ensures compatibility.

📸 **Before/After:** No major visual changes, screen reader logic only.

♿ **Accessibility:**
- Ensures screen readers announce context when entering the visa/product fields.
- Form inputs are formally tied to their labels and hints.

---
*PR created automatically by Jules for task [5502247956755644836](https://jules.google.com/task/5502247956755644836) started by @W73QB*