### PR TITLE
feat: SafetyWing affiliate links — GREEN routes only + compliance notes for RED routes

### DIFF
--- a/content/methodology/_index.md
+++ b/content/methodology/_index.md
@@ -1,3 +1,8 @@
+---
+title: "Methodology"
+description: "How the VisaFact compliance checker works — evidence-based approach, data model, and status definitions."
+---
+
 Methodology (How this checker works)
 
 {{< vf-trust >}}

--- a/content/posts/costa-rica-dn-insurance.md
+++ b/content/posts/costa-rica-dn-insurance.md
@@ -109,6 +109,25 @@ UNKNOWN results are common when product documents do not explicitly state the US
 - [Digital nomad insurance in the Americas](/posts/digital-nomad-insurance-americas/)
 - [How to read compliance results](/guides/how-to-read-results/)
 
+## Where to buy compliant insurance for Costa Rica Digital Nomad Visa
+
+The Costa Rica Digital Nomad Visa requires a minimum of $50,000 USD in medical coverage.
+
+[SafetyWing Nomad Insurance Essential](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=costa-rica-post) —
+covers unexpected illness or injury abroad in 175+ countries.
+Flexible plans: buy anytime, cancel anytime, auto-extends every 4 weeks.
+
+> Verify in the compliance checker before purchasing.
+> The checker shows the current evidence-based result for SafetyWing
+> against Costa Rica Executive Decree 43619 requirements.
+
+{{< checker_cta visa="CR_DN_VISA_2026" snapshot="releases/2026-01-15" label="Check SafetyWing for Costa Rica DN Visa" >}}
+
+*Affiliate disclosure: The link above is an affiliate link.
+We may earn a commission at no extra cost to you.
+Compliance results are generated independently.
+See [affiliate disclosure](/affiliate-disclosure/).*
+
 ## Disclaimer + Affiliate disclosure
 
 Not legal advice. Compliance results are evidence-based snapshots.

--- a/content/posts/costa-rica-dn-insurance.md
+++ b/content/posts/costa-rica-dn-insurance.md
@@ -111,17 +111,18 @@ UNKNOWN results are common when product documents do not explicitly state the US
 
 ## Where to buy compliant insurance for Costa Rica Digital Nomad Visa
 
-The Costa Rica Digital Nomad Visa requires a minimum of $50,000 USD in medical coverage.
+The Costa Rica Digital Nomad Visa requires at least US $50,000 in medical coverage
+for the full authorized stay period (Executive Decree 43619, Article 9).
 
 [SafetyWing Nomad Insurance Essential](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=costa-rica-post) —
-covers unexpected illness or injury abroad in 175+ countries.
-Flexible plans: buy anytime, cancel anytime, auto-extends every 4 weeks.
+travel medical insurance for 175+ countries covering unexpected illness and injury.
+Flexible monthly subscription, cancel anytime, auto-extends every 4 weeks.
 
-> Verify in the compliance checker before purchasing.
-> The checker shows the current evidence-based result for SafetyWing
-> against Costa Rica Executive Decree 43619 requirements.
+> Verify coverage amount and duration in the compliance checker before purchasing.
+> The checker confirms whether SafetyWing's documented coverage meets the $50,000
+> minimum and full-stay duration requirement for this route.
 
-{{< checker_cta visa="CR_DN_VISA_2026" snapshot="releases/2026-01-15" label="Check SafetyWing for Costa Rica DN Visa" >}}
+{{< checker_cta visa="CR_DN_DECREE_43619_2026" snapshot="releases/2026-01-15" label="Check SafetyWing for Costa Rica DN Visa" >}}
 
 *Affiliate disclosure: The link above is an affiliate link.
 We may earn a commission at no extra cost to you.

--- a/content/posts/digital-nomad-insurance-europe.md
+++ b/content/posts/digital-nomad-insurance-europe.md
@@ -111,6 +111,35 @@ As of snapshot `releases/2026-01-15`, example product outcomes across the verifi
 - [Malta nomad residence insurance hub](/posts/malta-nomad-insurance/)
 - [Spain DNV visa hub](/visas/spain/digital-nomad-visa/)
 
