### PR TITLE
🎨 Palette: Add explicit label and aria-describedby to selects

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-20 - Missing Explicit Label Associations in Flex Layouts
+**Learning:** In the `ui/index.html` file, form inputs and their visual labels were contained within `flex-col` layout groups but lacked explicit `for` attributes linking the `<label>` to the `<select>` input ID. Screen readers and users relying on clicking labels to focus inputs are disadvantaged when labels and inputs are visually grouped but programmatically detached.
+**Action:** Always ensure that visual labels in custom UI component layouts (like flex columns) contain an explicit `for="input_id"` attribute and inputs have `aria-describedby` when helper text is present, to maintain strict programmatic association regardless of visual layout.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
💡 What: Added programmatic associations for form inputs. The `visaSelect` and `productSelect` inputs now have explicit `<label for="...">` associations, and the inputs use `aria-describedby` pointing to their respective hint texts.
🎯 Why: In a `flex-col` layout, visual grouping of a label above an input isn't enough for screen readers or standard HTML interactions. Adding the `for` attribute explicitly links them, improving accessibility and allowing users to focus the input by clicking the label text.
📸 Before/After: Verified visually via Playwright video/screenshot tests. Labels when clicked now focus the input correctly.
♿ Accessibility: Improves form usability and screen reader hint parsing.

---
*PR created automatically by Jules for task [11286983266993422752](https://jules.google.com/task/11286983266993422752) started by @W73QB*