### PR TITLE
🎨 Palette: Add ARIA state attributes to mobile menu toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-16 - Ensure dynamic interactions map visual states to ARIA attributes
+**Learning:** When implementing dynamic interactions like toggleable menus, visual class changes (e.g., hidden) must be mapped to their corresponding ARIA attributes (e.g., `aria-expanded`) programmatically in the JavaScript logic to ensure full accessibility for screen readers.
+**Action:** Always verify that buttons controlling collapsible content have `aria-controls` and a dynamically updating `aria-expanded` attribute that mirrors the visual state of the controlled element.

--- a/ui/index.html
+++ b/ui/index.html
@@ -100,7 +100,9 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+        aria-label="Toggle menu"
+        aria-expanded="false"
+        aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -1145,6 +1147,7 @@
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
+      btn.setAttribute("aria-expanded", String(!isOpen));
     });
 
     init().catch(err => {


### PR DESCRIPTION
🎨 Palette: Add ARIA state attributes to mobile menu toggle

💡 What: Added `aria-expanded` and `aria-controls` to the mobile menu toggle button, dynamically updating `aria-expanded` via JavaScript when the menu opens/closes.
🎯 Why: Screen reader users previously had no way of knowing the state of the mobile menu (whether it was opened or closed) because the toggle relied entirely on visual CSS classes (`hidden`).
📸 Before/After: Verified via Playwright screenshot and video.
♿ Accessibility: Ensures the toggle interaction is fully accessible and predictable for screen reader users.

---
*PR created automatically by Jules for task [16230353308610169724](https://jules.google.com/task/16230353308610169724) started by @W73QB*