+## Recommended insurance for digital nomad visas in Europe
+
+Based on compliance check results for European digital nomad visa routes,
+two SafetyWing products cover most travelers:
+
+**For most routes (Spain DNV, Portugal E11, Malta Nomad):**
+
+[SafetyWing Nomad Insurance Essential](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=europe-post) —
+travel medical insurance covering unexpected illness, injury, delays, lost luggage,
+and trip interruptions in 175+ countries. Buy before you leave or while already abroad.
+Flexible monthly plans: cancel anytime, auto-extends every 4 weeks.
+
+**For routes requiring full health insurance:**
+
+[SafetyWing Nomad Insurance Complete](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=europe-post) —
+full health insurance with extra travel protections in 175+ countries.
+Includes routine checkups, mental health support, wellness therapies, and cancer treatment.
+Can be used as your primary health insurance wherever you live, work, or travel.
+
+> Always check the compliance checker for your specific route and product.
+> A GREEN result confirms compliance based on current evidence.
+
+{{< checker_cta snapshot="releases/2026-01-15" label="Check your route and product" >}}
+
+*Affiliate disclosure: Links above are affiliate links.
+We may earn a commission at no extra cost to you.
+Compliance results are generated independently and are not influenced
+by affiliate relationships. See our [affiliate disclosure](/affiliate-disclosure/).*
+
 ## Disclaimer + Affiliate disclosure
 
 Not legal advice. Compliance results are evidence-based snapshots.

--- a/content/posts/digital-nomad-insurance-europe.md
+++ b/content/posts/digital-nomad-insurance-europe.md
@@ -111,34 +111,35 @@ As of snapshot `releases/2026-01-15`, example product outcomes across the verifi
 - [Malta nomad residence insurance hub](/posts/malta-nomad-insurance/)
 - [Spain DNV visa hub](/visas/spain/digital-nomad-visa/)
 
-## Recommended insurance for digital nomad visas in Europe
+## Compliant insurance by route
 
-Based on compliance check results for European digital nomad visa routes,
-two SafetyWing products cover most travelers:
+Insurance requirements differ significantly across European digital nomad visa routes.
+See the compliance checker for your specific route.
 
-**For most routes (Spain DNV, Portugal E11, Malta Nomad):**
+**Portugal Remote Work Visa — SafetyWing shows GREEN:**
 
 [SafetyWing Nomad Insurance Essential](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=europe-post) —
-travel medical insurance covering unexpected illness, injury, delays, lost luggage,
-and trip interruptions in 175+ countries. Buy before you leave or while already abroad.
-Flexible monthly plans: cancel anytime, auto-extends every 4 weeks.
-
-**For routes requiring full health insurance:**
+travel medical insurance for 175+ countries. Flexible monthly plans, cancel anytime.
 
 [SafetyWing Nomad Insurance Complete](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=europe-post) —
-full health insurance with extra travel protections in 175+ countries.
-Includes routine checkups, mental health support, wellness therapies, and cancer treatment.
-Can be used as your primary health insurance wherever you live, work, or travel.
+full health insurance with extra travel protections, 175+ countries.
 
-> Always check the compliance checker for your specific route and product.
-> A GREEN result confirms compliance based on current evidence.
+**Spain DNV, Germany Freelance, Malta Nomad — SafetyWing shows RED:**
 
-{{< checker_cta snapshot="releases/2026-01-15" label="Check your route and product" >}}
+These routes require specific insurance types that SafetyWing does not meet.
+Compliant products for these routes will be listed when affiliate partnerships
+with qualifying providers are confirmed.
 
-*Affiliate disclosure: Links above are affiliate links.
+- **Spain DNV:** requires insurer authorized in Spain, unlimited coverage, no deductibles
+- **Germany Freelance:** requires statutory-level health insurance (not travel insurance)
+- **Malta Nomad:** requires annual prepayment (monthly policies not accepted)
+
+{{< checker_cta snapshot="releases/2026-01-15" label="Check your specific route and product" >}}
+
+*Affiliate disclosure: SafetyWing links are affiliate links for Portugal route only.
 We may earn a commission at no extra cost to you.
-Compliance results are generated independently and are not influenced
-by affiliate relationships. See our [affiliate disclosure](/affiliate-disclosure/).*
+Compliance results are generated independently.
+See [affiliate disclosure](/affiliate-disclosure/).*
 
 ## Disclaimer + Affiliate disclosure
 

--- a/content/posts/germany-freelance-insurance.md
+++ b/content/posts/germany-freelance-insurance.md
@@ -107,9 +107,19 @@ UNKNOWN is a signal to request clearer documentation, not a hint that the policy
 
 Not legal advice. Compliance results are evidence-based snapshots.
 
-If an affiliate link is present, it appears only after results and does not change the compliance outcome.
+**Why there is no affiliate link on this page:**
+The Germany Freelance Visa requires health insurance commensurate with
+German statutory minimum coverage. Travel insurance — including SafetyWing —
+does not meet this requirement and shows RED in the checker for this route.
 
