### PR TITLE
🎨 Palette: Form and Menu Accessibility Improvements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-06 - Form Input Accessibility
+**Learning:** Flex-col layouts visually separate labels from inputs, making explicit `for` and `aria-describedby` attributes essential for screen reader context. Icon-only mobile buttons must also dynamically update `aria-expanded` and reference `aria-controls`.
+**Action:** Ensure all form labels use the `for` attribute referencing an input ID, and inputs use `aria-describedby` referencing helper text. Icon buttons toggling visibility need explicit ARIA state handling.

--- a/ui/index.html
+++ b/ui/index.html
@@ -100,7 +100,9 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+        aria-label="Toggle menu"
+        aria-expanded="false"
+        aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -173,12 +175,13 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
             <select id="visaSelect"
+              aria-describedby="visaHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -190,12 +193,13 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
             <select id="productSelect"
+              aria-describedby="productHint"
               class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
               <option value="">Select an insurance product</option>
             </select>
@@ -1144,6 +1148,7 @@
       const btn = $("mobileMenuBtn");
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
+      btn.setAttribute("aria-expanded", String(!isOpen));
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
     });
 


### PR DESCRIPTION
This PR implements a micro-UX/accessibility enhancement as per Palette's role. It improves keyboard and screen reader accessibility by properly associating form labels with their select inputs, and by providing correct ARIA state management for the mobile navigation menu toggle.

💡 **What:** The UX enhancement added:
- Explicit `for` attributes on form labels connecting to `visaSelect` and `productSelect`.
- Explicit `aria-describedby` on the select inputs.
- ARIA state management (`aria-expanded`, `aria-controls`) for the mobile menu button.

🎯 **Why:** The user problem it solves:
- The flex-col layout visually separated the labels from the inputs. Without explicit `for` attributes, screen readers couldn't reliably announce the label context when the user focused the input.
- The mobile menu button was a visual toggle but lacked the semantic ARIA properties needed for screen readers to understand whether the menu was open or closed.

♿ **Accessibility:**
- Ensures screen readers announce the correct label for the visa and product selectors.
- Ensures screen readers announce the current state (expanded/collapsed) of the mobile navigation menu.

---
*PR created automatically by Jules for task [12396008121401839986](https://jules.google.com/task/12396008121401839986) started by @W73QB*