### PR TITLE
🎨 Palette: Improve accessibility of form inputs in UI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-20 - Form Input Associations
+**Learning:** In flex-col layouts, visual labels and helper text are separated from their inputs visually, requiring explicit `for` and `aria-describedby` attributes to maintain screen reader association.
+**Action:** Always verify `for` and `aria-describedby` explicitly when building visually decoupled form groups.

--- a/ui/index.html
+++ b/ui/index.html
@@ -173,12 +173,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +190,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
🎨 Palette: Improve accessibility of form inputs in UI

💡 What: Added explicit `for` attributes to the "I am applying for" and "I want to use" labels, linking them to their respective `<select>` inputs via ID (`visaSelect` and `productSelect`). Additionally, added `aria-describedby` attributes to both select elements linking to their helper hint paragraphs (`visaHint` and `productHint`).
🎯 Why: Because the form groups use a `flex-col` layout, the labels and helper texts are visually decoupled from the interactive elements. This explicit programmatic association ensures screen readers announce the labels when focusing the inputs and provide the necessary context.
♿ Accessibility: Improves screen reader support and form navigability, guaranteeing WCAG compliance for label-to-input mappings.

---
*PR created automatically by Jules for task [2107924812691267912](https://jules.google.com/task/2107924812691267912) started by @W73QB*