### PR TITLE
🎨 Palette: Improve accessibility of form selects and mobile menu

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Add ARIA accessibility to form and menu
+**Learning:** Form labels using visual proximity instead of explicit `for` attributes fail screen reader tests, and mobile menu toggles need `aria-controls` and dynamic `aria-expanded` attributes to convey their state.
+**Action:** Always add explicit `for="[id]"` attributes to labels and `aria-describedby` for hint text, and ensure interactive toggles programmatically reflect their visual state changes using `setAttribute('aria-expanded', String(!isOpen))`.

--- a/ui/index.html
+++ b/ui/index.html
@@ -100,7 +100,7 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+        aria-label="Toggle menu" aria-expanded="false" aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -173,12 +173,13 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
             <select id="visaSelect"
+              aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +191,13 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
             <select id="productSelect"
+              aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>
@@ -1144,6 +1146,7 @@
       const btn = $("mobileMenuBtn");
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
+      btn.setAttribute("aria-expanded", String(!isOpen));
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
     });
 


### PR DESCRIPTION
💡 What: Added explicit `for` attributes to form labels linking them to their corresponding `<select>` elements (`#visaSelect`, `#productSelect`). Added `aria-describedby` to link the selects to their hint texts. Also added `aria-controls` and dynamic `aria-expanded` attributes to the mobile menu toggle button (`#mobileMenuBtn`).
🎯 Why: Enhances screen reader accessibility. Visually proximate labels without explicit `for` associations can be missed by assistive technologies, and mobile menus need explicit state management (expanded/collapsed) to communicate their status effectively.
♿ Accessibility: Improves ARIA compliance for dynamic interactive elements and basic HTML form element associations.

---
*PR created automatically by Jules for task [11681850336662495589](https://jules.google.com/task/11681850336662495589) started by @W73QB*