### PR TITLE
🎨 Palette: [UX improvement] Add ARIA attributes to interactive buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-03 - Added ARIA attributes to mobile menu and check button
+**Learning:** Interactive elements that toggle visibility (like mobile menus) or change states (like submit buttons) can cause confusion for screen reader users if `aria-expanded` and `aria-disabled` attributes are missing or not kept in sync dynamically alongside visual class or property changes.
+**Action:** Ensure dynamic components are audited for correct ARIA state management so screen reader context accurately reflects visual state.

--- a/ui/index.html
+++ b/ui/index.html
@@ -100,7 +100,9 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+        aria-label="Toggle menu"
+        aria-expanded="false"
+        aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -209,7 +211,7 @@
       </div>
 
       <div class="mt-10 flex justify-center">
-        <button id="checkBtn" disabled
+        <button id="checkBtn" disabled aria-disabled="true"
           class="group flex items-center gap-3 px-8 py-3.5 bg-primary/50 text-white text-lg font-bold rounded-lg transition-all shadow-md cursor-not-allowed">
           <span class="material-symbols-outlined group-hover:scale-110 transition-transform">check_circle</span>
           Check Compliance
@@ -650,6 +652,7 @@
       const ok = $("visaSelect").value && $("productSelect").value;
       const btn = $("checkBtn");
       btn.disabled = !ok;
+      btn.setAttribute("aria-disabled", String(!ok));
       btn.className = ok
         ? "group flex items-center gap-3 px-8 py-3.5 bg-primary hover:bg-primary-hover text-white text-lg font-bold rounded-lg transition-all shadow-md hover:shadow-lg hover:-translate-y-0.5 active:translate-y-0"
         : "group flex items-center gap-3 px-8 py-3.5 bg-primary/50 text-white text-lg font-bold rounded-lg transition-all shadow-md cursor-not-allowed";
@@ -1145,6 +1148,7 @@
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
+      btn.setAttribute("aria-expanded", String(!isOpen));
     });
 
     init().catch(err => {


### PR DESCRIPTION
💡 **What**: Added missing ARIA attributes (`aria-expanded`, `aria-controls`, and `aria-disabled`) to the mobile menu and the compliance check button.
🎯 **Why**: To ensure screen readers accurately announce the state of these dynamic interactive elements. Without them, users relying on assistive technology wouldn't know if the menu was open or if the check button was actually disabled or enabled.
📸 **Before/After**: See attached frontend verification artifacts (mobile menu open).
♿ **Accessibility**: Enhanced structural accessibility for both keyboard and screen reader users by programmatically exposing component state changes that were previously only communicated via visual class toggles (`md:hidden`, `disabled` property).

---
*PR created automatically by Jules for task [14637404590088823791](https://jules.google.com/task/14637404590088823791) started by @W73QB*