### PR TITLE
🎨 Palette: Add explicit labels and aria-describedby to form dropdowns

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Explicit Form Labels in Complex Layouts
+**Learning:** In complex layouts (like flex-col or grid), where labels and inputs are visually disjointed but semantically related, implicit wrapping `<label><input/></label>` is often structurally difficult. Missing explicit `for` attributes on labels targeting input IDs severely breaks accessibility and usability, preventing users from clicking the label to focus the input.
+**Action:** Always verify that every independent `<label>` element has a `for` attribute precisely matching the `id` of its corresponding input, and use `aria-describedby` to associate helper text, regardless of visual proximity.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
### 💡 What
Added explicit `for` attributes to the main labels targeting the `<select>` inputs, and added `aria-describedby` attributes to those inputs to associate them with their respective hint text paragraphs.

### 🎯 Why
In complex visual layouts where a label text is styled as a header above a group containing both an icon and an input, implicit wrapping (`<label><input/></label>`) is structurally difficult. Without an explicit `for` attribute, users cannot click the label text to focus the input, and screen readers may not accurately announce the relationship. Additionally, `aria-describedby` is necessary so screen readers read the helper hint text when the dropdown receives focus.

### ♿ Accessibility
* Screen readers will now reliably associate the labels "I am applying for" and "I want to use" with their corresponding `<select>` elements.
* Screen readers will now announce the hints (e.g., "Choose a visa record (route + authority)...") when the inputs are focused.
* Sighted mouse and touch users can now click on the label text to focus the `<select>` element.

*This change remains under the 50 line modification limit and uses pure HTML/semantic improvements without altering the visual design or requiring new CSS.*

---
*PR created automatically by Jules for task [5838080726012630006](https://jules.google.com/task/5838080726012630006) started by @W73QB*