-Last updated: 2026-02-05
+We only place affiliate links for products that show GREEN.
+Compliant products for this route (dedicated expat health insurance providers)
+will be added when our affiliate partnerships are confirmed.
+
+*Compliance results are never influenced by commercial relationships.
+See our [affiliate disclosure](/affiliate-disclosure/).*
+
+Last updated: 2026-06-05
 
 ## Evidence log
 

--- a/content/posts/germany-freelance-insurance.md
+++ b/content/posts/germany-freelance-insurance.md
@@ -109,15 +109,15 @@ Not legal advice. Compliance results are evidence-based snapshots.
 
 **Why there is no affiliate link on this page:**
 The Germany Freelance Visa requires health insurance commensurate with
-German statutory minimum coverage. Travel insurance — including SafetyWing —
-does not meet this requirement and shows RED in the checker for this route.
+German statutory minimum coverage. Travel insurance — including SafetyWing
+and World Nomads — does not meet this requirement and shows RED in the checker.
 
-We only place affiliate links for products that show GREEN.
 Compliant products for this route (dedicated expat health insurance providers)
 will be added when our affiliate partnerships are confirmed.
+Feather Insurance and similar Germany-authorized providers are being evaluated.
 
 *Compliance results are never influenced by commercial relationships.
-See our [affiliate disclosure](/affiliate-disclosure/).*
+See [affiliate disclosure](/affiliate-disclosure/).*
 
 Last updated: 2026-06-05
 

--- a/content/posts/malta-nomad-insurance.md
+++ b/content/posts/malta-nomad-insurance.md
@@ -109,6 +109,25 @@ UNKNOWN results are most common when product documents do not explicitly state a
 - [How to read compliance results](/guides/how-to-read-results/)
 - [Compliance status meaning](/guides/compliance-status-meaning/)
 
+## Where to buy compliant insurance for Malta Nomad Residence Permit
+
+The Malta Nomad Residence Permit requires health insurance for the full permit period.
+
+[SafetyWing Nomad Insurance Complete](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=malta-post) —
+full health insurance with extra travel protections in 175+ countries.
+Includes routine checkups, mental health support, wellness therapies, and cancer treatment.
+Can be used as your primary health insurance for the duration of your permit.
+
+> Verify coverage duration requirements in the checker
+> before submitting your Malta application.
+
+{{< checker_cta visa="MT_NOMAD_RESIDENCE_2026" snapshot="releases/2026-01-15" label="Check insurance for Malta Nomad Permit" >}}
+
+*Affiliate disclosure: The link above is an affiliate link.
+We may earn a commission at no extra cost to you.
+Compliance results are independent of affiliate relationships.
+See [affiliate disclosure](/affiliate-disclosure/).*
+
 ## Disclaimer + Affiliate disclosure
 
 Not legal advice. Compliance results are evidence-based snapshots.

--- a/content/posts/malta-nomad-insurance.md
+++ b/content/posts/malta-nomad-insurance.md
@@ -109,23 +109,24 @@ UNKNOWN results are most common when product documents do not explicitly state a
 - [How to read compliance results](/guides/how-to-read-results/)
 - [Compliance status meaning](/guides/compliance-status-meaning/)
 
-## Where to buy compliant insurance for Malta Nomad Residence Permit
+## Compliant insurance for Malta Nomad Residence Permit
 
-The Malta Nomad Residence Permit requires health insurance for the full permit period.
+Malta requires health insurance with **full-year premiums paid in advance**.
+Monthly payment policies are not accepted.
 
-[SafetyWing Nomad Insurance Complete](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=malta-post) —
-full health insurance with extra travel protections in 175+ countries.
-Includes routine checkups, mental health support, wellness therapies, and cancer treatment.
-Can be used as your primary health insurance for the duration of your permit.
+As of snapshot `releases/2026-01-15`, 2 products show GREEN for this route.
+SafetyWing shows RED because it uses a monthly subscription model.
 
-> Verify coverage duration requirements in the checker
-> before submitting your Malta application.
+Compliant providers (those showing GREEN in the checker) will be linked here
+when our affiliate partnerships with annual-plan insurance providers are confirmed.
 
-{{< checker_cta visa="MT_NOMAD_RESIDENCE_2026" snapshot="releases/2026-01-15" label="Check insurance for Malta Nomad Permit" >}}
+> Use the compliance checker to see which products currently show GREEN
+> for the Malta Nomad Residence Permit route.
 
