### PR TITLE
🎨 Palette: Add aria-expanded to mobile menu button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-13 - Missing ARIA attributes on dynamic mobile menus
+**Learning:** Icon-only buttons used for mobile menus must include `aria-expanded` and `aria-controls` explicitly linked to the menu content, and ensure JS updates `aria-expanded` based on visibility.
+**Action:** Always map toggleable visual states (like hidden/visible menus) to ARIA attributes programmatically and add `aria-expanded`/`aria-controls` to the toggle button.

--- a/ui/index.html
+++ b/ui/index.html
@@ -100,6 +100,7 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+        aria-expanded="false" aria-controls="mobileMenu"
         aria-label="Toggle menu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
@@ -1144,6 +1145,7 @@
       const btn = $("mobileMenuBtn");
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
+      btn.setAttribute("aria-expanded", !isOpen ? "true" : "false");
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
     });
 


### PR DESCRIPTION
💡 What: Added `aria-expanded` and `aria-controls` to the `#mobileMenuBtn` icon-only toggle button and wired it up in JavaScript.
🎯 Why: Without these attributes, screen reader users do not know what the button controls or whether the menu is currently open or closed.
♿ Accessibility: Improves structural navigation and context for screen readers on mobile devices by properly communicating the state of the navigation menu.

---
*PR created automatically by Jules for task [8527938665120042901](https://jules.google.com/task/8527938665120042901) started by @W73QB*