-*Affiliate disclosure: The link above is an affiliate link.
-We may earn a commission at no extra cost to you.
-Compliance results are independent of affiliate relationships.
+{{< checker_cta visa="MT_NOMAD_RESIDENCY_2026" snapshot="releases/2026-01-15" label="Check compliant insurance for Malta Nomad Permit" >}}
+
+*No affiliate links on this page at this time.
+We only recommend products that show GREEN in the checker.
 See [affiliate disclosure](/affiliate-disclosure/).*
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/portugal-dnv-insurance.md
+++ b/content/posts/portugal-dnv-insurance.md
@@ -90,22 +90,27 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 ## Where to buy compliant insurance for Portugal Remote Work Visa
 
+Based on compliance check results for this route, the following products
+show GREEN for Portugal DNV / Remote Work Visa:
+
 [SafetyWing Nomad Insurance Essential](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=portugal-post) —
-travel medical insurance for 175+ countries covering unexpected illness, injury,
-delays, lost luggage, and trip interruptions.
-Flexible plans: buy before you leave or while already abroad, cancel anytime.
+travel medical insurance covering unexpected illness, injury, delays, lost luggage,
+and trip interruptions in 175+ countries. Buy before you leave or while already abroad.
+Flexible plans: cancel anytime, auto-extends every 4 weeks.
 
 [SafetyWing Nomad Insurance Complete](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=portugal-post) —
 full health insurance with extra travel protections in 175+ countries.
-Includes routine checkups, mental health, and wellness coverage.
+Includes routine checkups, mental health support, wellness therapies, and cancer treatment.
+Can be used as your primary health insurance wherever you live, work, or travel.
 
-> Check the compliance checker for your specific Portugal consulate route.
-> Requirements can vary between VFS and other routes.
+> Always verify in the compliance checker for your specific consulate route.
+> Requirements can vary between VFS and other Portugal routes.
 
-{{< checker_cta visa="PT_DNV_2026" snapshot="releases/2026-01-15" label="Check insurance for Portugal Remote Work Visa" >}}
+{{< checker_cta visa="PT_DNV_2026" snapshot="releases/2026-01-15" label="Check your insurance for Portugal Remote Work Visa" >}}
 
 *Affiliate disclosure: Links above are affiliate links.
 We may earn a commission at no extra cost to you.
+Compliance results are generated independently.
 See [affiliate disclosure](/affiliate-disclosure/).*
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/portugal-dnv-insurance.md
+++ b/content/posts/portugal-dnv-insurance.md
@@ -88,6 +88,26 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 - [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
 - [Schengen 30,000 EUR insurance rule](/guides/schengen-30000-insurance/)
 
+## Where to buy compliant insurance for Portugal Remote Work Visa
+
+[SafetyWing Nomad Insurance Essential](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=portugal-post) —
+travel medical insurance for 175+ countries covering unexpected illness, injury,
+delays, lost luggage, and trip interruptions.
+Flexible plans: buy before you leave or while already abroad, cancel anytime.
+
+[SafetyWing Nomad Insurance Complete](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=portugal-post) —
+full health insurance with extra travel protections in 175+ countries.
+Includes routine checkups, mental health, and wellness coverage.
+
+> Check the compliance checker for your specific Portugal consulate route.
+> Requirements can vary between VFS and other routes.
+
+{{< checker_cta visa="PT_DNV_2026" snapshot="releases/2026-01-15" label="Check insurance for Portugal Remote Work Visa" >}}
+
+*Affiliate disclosure: Links above are affiliate links.
+We may earn a commission at no extra cost to you.
+See [affiliate disclosure](/affiliate-disclosure/).*
+
 ## Disclaimer + Affiliate disclosure
 
 Not legal advice. Compliance results are evidence-based snapshots.

--- a/content/posts/safetywing-spain-dnv-rejected.md
+++ b/content/posts/safetywing-spain-dnv-rejected.md
@@ -126,6 +126,26 @@ These two conflicts alone are enough to keep the route RED, even if other requir
 - [Spain DNV insurance mistakes](/traps/spain-dnv-insurance-mistakes/)
 - [How to read compliance results](/guides/how-to-read-results/)
 
+## Compliant insurance for Spain Digital Nomad Visa
+
+Spain DNV requires: insurer authorized in Spain, unlimited coverage,
+no deductibles, no co-payments, no moratorium.
+
+SafetyWing shows RED for this route. The checker confirmed this finding —
+see the article above for the detailed evidence.
+
+Compliant providers for Spain DNV (those showing GREEN in the checker)
+will be linked here when our affiliate partnerships are confirmed.
+AXA Schengen and similar Spain-authorized insurers are being evaluated.
+
+> Use the compliance checker to see current GREEN products for Spain DNV.
+
+{{< checker_cta visa="ES_DNV_BLS_LONDON_2026" snapshot="releases/2026-01-15" label="Check compliant insurance for Spain DNV" >}}
+
+*No affiliate links on this page at this time.
+We only recommend products that show GREEN in the checker.
+See [affiliate disclosure](/affiliate-disclosure/).*
+
 ## Disclaimer + Affiliate disclosure
 
 Not legal advice. Compliance results are evidence-based snapshots.

--- a/content/posts/safetywing-vs-worldnomads-vs-genki.md
+++ b/content/posts/safetywing-vs-worldnomads-vs-genki.md
@@ -136,6 +136,27 @@ Reading this table:
 - [Germany freelance visa insurance](/posts/germany-freelance-insurance/)
 - [How to choose DNV insurance](/guides/how-to-choose-dnv-insurance/)
 
+## Quick links
+
+If the compliance checker shows a product as GREEN for your visa route,
+you can purchase directly:
+
+- [SafetyWing Nomad Insurance Essential](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=sw-comparison) —
+  travel medical, 175+ countries, flexible monthly subscription, cancel anytime
+- [SafetyWing Nomad Insurance Complete](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=sw-comparison) —
+  full health insurance with travel protections, 175+ countries,
+  includes routine checkups and mental health coverage
+
+*Check the compliance checker for your specific visa route before purchasing.
+A product GREEN for one route may show RED or UNKNOWN for another.*
+
+{{< checker_cta snapshot="releases/2026-01-15" label="Check compliance for your visa route" >}}
+
+*Affiliate disclosure: SafetyWing links are affiliate links.
+We may earn a commission at no extra cost to you.
+This does not affect compliance results or comparisons.
+See [affiliate disclosure](/affiliate-disclosure/).*
+
 ## Disclaimer + Affiliate disclosure
 
 Not legal advice. Compliance results are evidence-based snapshots.

--- a/content/posts/safetywing-vs-worldnomads-vs-genki.md
+++ b/content/posts/safetywing-vs-worldnomads-vs-genki.md
@@ -136,19 +136,21 @@ Reading this table:
 - [Germany freelance visa insurance](/posts/germany-freelance-insurance/)
 - [How to choose DNV insurance](/guides/how-to-choose-dnv-insurance/)
 
-## Quick links
+## Quick links — compliant products by route
 
-If the compliance checker shows a product as GREEN for your visa route,
-you can purchase directly:
+SafetyWing shows GREEN for Portugal DNV and Costa Rica.
+For other European routes (Spain, Germany, Malta), different products apply — see route pages.
+
+**For Portugal Remote Work Visa and Costa Rica Digital Nomad Visa:**
 
 - [SafetyWing Nomad Insurance Essential](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=sw-comparison) —
   travel medical, 175+ countries, flexible monthly subscription, cancel anytime
 - [SafetyWing Nomad Insurance Complete](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=sw-comparison) —
   full health insurance with travel protections, 175+ countries,
-  includes routine checkups and mental health coverage
+  routine checkups, mental health, and wellness included
 
-*Check the compliance checker for your specific visa route before purchasing.
-A product GREEN for one route may show RED or UNKNOWN for another.*
+*Always use the compliance checker for your specific route before purchasing.
+SafetyWing is RED for Spain DNV, Malta Nomad, and Germany Freelance.*
 
 {{< checker_cta snapshot="releases/2026-01-15" label="Check compliance for your visa route" >}}
 

--- a/content/posts/thailand-dtv-insurance.md
+++ b/content/posts/thailand-dtv-insurance.md
@@ -109,18 +109,18 @@ As of snapshot `releases/2026-01-15`, the checker evaluated 7 products and retur
 The Thailand Digital Nomad Visa (DTV) does **not** require health insurance.
 The compliance checker confirms: NOT_REQUIRED for this route.
 
-Many travelers choose to get voluntary coverage for peace of mind:
+Many travelers choose voluntary coverage for peace of mind while living abroad:
 
 [SafetyWing Nomad Insurance Essential](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=thailand-post) —
-optional travel medical coverage for Thailand and 175+ other countries.
+optional travel medical coverage in Thailand and 175+ other countries.
 Covers unexpected illness, injury, and travel disruptions.
-Monthly subscription, cancel anytime.
+Monthly subscription — cancel anytime.
 
-{{< checker_cta visa="TH_DTV_2026" snapshot="releases/2026-01-15" label="Verify Thailand DTV requirements" >}}
+{{< checker_cta visa="TH_DTV_2026" snapshot="releases/2026-01-15" label="Verify Thailand DTV insurance requirements" >}}
 
-*Affiliate disclosure: SafetyWing link above is an affiliate link.
+*Affiliate disclosure: The SafetyWing link above is an affiliate link.
 We may earn a commission at no extra cost to you.
-Insurance is optional for this route — this is not a compliance recommendation.
+Note: insurance is optional for this route — this is not a compliance recommendation.
 See [affiliate disclosure](/affiliate-disclosure/).*
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/thailand-dtv-insurance.md
+++ b/content/posts/thailand-dtv-insurance.md
@@ -104,6 +104,25 @@ As of snapshot `releases/2026-01-15`, the checker evaluated 7 products and retur
 - [How to read compliance results](/guides/how-to-read-results/)
 - [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
 
+## Insurance is not required — but here's what smart travelers get anyway
+
+The Thailand Digital Nomad Visa (DTV) does **not** require health insurance.
+The compliance checker confirms: NOT_REQUIRED for this route.
+
+Many travelers choose to get voluntary coverage for peace of mind:
+
+[SafetyWing Nomad Insurance Essential](https://safetywing.com/?referenceID=26539911&utm_source=26539911&utm_medium=Ambassador&utm_campaign=thailand-post) —
+optional travel medical coverage for Thailand and 175+ other countries.
+Covers unexpected illness, injury, and travel disruptions.
+Monthly subscription, cancel anytime.
+
+{{< checker_cta visa="TH_DTV_2026" snapshot="releases/2026-01-15" label="Verify Thailand DTV requirements" >}}
+
+*Affiliate disclosure: SafetyWing link above is an affiliate link.
+We may earn a commission at no extra cost to you.
+Insurance is optional for this route — this is not a compliance recommendation.
+See [affiliate disclosure](/affiliate-disclosure/).*
+
 ## Disclaimer + Affiliate disclosure
 
 Not legal advice. Compliance results are evidence-based snapshots.


### PR DESCRIPTION
## Summary

Adds SafetyWing affiliate links strictly where the compliance checker shows GREEN,
and replaces incorrect/missing sections with honest compliance notes where it shows RED.

### Affiliate links added (GREEN / NOT_REQUIRED routes only)

| Post | Links | Checker status |
|---|---|---|
| `portugal-dnv-insurance.md` | 2 | GREEN ✅ |
| `costa-rica-dn-insurance.md` | 1 | GREEN ✅ |
| `thailand-dtv-insurance.md` | 1 | NOT_REQUIRED ✅ |
| `safetywing-vs-worldnomads-vs-genki.md` | 2 | Portugal / Costa Rica context only |
| `digital-nomad-insurance-europe.md` | 2 | Portugal section only |

### No affiliate links — honest compliance notes instead

| Post | Reason |
|---|---|
| `malta-nomad-insurance.md` | SafetyWing = RED (monthly subscription; Malta requires annual prepayment) |
| `safetywing-spain-dnv-rejected.md` | SafetyWing = RED (Spain requires authorized insurer, unlimited coverage, no deductible) |
| `germany-freelance-insurance.md` | SafetyWing = RED (travel insurance not accepted for national D visa) |

### Critical fix from previous version
Europe hub (`digital-nomad-insurance-europe.md`) previously claimed SafetyWing covers
"Spain DNV, Portugal E11, Malta Nomad" — this was factually wrong (Spain and Malta are RED).
Corrected to Portugal-only with explicit RED notices for Spain, Germany, Malta.

### Structured data fix
- `content/methodology/_index.md`: Hugo front matter added — resolves BreadcrumbList schema error in Google Search Console

## Test plan
- [ ] Confirm SafetyWing links appear in Portugal, Costa Rica, Thailand, comparison, Europe posts
- [ ] Confirm NO SafetyWing affiliate URLs in Spain, Malta, Germany posts
- [ ] Verify Europe hub now says "Portugal — SafetyWing GREEN" and "Spain/Germany/Malta — RED"
- [ ] Run `py tools/lint_content.py` on modified posts
- [ ] Check `checker_cta` shortcodes render on Hugo local server

🤖 Generated with [Claude Code](https://claude.com/claude-code)