### PR TITLE
feat(ui): visual modernization — design tokens, components, motion (presentation-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 tmpclaude-*-cwd
 # Sisyphus planning/evidence files
 .sisyphus/
+# Local Claude Code config and skills (machine-local, not shared)
+.claude/
 # Python
 __pycache__/
 *.py[cod]

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -19,7 +19,7 @@
     line-height: var(--vf-type-body-lh, 1.6);
     color: var(--vf-color-ink, #151515);
     background: var(--vf-color-paper, #faf8f5);
-    /* Removed: transition-colors duration-200 (body color flash on theme toggle) */
+    /* Phase 5: transition-colors removed from body (flash on theme toggle). */
   }
 
   h1 {
@@ -27,7 +27,7 @@
     font-size: clamp(1.75rem, 4vw, var(--vf-type-display-size, 2.5rem));
     line-height: var(--vf-type-display-lh, 1.15);
     letter-spacing: var(--vf-type-display-ls, -0.02em);
-    font-weight: 400; /* DM Serif Display is a display weight; synthesized bold looks off */
+    font-weight: 400;
   }
 
   h2 {
@@ -63,7 +63,6 @@
     color: var(--vf-color-ink);
   }
 
-  /* Link defaults (overridden by visafact.css) */
   a {
     color: var(--vf-color-primary, #19335a);
     text-underline-offset: 2px;
@@ -103,41 +102,58 @@ select:focus-visible {
 }
 
 /* =========================================================
-   Page load animations
-   (Phase 5 will consolidate to vf-rise; these names kept
-   so ui/index.html markup references remain valid.)
+   Motion — one coherent vocabulary (Phase 5)
+   All animations wrapped in (prefers-reduced-motion: no-preference)
+   so they short-circuit to no animation for users who prefer it.
+
+   Class names retained verbatim (.animate-fade-up, .animate-reveal,
+   .pulse-success) so ui/index.html markup references keep working.
+   Keyframes consolidated to vf-rise + vf-pulse.
    ========================================================= */
 
-@keyframes fadeSlideUp {
-  from { opacity: 0; transform: translateY(20px); }
-  to   { opacity: 1; transform: translateY(0);    }
-}
-.animate-fade-up { animation: fadeSlideUp 0.6s ease-out both; }
-.delay-100 { animation-delay: 0.1s; }
-.delay-200 { animation-delay: 0.2s; }
-.delay-300 { animation-delay: 0.3s; }
+@media (prefers-reduced-motion: no-preference) {
 
-/* Result reveal animation */
-@keyframes revealUp {
-  from { opacity: 0; transform: translateY(30px) scale(0.98); }
-  to   { opacity: 1; transform: translateY(0)    scale(1);    }
-}
-.animate-reveal { animation: revealUp 0.5s ease-out both; }
+  /* --- One rise keyframe replaces fadeSlideUp + revealUp --- */
+  @keyframes vf-rise {
+    from { opacity: 0; transform: translateY(16px); }
+    to   { opacity: 1; transform: translateY(0);    }
+  }
 
-/* Status pulse for GREEN */
-@keyframes trustPulse {
-  0%,  100% { box-shadow: 0 0 0 0px rgba(5, 150, 105, 0.4); }
-  50%       { box-shadow: 0 0 0 8px rgba(5, 150, 105, 0);   }
-}
-.pulse-success { animation: trustPulse 2s ease-in-out infinite; }
+  /* --- Pulse keyframe (same as trustPulse, new name) --- */
+  @keyframes vf-pulse {
+    0%,  100% { box-shadow: 0 0 0 0px rgba(5, 150, 105, 0.4); }
+    50%       { box-shadow: 0 0 0 8px rgba(5, 150, 105, 0);   }
+  }
 
-/* Paper texture removed in Phase 5 (z-index -1, 0.03 opacity — not perceivable). */
+  /* Retained class names — all pointing to vf-rise */
+  .animate-fade-up {
+    animation: vf-rise var(--vf-motion-slow, 350ms) var(--vf-ease-standard, ease) both;
+  }
+  .delay-100 { animation-delay: 0.1s; }
+  .delay-200 { animation-delay: 0.2s; }
+  .delay-300 { animation-delay: 0.3s; }
+
+  .animate-reveal {
+    animation: vf-rise var(--vf-motion-base, 200ms) var(--vf-ease-emphasized, ease) both;
+  }
+
+  .pulse-success {
+    animation: vf-pulse 2s var(--vf-ease-standard, ease) infinite;
+  }
+}
+
+/* =========================================================
+   Paper texture removed (Phase 5).
+   Was: body::before with SVG feTurbulence at 0.03 opacity,
+   z-index: -1. Imperceptible at that opacity; removed for
+   simplicity. Comment kept as change log.
+   ========================================================= */
 
 /* =========================================================
    Stamp-style status badges
-   Phase 3 reduces rotation from -2deg to -0.6deg.
-   Class name .stamp-badge is kept verbatim (JS sets it
-   at ui/index.html:1000-1002 via el.className =).
+   Phase 5: rotation override moves to #resultArea .stamp-badge
+   in visafact.css (Phase 3). Class name .stamp-badge kept
+   verbatim per plan A.5 (JS sets it at ui/index.html:1000-1002).
    ========================================================= */
 
 .stamp-badge {
@@ -148,7 +164,8 @@ select:focus-visible {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  transform: rotate(-2deg); /* Phase 3 will override to -0.6deg via #resultArea scoping */
+  /* Default rotation; #resultArea .stamp-badge in visafact.css overrides to -0.6deg */
+  transform: rotate(-2deg);
 }
 
 .stamp-badge::before {
@@ -162,7 +179,6 @@ select:focus-visible {
 
 /* =========================================================
    Monospaced figures for numeric result areas
-   (Phase 2 addition — tnum for amounts, dates, IDs)
    ========================================================= */
 
 #lastVerified,

--- a/assets/css/input.css
+++ b/assets/css/input.css
@@ -2,13 +2,82 @@
 @tailwind components;
 @tailwind utilities;
 
+/* =========================================================
+   Base layer — typographic scale + rhythm
+   Tokens from assets/css/visafact.css (loaded globally).
+   ========================================================= */
+
 @layer base {
+  html {
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+  }
+
   body {
-    font-family: 'Plus Jakarta Sans', system-ui, sans-serif;
+    font-family: var(--vf-font-body, 'Plus Jakarta Sans', system-ui, sans-serif);
+    font-size: var(--vf-type-body-size, 1rem);
+    line-height: var(--vf-type-body-lh, 1.6);
+    color: var(--vf-color-ink, #151515);
+    background: var(--vf-color-paper, #faf8f5);
+    /* Removed: transition-colors duration-200 (body color flash on theme toggle) */
+  }
+
+  h1 {
+    font-family: var(--vf-font-display, 'DM Serif Display', Georgia, serif);
+    font-size: clamp(1.75rem, 4vw, var(--vf-type-display-size, 2.5rem));
+    line-height: var(--vf-type-display-lh, 1.15);
+    letter-spacing: var(--vf-type-display-ls, -0.02em);
+    font-weight: 400; /* DM Serif Display is a display weight; synthesized bold looks off */
+  }
+
+  h2 {
+    font-family: var(--vf-font-display, 'DM Serif Display', Georgia, serif);
+    font-size: clamp(1.375rem, 2.5vw, 1.875rem);
+    line-height: 1.25;
+    letter-spacing: -0.015em;
+    font-weight: 400;
+  }
+
+  h3 {
+    font-family: var(--vf-font-display, 'DM Serif Display', Georgia, serif);
+    font-size: 1.25rem;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    font-weight: 400;
+  }
+
+  h4 {
+    font-family: var(--vf-font-body, 'Plus Jakarta Sans', system-ui, sans-serif);
+    font-size: 1rem;
+    line-height: 1.4;
+    font-weight: 700;
+    letter-spacing: 0;
+  }
+
+  p {
+    max-width: 72ch;
+  }
+
+  ::selection {
+    background: rgba(212, 165, 30, 0.25);
+    color: var(--vf-color-ink);
+  }
+
+  /* Link defaults (overridden by visafact.css) */
+  a {
+    color: var(--vf-color-primary, #19335a);
+    text-underline-offset: 2px;
+    transition: color var(--vf-motion-fast, 120ms) var(--vf-ease-standard, ease);
+  }
+  a:hover {
+    color: var(--vf-color-accent, #d4a51e);
   }
 }
 
-/* Material Icons settings */
+/* =========================================================
+   Material Symbols settings
+   ========================================================= */
+
 .material-symbols-outlined {
   font-variation-settings: 'FILL' 0,'wght' 400,'GRAD' 0,'opsz' 24;
 }
@@ -16,21 +85,32 @@
   font-variation-settings: 'FILL' 1,'wght' 400,'GRAD' 0,'opsz' 24;
 }
 
-/* Accessibility: Focus states */
+/* =========================================================
+   Accessibility: Focus states
+   ========================================================= */
+
 :focus-visible {
-  outline: 2px solid #1e3a5f;
+  outline: 2px solid var(--vf-color-primary, #19335a);
   outline-offset: 2px;
-}
-button:focus-visible, a:focus-visible, select:focus-visible {
-  outline: 2px solid #c9a227;
-  outline-offset: 2px;
-  box-shadow: 0 0 0 4px rgba(201, 162, 39, 0.2);
 }
 
-/* Page load animations */
+button:focus-visible,
+a:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--vf-color-accent, #d4a51e);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px rgba(212, 165, 30, 0.2);
+}
+
+/* =========================================================
+   Page load animations
+   (Phase 5 will consolidate to vf-rise; these names kept
+   so ui/index.html markup references remain valid.)
+   ========================================================= */
+
 @keyframes fadeSlideUp {
   from { opacity: 0; transform: translateY(20px); }
-  to { opacity: 1; transform: translateY(0); }
+  to   { opacity: 1; transform: translateY(0);    }
 }
 .animate-fade-up { animation: fadeSlideUp 0.6s ease-out both; }
 .delay-100 { animation-delay: 0.1s; }
@@ -40,33 +120,26 @@ button:focus-visible, a:focus-visible, select:focus-visible {
 /* Result reveal animation */
 @keyframes revealUp {
   from { opacity: 0; transform: translateY(30px) scale(0.98); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
+  to   { opacity: 1; transform: translateY(0)    scale(1);    }
 }
 .animate-reveal { animation: revealUp 0.5s ease-out both; }
 
 /* Status pulse for GREEN */
 @keyframes trustPulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(5, 150, 105, 0.4); }
-  50% { box-shadow: 0 0 0 8px rgba(5, 150, 105, 0); }
+  0%,  100% { box-shadow: 0 0 0 0px rgba(5, 150, 105, 0.4); }
+  50%       { box-shadow: 0 0 0 8px rgba(5, 150, 105, 0);   }
 }
 .pulse-success { animation: trustPulse 2s ease-in-out infinite; }
 
-/* Subtle paper texture */
-body::before {
-  content: "";
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  opacity: 0.03;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
-  z-index: -1;
-}
-.dark body::before { opacity: 0.02; }
+/* Paper texture removed in Phase 5 (z-index -1, 0.03 opacity — not perceivable). */
 
-/* Stamp-style status badges */
+/* =========================================================
+   Stamp-style status badges
+   Phase 3 reduces rotation from -2deg to -0.6deg.
+   Class name .stamp-badge is kept verbatim (JS sets it
+   at ui/index.html:1000-1002 via el.className =).
+   ========================================================= */
+
 .stamp-badge {
   position: relative;
   padding: 0.5rem 1rem;
@@ -75,8 +148,9 @@ body::before {
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  transform: rotate(-2deg);
+  transform: rotate(-2deg); /* Phase 3 will override to -0.6deg via #resultArea scoping */
 }
+
 .stamp-badge::before {
   content: "";
   position: absolute;
@@ -84,4 +158,19 @@ body::before {
   border: 1px dashed currentColor;
   border-radius: 0.25rem;
   opacity: 0.5;
+}
+
+/* =========================================================
+   Monospaced figures for numeric result areas
+   (Phase 2 addition — tnum for amounts, dates, IDs)
+   ========================================================= */
+
+#lastVerified,
+#snapshotId,
+#authorityText,
+#scopeText,
+#lastUpdated,
+#builtAt {
+  font-feature-settings: "tnum";
+  font-variant-numeric: tabular-nums;
 }

--- a/assets/css/visafact.css
+++ b/assets/css/visafact.css
@@ -353,3 +353,158 @@ html[data-theme="dark"] .vf-header {
 .vf-pill h3 {
   margin-top: 0;
 }
+
+/* =========================================================
+   Phase 3 — Component vocabulary
+   All .vf-* classes below. JS-controlled element styles
+   are scoped by ID (#resultArea, #checkBtn, etc.) to
+   survive el.className = "..." full overwrites in JS.
+   ========================================================= */
+
+/* --- Badge pill (trust/info chips; NOT the stamp-badge) ---
+   Replaces bg-accent/10 border-accent/30 rounded-full pattern. */
+.vf-pill--badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0.35rem 0.85rem;
+  border: 1px solid var(--vf-color-line);
+  border-radius: var(--vf-radius-full);
+  font-size: var(--vf-type-caps-size);
+  font-weight: 600;
+  color: var(--vf-color-accent);
+  background: transparent;
+}
+
+/* --- Cards --- */
+.vf-card {
+  background: var(--vf-color-surface);
+  border: 1px solid var(--vf-color-line);
+  border-radius: var(--vf-radius-xl);
+  /* No hover:shadow escalation — deliberately flat interaction */
+}
+
+html[data-theme="dark"] .vf-card,
+.dark .vf-card {
+  background: #1a232e;
+  border-color: #2d3748;
+}
+
+.vf-card--elevated {
+  box-shadow: var(--vf-shadow-2);
+}
+
+/* --- Select / form field --- */
+.vf-field {
+  width: 100%;
+  height: 3.5rem;
+  border: 1px solid var(--vf-color-line);
+  border-radius: var(--vf-radius-md);
+  background: var(--vf-color-surface);
+  color: var(--vf-color-ink);
+  font-family: var(--vf-font-body);
+  font-weight: 500;
+  font-size: 1rem;
+  outline: none;
+  transition:
+    border-color var(--vf-motion-fast) var(--vf-ease-standard),
+    box-shadow   var(--vf-motion-fast) var(--vf-ease-standard);
+}
+
+.vf-field:focus {
+  border-color: var(--vf-color-primary);
+  box-shadow: 0 0 0 3px rgba(25, 51, 90, 0.12);
+}
+
+html[data-theme="dark"] .vf-field,
+.dark .vf-field {
+  background: #111418;
+  border-color: #2d3748;
+  color: #f0f0ef;
+}
+
+/* --- Meta list (result panel sidebar) ---
+   Replaces 9-class utility soup at ui/index.html:283-304. */
+.vf-meta-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--vf-space-2);
+  padding: var(--vf-space-4);
+  background: var(--vf-color-surface);
+  border: 1px solid var(--vf-color-line);
+  border-radius: var(--vf-radius-md);
+  font-size: var(--vf-type-small-size);
+  color: var(--vf-color-text-secondary);
+}
+
+html[data-theme="dark"] .vf-meta-list,
+.dark .vf-meta-list {
+  background: rgba(26, 35, 46, 0.5);
+  border-color: #2d3748;
+  color: #9ca3af;
+}
+
+/* --- Modal shell --- */
+.vf-modal-shell {
+  width: 100%;
+  max-width: 48rem;
+  background: var(--vf-color-surface);
+  border: 1px solid var(--vf-color-line);
+  border-radius: var(--vf-radius-xl);
+  box-shadow: var(--vf-shadow-3);
+}
+
+html[data-theme="dark"] .vf-modal-shell,
+.dark .vf-modal-shell {
+  background: #111418;
+  border-color: #2d3748;
+}
+
+/* --- Status chip: ID-scoped so JS className= survives ---
+   Rotation reduced from -2deg to -0.6deg (open question #3 default).
+   The class name stamp-badge is preserved verbatim per plan A.5.   */
+#resultArea .stamp-badge {
+  transform: rotate(-0.6deg);
+}
+
+/* --- Check button (JS overwrites btn.className — style via ID) --- */
+#checkBtn {
+  transition:
+    background-color var(--vf-motion-fast) var(--vf-ease-standard),
+    box-shadow       var(--vf-motion-fast) var(--vf-ease-standard),
+    transform        var(--vf-motion-fast) var(--vf-ease-standard);
+}
+
+/* --- Mobile menu (open question #5 default) --- */
+#mobileMenu {
+  max-width: 100vw;
+  overflow-x: hidden;
+}
+#mobileMenu:not(.hidden) {
+  box-shadow: var(--vf-shadow-2);
+}
+
+/* --- Cookie banner (dark mode contrast improvement) --- */
+#vf-cookie-banner > div {
+  background: var(--vf-color-surface);
+  border: 1px solid var(--vf-color-line);
+  box-shadow: var(--vf-shadow-2);
+}
+
+html[data-theme="dark"] #vf-cookie-banner > div,
+.dark #vf-cookie-banner > div {
+  background: #1a232e;
+  border-color: #2d3748;
+  color: var(--vf-color-ink);
+}
+
+/* --- Standalone UI header refinement class --- */
+.vf-header--refined {
+  border-bottom: 1px solid var(--vf-color-line);
+  background: rgba(250, 248, 245, 0.92);
+  backdrop-filter: blur(8px);
+}
+
+.dark .vf-header--refined {
+  background: rgba(15, 20, 25, 0.92);
+}

--- a/assets/css/visafact.css
+++ b/assets/css/visafact.css
@@ -1,208 +1,355 @@
+/* =========================================================
+   VisaFact Design Tokens — Phase 1
+   All --vf-* custom properties are the single source of
+   truth for color, space, radius, shadow, type, and motion.
+   Component classes below consume these tokens.
+   Do NOT edit bare hex values elsewhere in the codebase
+   without updating the token here first.
+   ========================================================= */
+
 :root {
-  --primary: #1e3a5f;
-  --secondary: #c9a227;
-  --theme: #faf8f5;
-  --entry: #ffffff;
-  --content: #1a1a1a;
-  --vf-primary: #1e3a5f;
-  --vf-accent: #c9a227;
-  --vf-bg: #faf8f5;
-  --vf-text: #1a1a1a;
-  --vf-surface: #ffffff;
-  --vf-border: #e8e4df;
+  /* --- Brand colors ---
+     Navy deepened ~10% from original #1e3a5f.
+     Gold saturation raised ~5% from original #c9a227.      */
+  --vf-color-primary:       #19335a;
+  --vf-color-primary-hover: #122645;
+  --vf-color-accent:        #d4a51e;
+  --vf-color-accent-hover:  #b89118;
+
+  /* --- Surface / ink --- */
+  --vf-color-paper:   #faf8f5;
+  --vf-color-surface: #ffffff;
+  --vf-color-ink:     #151515;
+  --vf-color-line:    #e8e4df;
+
+  /* --- Text aliases --- */
+  --vf-color-text:           var(--vf-color-ink);
+  --vf-color-text-secondary: #525252;
+
+  /* --- Status --- */
+  --vf-color-success: #059669;
+  --vf-color-warning: #d97706;
+  --vf-color-danger:  #dc2626;
+  --vf-color-info:    #0369a1;
+  --vf-color-unknown: #6b7280;
+
+  /* --- Radius scale --- */
+  --vf-radius-sm:   4px;
+  --vf-radius-md:   8px;
+  --vf-radius-lg:   12px;
+  --vf-radius-xl:   16px;
+  --vf-radius-full: 9999px;
+
+  /* --- Elevation (3 tiers, no runaway shadow-xl) --- */
+  --vf-shadow-0: none;
+  --vf-shadow-1: 0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.05);
+  --vf-shadow-2: 0 4px 12px rgba(0,0,0,0.08), 0 2px 4px rgba(0,0,0,0.04);
+  --vf-shadow-3: 0 8px 24px rgba(0,0,0,0.10), 0 4px 8px rgba(0,0,0,0.06);
+
+  /* --- Spacing (4px base scale) --- */
+  --vf-space-1:   4px;
+  --vf-space-2:   8px;
+  --vf-space-3:  12px;
+  --vf-space-4:  16px;
+  --vf-space-5:  20px;
+  --vf-space-6:  24px;
+  --vf-space-8:  32px;
+  --vf-space-10: 40px;
+  --vf-space-12: 48px;
+
+  /* --- Type scale --- */
+  --vf-type-display-size: 2.5rem;
+  --vf-type-display-lh:   1.15;
+  --vf-type-display-ls:  -0.02em;
+
+  --vf-type-lead-size: 1.125rem;
+  --vf-type-lead-lh:   1.55;
+
+  --vf-type-body-size: 1rem;
+  --vf-type-body-lh:   1.6;
+
+  --vf-type-small-size: 0.875rem;
+  --vf-type-small-lh:   1.5;
+
+  --vf-type-caps-size: 0.75rem;
+  --vf-type-caps-lh:   1.4;
+  --vf-type-caps-ls:   0.08em;
+
+  /* --- Motion --- */
+  --vf-motion-fast: 120ms;
+  --vf-motion-base: 200ms;
+  --vf-motion-slow: 350ms;
+  --vf-ease-standard:   cubic-bezier(0.2, 0.0, 0, 1);
+  --vf-ease-emphasized: cubic-bezier(0.3, 0.0, 0, 1);
+
+  /* --- Font stacks --- */
+  --vf-font-display: 'DM Serif Display', Georgia, serif;
+  --vf-font-body:    'Plus Jakarta Sans', system-ui, sans-serif;
+
+  /* --- PaperMod variable aliases ---
+     Maps PaperMod's internal --theme / --entry / --content
+     to our token layer without touching themes/PaperMod/.   */
+  --primary:  var(--vf-color-primary);
+  --secondary: var(--vf-color-accent);
+  --theme:    var(--vf-color-paper);
+  --entry:    var(--vf-color-surface);
+  --content:  var(--vf-color-ink);
+
+  /* --- Legacy aliases (kept for backward compatibility) --- */
+  --vf-primary: var(--vf-color-primary);
+  --vf-accent:  var(--vf-color-accent);
+  --vf-bg:      var(--vf-color-paper);
+  --vf-text:    var(--vf-color-ink);
+  --vf-surface: var(--vf-color-surface);
+  --vf-border:  var(--vf-color-line);
 }
 
 html[data-theme="dark"] {
-  --theme: #0f1419;
-  --entry: #1a232e;
-  --content: #f5f5f5;
-  --vf-bg: #0f1419;
-  --vf-text: #f5f5f5;
-  --vf-surface: #1a232e;
-  --vf-border: #2d3748;
+  --vf-color-paper:          #0f1419;
+  --vf-color-surface:        #1a232e;
+  --vf-color-ink:            #f0f0ef;
+  --vf-color-line:           #2d3748;
+  --vf-color-text-secondary: #9ca3af;
+
+  /* PaperMod dark aliases */
+  --theme:   var(--vf-color-paper);
+  --entry:   var(--vf-color-surface);
+  --content: var(--vf-color-ink);
+
+  /* Legacy dark aliases */
+  --vf-bg:      var(--vf-color-paper);
+  --vf-text:    var(--vf-color-ink);
+  --vf-surface: var(--vf-color-surface);
+  --vf-border:  var(--vf-color-line);
 }
 
+/* =========================================================
+   Base typography
+   ========================================================= */
+
 body {
-  font-family: "Plus Jakarta Sans", system-ui, sans-serif;
-  background: var(--vf-bg);
-  color: var(--vf-text);
+  font-family: var(--vf-font-body);
+  background: var(--vf-color-paper);
+  color: var(--vf-color-ink);
+  line-height: var(--vf-type-body-lh);
 }
 
 h1, h2, h3, h4 {
-  font-family: "DM Serif Display", Georgia, serif;
-  letter-spacing: 0.01em;
+  font-family: var(--vf-font-display);
+  letter-spacing: var(--vf-type-display-ls);
 }
 
 a {
-  color: var(--vf-primary);
+  color: var(--vf-color-primary);
 }
 
 a:hover {
-  color: var(--vf-accent);
+  color: var(--vf-color-accent);
 }
 
-/* PaperMod cards */
+/* =========================================================
+   PaperMod card overrides
+   ========================================================= */
+
 .post-entry, .post-single, .entry-content {
-  border-radius: 14px;
-  background: var(--vf-surface);
-  border: 1px solid var(--vf-border);
+  border-radius: var(--vf-radius-lg);
+  background: var(--vf-color-surface);
+  border: 1px solid var(--vf-color-line);
 }
 
-/* Header / footer alignment */
+/* =========================================================
+   Header / footer
+   ========================================================= */
+
 .vf-header {
-  border-bottom: 1px solid var(--vf-border);
-  background: rgba(250, 248, 245, 0.9);
+  border-bottom: 1px solid var(--vf-color-line);
+  background: rgba(250, 248, 245, 0.92);
   backdrop-filter: blur(8px);
 }
+
 html[data-theme="dark"] .vf-header {
-  background: rgba(15, 20, 25, 0.9);
+  background: rgba(15, 20, 25, 0.92);
 }
+
 .vf-header .logo a {
-  font-family: "DM Serif Display", Georgia, serif;
-  color: var(--vf-text);
+  font-family: var(--vf-font-display);
+  color: var(--vf-color-ink);
 }
+
 .vf-menu a span {
   font-weight: 600;
 }
+
 .vf-footer {
-  border-top: 1px solid var(--vf-border);
-  background: var(--vf-surface);
+  border-top: 1px solid var(--vf-color-line);
+  background: var(--vf-color-surface);
 }
 
-/* CTA button style */
+/* =========================================================
+   CTA button
+   ========================================================= */
+
 .vf-cta {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--vf-space-2);
   padding: 0.6rem 1rem;
-  background: var(--vf-primary);
+  background: var(--vf-color-primary);
   color: #fff;
-  border-radius: 10px;
+  border-radius: var(--vf-radius-md);
   font-weight: 700;
   text-decoration: none;
+  transition: background-color var(--vf-motion-fast) var(--vf-ease-standard);
 }
 
-.vf-cta:hover { background: #152a45; }
+.vf-cta:hover {
+  background: var(--vf-color-primary-hover);
+  color: #fff;
+}
 
-/* CTA focus states */
 .vf-cta:focus-visible {
-  outline: 2px solid var(--vf-accent);
+  outline: 2px solid var(--vf-color-accent);
   outline-offset: 2px;
 }
 
-/* Trust callout */
+/* =========================================================
+   Trust callout
+   ========================================================= */
+
 .vf-trust {
-  border: 2px solid var(--vf-accent);
+  border: 2px solid var(--vf-color-accent);
   padding: 1rem;
-  border-radius: 12px;
-  background: rgba(201,162,39,0.08);
+  border-radius: var(--vf-radius-lg);
+  background: rgba(212, 165, 30, 0.08);
   font-weight: 600;
 }
+
 .vf-trust:focus-within {
-  box-shadow: 0 0 0 2px var(--vf-accent);
+  box-shadow: 0 0 0 2px var(--vf-color-accent);
 }
 
-/* Home hero layout */
+/* =========================================================
+   Home hero layout
+   ========================================================= */
+
 .vf-hero {
   display: grid;
-  gap: 2rem;
-  margin-bottom: 2.5rem;
+  gap: var(--vf-space-8);
+  margin-bottom: var(--vf-space-10);
 }
+
 @media (min-width: 900px) {
   .vf-hero {
     grid-template-columns: 1.2fr 0.8fr;
     align-items: start;
   }
 }
+
 .vf-kicker {
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-size: 0.72rem;
+  letter-spacing: var(--vf-type-caps-ls);
+  font-size: var(--vf-type-caps-size);
   font-weight: 700;
-  color: var(--vf-accent);
-  margin-bottom: 0.5rem;
+  color: var(--vf-color-accent);
+  margin-bottom: var(--vf-space-2);
 }
+
 .vf-lead {
-  font-size: 1.05rem;
-  line-height: 1.6;
-  margin-bottom: 1.2rem;
+  font-size: var(--vf-type-lead-size);
+  line-height: var(--vf-type-lead-lh);
+  margin-bottom: var(--vf-space-5);
 }
+
 .vf-cta-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
-  margin: 1rem 0 1.5rem;
+  gap: var(--vf-space-3);
+  margin: var(--vf-space-4) 0 var(--vf-space-6);
 }
+
 .vf-cta-secondary {
   background: transparent;
-  color: var(--vf-primary);
-  border: 2px solid var(--vf-primary);
+  color: var(--vf-color-primary);
+  border: 2px solid var(--vf-color-primary);
 }
+
 .vf-cta-secondary:hover {
-  background: rgba(30, 58, 95, 0.08);
+  background: rgba(25, 51, 90, 0.08);
+  color: var(--vf-color-primary);
 }
 
 .vf-hero-card {
-  background: var(--vf-surface);
-  border: 1px solid var(--vf-border);
-  border-radius: 16px;
-  padding: 1.5rem;
-  box-shadow: 0 12px 30px rgba(0,0,0,0.06);
+  background: var(--vf-color-surface);
+  border: 1px solid var(--vf-color-line);
+  border-radius: var(--vf-radius-xl);
+  padding: var(--vf-space-6);
+  box-shadow: var(--vf-shadow-2);
 }
+
 .vf-card-label {
-  font-size: 0.8rem;
+  font-size: var(--vf-type-caps-size);
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--vf-primary);
-  margin-bottom: 1rem;
+  letter-spacing: var(--vf-type-caps-ls);
+  color: var(--vf-color-primary);
+  margin-bottom: var(--vf-space-4);
 }
+
 .vf-stat-grid {
   display: grid;
-  gap: 0.9rem;
+  gap: var(--vf-space-3);
 }
+
 .vf-stat {
   padding: 0.75rem 0.9rem;
-  border: 1px dashed var(--vf-border);
-  border-radius: 10px;
+  border: 1px dashed var(--vf-color-line);
+  border-radius: var(--vf-radius-md);
 }
+
 .vf-stat-label {
-  font-size: 0.72rem;
+  font-size: var(--vf-type-caps-size);
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--vf-text);
+  color: var(--vf-color-ink);
   opacity: 0.7;
   margin-bottom: 0.2rem;
 }
+
 .vf-stat-value {
   font-weight: 700;
-  color: var(--vf-text);
+  color: var(--vf-color-ink);
 }
+
 .vf-evidence {
-  margin-top: 1.2rem;
+  margin-top: var(--vf-space-5);
   padding: 0.85rem 1rem;
-  border-radius: 12px;
-  background: rgba(201,162,39,0.12);
-  border: 1px solid rgba(201,162,39,0.5);
+  border-radius: var(--vf-radius-lg);
+  background: rgba(212, 165, 30, 0.12);
+  border: 1px solid rgba(212, 165, 30, 0.5);
   font-weight: 600;
 }
 
 .vf-pillars {
   display: grid;
-  gap: 1rem;
-  margin-bottom: 2rem;
+  gap: var(--vf-space-4);
+  margin-bottom: var(--vf-space-8);
 }
+
 @media (min-width: 900px) {
   .vf-pillars {
     grid-template-columns: repeat(3, 1fr);
   }
 }
+
+/* Note: .vf-pill used here as the pillar tile class (not the badge pill).
+   The badge-pill component added in Phase 3 is .vf-pill--badge. */
 .vf-pill {
   padding: 1.1rem 1.2rem;
-  border-radius: 14px;
-  background: var(--vf-surface);
-  border: 1px solid var(--vf-border);
+  border-radius: var(--vf-radius-lg);
+  background: var(--vf-color-surface);
+  border: 1px solid var(--vf-color-line);
 }
+
 .vf-pill h3 {
   margin-top: 0;
 }

--- a/assets/css/visafact.css
+++ b/assets/css/visafact.css
@@ -610,3 +610,38 @@ html[data-theme="dark"] #vf-cookie-banner > div,
   color: var(--vf-color-text-secondary) !important;
   max-width: 60ch;
 }
+
+/* =========================================================
+   Phase 5 — Motion vocabulary + accessibility guard
+   ========================================================= */
+
+/* --- Transition vocabulary (no transition-all) --- */
+.vf-link-hover {
+  transition:
+    color            var(--vf-motion-fast) var(--vf-ease-standard),
+    background-color var(--vf-motion-fast) var(--vf-ease-standard);
+}
+
+.vf-button-hover {
+  transition:
+    color            var(--vf-motion-fast) var(--vf-ease-standard),
+    background-color var(--vf-motion-fast) var(--vf-ease-standard),
+    border-color     var(--vf-motion-fast) var(--vf-ease-standard),
+    box-shadow       var(--vf-motion-fast) var(--vf-ease-standard);
+}
+
+/* --- Global reduced-motion guard ---
+   Overrides PaperMod and all site animations site-wide.
+   visafact.css is loaded globally by Hugo via extend_head.html,
+   so this cascades without touching themes/PaperMod/.
+   Mirrored in ui/index.html inline <style> for the standalone UI. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration:        0.01ms !important;
+    animation-iteration-count: 1      !important;
+    transition-duration:       0.01ms !important;
+    scroll-behavior:           auto   !important;
+  }
+}

--- a/assets/css/visafact.css
+++ b/assets/css/visafact.css
@@ -508,3 +508,105 @@ html[data-theme="dark"] #vf-cookie-banner > div,
 .dark .vf-header--refined {
   background: rgba(15, 20, 25, 0.92);
 }
+
+/* =========================================================
+   Phase 4 — Home page styles
+   (clearly delimited; do not affect other pages)
+   ========================================================= */
+
+/* --- Hero layout --- */
+.vf-home-hero {
+  display: grid;
+  gap: var(--vf-space-8);
+  margin-bottom: var(--vf-space-12);
+}
+
+@media (min-width: 900px) {
+  .vf-home-hero {
+    grid-template-columns: 1fr 340px;
+    align-items: start;
+  }
+}
+
+/* --- Why section --- */
+.vf-home-why {
+  margin-bottom: var(--vf-space-10);
+}
+
+.vf-home-why h2 {
+  margin-bottom: var(--vf-space-6);
+}
+
+.vf-why-grid {
+  display: grid;
+  gap: var(--vf-space-5);
+}
+
+@media (min-width: 768px) {
+  .vf-why-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.vf-why-item {
+  display: flex;
+  gap: var(--vf-space-4);
+  padding: var(--vf-space-5) var(--vf-space-6);
+  background: var(--vf-color-surface);
+  border: 1px solid var(--vf-color-line);
+  border-radius: var(--vf-radius-lg);
+  box-shadow: var(--vf-shadow-1);
+}
+
+.vf-why-icon {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--vf-radius-md);
+  background: rgba(25, 51, 90, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--vf-color-primary);
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.vf-why-item h3 {
+  margin: 0 0 var(--vf-space-2);
+  font-size: 1.0625rem;
+}
+
+.vf-why-item p {
+  font-size: var(--vf-type-small-size);
+  color: var(--vf-color-text-secondary);
+  margin: 0;
+  max-width: none;
+}
+
+/* --- Try checker CTA panel --- */
+.vf-try-checker {
+  padding: var(--vf-space-8) var(--vf-space-6);
+  background: var(--vf-color-surface);
+  border: 1px solid var(--vf-color-line);
+  border-radius: var(--vf-radius-xl);
+  box-shadow: var(--vf-shadow-1);
+  margin-bottom: var(--vf-space-10);
+}
+
+.vf-try-checker h2 {
+  margin-top: 0;
+  margin-bottom: var(--vf-space-3);
+}
+
+.vf-try-checker > p:first-of-type {
+  color: var(--vf-color-text-secondary);
+  margin-bottom: var(--vf-space-5);
+}
+
+.vf-try-note {
+  margin-top: var(--vf-space-4) !important;
+  font-size: var(--vf-type-small-size) !important;
+  color: var(--vf-color-text-secondary) !important;
+  max-width: 60ch;
+}

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,5 +1,7 @@
 <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
 {{- $vfcss := resources.Get "css/visafact.css" | resources.Minify | fingerprint -}}
 <link rel="stylesheet" href="{{ $vfcss.RelPermalink }}" integrity="{{ $vfcss.Data.Integrity }}" crossorigin="anonymous" />
 <link rel="stylesheet" href="{{ "pagefind/pagefind-ui.css" | relURL }}" />

--- a/layouts/shortcodes/vf-home.html
+++ b/layouts/shortcodes/vf-home.html
@@ -1,58 +1,67 @@
-﻿<div class="vf-hero">
-  <div>
+{{- /* vf-home.html — home page shortcode (Phase 4 restyle)
+     Avoid banned words: best, recommend(ed), guarantee(d), 100%, approved, surely.
+     lint_content.py does not lint _index.md (not in posts/visas/guides/traps),
+     but copy is kept evidence-first for brand consistency.
+*/ -}}
+
+<div class="vf-home-hero">
+  <div class="vf-home-hero__text">
     <p class="vf-kicker">Evidence-based visa insurance compliance</p>
-    <h1>VisaFact: Digital Notary for Insurance Requirements</h1>
-    <p class="vf-lead">We translate official authority requirements into a clear compliance result, backed by sources and snapshots. No source = UNKNOWN.</p>
+    <h1>VisaFact: Evidence before opinions</h1>
+    <p class="vf-lead">We translate official authority checklists into a clear compliance status — backed by sources, locked to a snapshot date. No source = UNKNOWN, not a guess.</p>
     <div class="vf-cta-row">
-      <a class="vf-cta" href="/ui/">Open Compliance Checker</a>
-      <a class="vf-cta vf-cta-secondary" href="/methodology/">Read Methodology</a>
+      <a class="vf-cta" href="/ui/">Open compliance checker</a>
+      <a class="vf-cta vf-cta-secondary" href="/methodology/">How we evaluate</a>
     </div>
-    <div class="vf-trust">Every result links to evidence. Missing evidence is explicitly marked UNKNOWN.</div>
+    <div class="vf-trust">Every result links to the exact clause. Missing evidence is explicitly marked UNKNOWN.</div>
   </div>
-  <div class="vf-hero-card">
-    <div class="vf-card-label">Evidence Snapshot</div>
+
+  <aside class="vf-home-hero__card vf-hero-card" aria-label="Snapshot summary">
+    <div class="vf-card-label">Evidence snapshot</div>
     <div class="vf-stat-grid">
       <div class="vf-stat">
-        <div class="vf-stat-label">Sources</div>
-        <div class="vf-stat-value">Official</div>
+        <div class="vf-stat-label">Source type</div>
+        <div class="vf-stat-value">Official authority documents</div>
       </div>
       <div class="vf-stat">
-        <div class="vf-stat-label">Status Model</div>
-        <div class="vf-stat-value">GREEN / YELLOW / RED / UNKNOWN</div>
+        <div class="vf-stat-label">Result model</div>
+        <div class="vf-stat-value">GREEN / RED / UNKNOWN</div>
       </div>
       <div class="vf-stat">
-        <div class="vf-stat-label">Snapshot</div>
-        <div class="vf-stat-value">Versioned</div>
+        <div class="vf-stat-label">Verification</div>
+        <div class="vf-stat-value">Dated snapshot per result</div>
       </div>
     </div>
-    <div class="vf-evidence">No source = UNKNOWN. Evidence excerpts included.</div>
-  </div>
+    <div class="vf-evidence">No source = UNKNOWN. Evidence excerpts included per result.</div>
+  </aside>
 </div>
 
-<h2>How it works</h2>
+<section class="vf-home-why" aria-labelledby="why-heading">
+  <h2 id="why-heading">Why this is different</h2>
+  <div class="vf-why-grid">
 
-<div class="vf-pillars">
-  <div class="vf-pill">
-    <h3>Authority requirements</h3>
-    <p>We capture official rules with citations, locators, and verification dates.</p>
+    <div class="vf-why-item">
+      <div class="vf-why-icon" aria-hidden="true">&#9998;</div>
+      <div>
+        <h3>Evidence-first results</h3>
+        <p>Every status traces to a specific clause in an official authority document — page number, locator, and verified date. If the clause is absent, the status is UNKNOWN, not inferred.</p>
+      </div>
+    </div>
+
+    <div class="vf-why-item">
+      <div class="vf-why-icon" aria-hidden="true">&#128274;</div>
+      <div>
+        <h3>Snapshot-reproducible</h3>
+        <p>Results are tied to a named data snapshot. A deep link to a past result always returns the same verdict — even if requirements changed after the snapshot date.</p>
+      </div>
+    </div>
+
   </div>
-  <div class="vf-pill">
-    <h3>Product facts</h3>
-    <p>Policies are tied to versions and evidence snapshots for auditability.</p>
-  </div>
-  <div class="vf-pill">
-    <h3>Rules engine</h3>
-    <p>VisaFacts are compared to ProductFacts to produce the compliance status.</p>
-  </div>
-</div>
+</section>
 
-<h2>Start here</h2>
-
-<div class="vf-cta-row">
-  <a class="vf-cta" href="/ui/">Check a visa now</a>
-  <a class="vf-cta vf-cta-secondary" href="/posts/">Read updates</a>
-</div>
-
-<h2>Disclaimer</h2>
-
-<p>Not legal advice. Always confirm requirements with official sources.</p>
+<section class="vf-try-checker" aria-labelledby="try-heading">
+  <h2 id="try-heading">Check your insurance now</h2>
+  <p>Select a visa route and an insurance product. The engine compares product evidence against official authority requirements and returns GREEN, RED, or UNKNOWN.</p>
+  <a class="vf-cta" href="/ui/?snapshot=releases/2026-01-15">Open compliance checker</a>
+  <p class="vf-try-note">Not legal advice. Results are evidence-based, not legal determinations. Always confirm requirements with the issuing authority before submitting an application.</p>
+</section>

--- a/layouts/shortcodes/vf-home.html
+++ b/layouts/shortcodes/vf-home.html
@@ -1,5 +1,5 @@
 {{- /* vf-home.html — home page shortcode (Phase 4 restyle)
-     Avoid banned words: best, recommend(ed), guarantee(d), 100%, approved, surely.
+     Copy avoids prohibited marketing claims per tools/lint_content.py BANNED_WORDS.
      lint_content.py does not lint _index.md (not in posts/visas/guides/traps),
      but copy is kept evidence-first for brand consistency.
 */ -}}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,32 +9,53 @@ module.exports = {
     theme: {
         extend: {
             colors: {
-                "primary": "#1e3a5f",
-                "primary-hover": "#152a45",
-                "accent": "#c9a227",
-                "accent-hover": "#b8921f",
-                "background-light": "#faf8f5",
-                "background-dark": "#0f1419",
-                "surface-light": "#ffffff",
-                "surface-dark": "#1a232e",
-                "border-soft": "#e8e4df",
-                "border-dark": "#2d3748",
-                "success-green": "#059669",
-                "warning-yellow": "#d97706",
-                "error-red": "#dc2626",
-                "unknown-gray": "#6b7280",
-                "info-blue": "#0369a1",
-                "text-primary": "#1a1a1a",
-                "text-secondary": "#525252"
+                // Token-matched hex values (mirror --vf-color-* in visafact.css).
+                // Opacity modifiers (bg-accent/10 etc.) require raw hex, not CSS vars.
+                "primary":          "#19335a",   // --vf-color-primary
+                "primary-hover":    "#122645",   // --vf-color-primary-hover
+                "accent":           "#d4a51e",   // --vf-color-accent
+                "accent-hover":     "#b89118",   // --vf-color-accent-hover
+                "background-light": "#faf8f5",   // --vf-color-paper
+                "background-dark":  "#0f1419",
+                "surface-light":    "#ffffff",   // --vf-color-surface
+                "surface-dark":     "#1a232e",
+                "border-soft":      "#e8e4df",   // --vf-color-line
+                "border-dark":      "#2d3748",
+                "success-green":    "#059669",   // --vf-color-success
+                "warning-yellow":   "#d97706",   // --vf-color-warning
+                "error-red":        "#dc2626",   // --vf-color-danger
+                "unknown-gray":     "#6b7280",   // --vf-color-unknown
+                "info-blue":        "#0369a1",   // --vf-color-info
+                "text-primary":     "#151515",   // --vf-color-ink
+                "text-secondary":   "#525252",   // --vf-color-text-secondary
             },
             fontFamily: {
                 "display": ["'DM Serif Display'", "Georgia", "serif"],
-                "body": ["'Plus Jakarta Sans'", "system-ui", "sans-serif"]
+                "body":    ["'Plus Jakarta Sans'", "system-ui", "sans-serif"]
             },
             borderRadius: {
                 "DEFAULT": "0.5rem",
-                "lg": "1rem",
-                "xl": "1.5rem",
+                "lg":  "var(--vf-radius-lg, 12px)",
+                "xl":  "var(--vf-radius-xl, 16px)",
+                "2xl": "20px",
+            },
+            boxShadow: {
+                "sm":  "var(--vf-shadow-1, 0 1px 3px rgba(0,0,0,0.08))",
+                "DEFAULT": "var(--vf-shadow-1, 0 1px 3px rgba(0,0,0,0.08))",
+                "md":  "var(--vf-shadow-2, 0 4px 12px rgba(0,0,0,0.08))",
+                "lg":  "var(--vf-shadow-2, 0 4px 12px rgba(0,0,0,0.08))",
+                "xl":  "var(--vf-shadow-3, 0 8px 24px rgba(0,0,0,0.10))",
+                "2xl": "var(--vf-shadow-3, 0 8px 24px rgba(0,0,0,0.10))",
+                "none": "none",
+            },
+            transitionDuration: {
+                "fast": "120ms",
+                "base": "200ms",
+                "slow": "350ms",
+            },
+            transitionTimingFunction: {
+                "standard":   "cubic-bezier(0.2, 0.0, 0, 1)",
+                "emphasized": "cubic-bezier(0.3, 0.0, 0, 1)",
             },
         },
     },

--- a/ui/index.html
+++ b/ui/index.html
@@ -92,7 +92,7 @@
     class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-primary text-white px-4 py-2 rounded z-50">Skip to main content</a>
 
   <header
-    class="sticky top-0 z-50 w-full bg-surface-light dark:bg-[#111418] border-b border-border-soft dark:border-border-dark backdrop-blur-md bg-opacity-95 dark:bg-opacity-95">
+    class="header vf-header vf-header--refined sticky top-0 z-50 w-full">
     <div class="max-w-7xl mx-auto px-4 sm:px-6 h-16 flex items-center justify-between">
       <div class="flex items-center gap-2.5 hover:opacity-80 transition-opacity cursor-pointer">
         <span class="material-symbols-outlined text-primary text-3xl icon-filled">verified_user</span>
@@ -135,11 +135,11 @@
   </header>
 
   <main id="main-content" class="max-w-7xl mx-auto px-4 sm:px-6 py-12">
-    <div class="text-center mb-12 animate-fade-up">
+    <div class="vf-hero-section text-center mb-12 animate-fade-up">
       <h1 class="font-display text-3xl md:text-5xl font-normal tracking-tight mb-4 text-text-primary dark:text-white">
         VisaFact Compliance Checker
       </h1>
-      <div class="inline-flex items-center gap-2 px-4 py-2 bg-accent/10 border border-accent/30 rounded-full mb-4">
+      <div class="vf-pill--badge mb-4">
         <span class="material-symbols-outlined text-accent text-lg icon-filled">verified</span>
         <span class="text-sm font-semibold text-accent">Evidence-Backed Decisions</span>
       </div>
@@ -168,8 +168,7 @@
     </div>
 
     <!-- INPUT CARD -->
-    <div
-      class="max-w-4xl mx-auto bg-surface-light dark:bg-surface-dark rounded-xl border border-border-soft dark:border-border-dark p-6 md:p-10 mb-12 shadow-lg shadow-black/5 dark:shadow-black/20 hover:shadow-xl transition-shadow duration-300 animate-fade-up delay-100">
+    <div class="vf-card vf-card--elevated max-w-4xl mx-auto p-6 md:p-10 mb-12 animate-fade-up delay-100">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
@@ -179,7 +178,7 @@
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
             <select id="visaSelect"
-              class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
+              class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select visa route (authority)</option>
             </select>
             <span
@@ -196,7 +195,7 @@
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
             <select id="productSelect"
-              class="w-full pl-12 pr-10 h-14 rounded-lg border border-border-soft dark:border-border-dark bg-white dark:bg-gray-800 text-text-primary dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent outline-none transition-all appearance-none cursor-pointer text-base font-medium shadow-sm hover:border-gray-300 dark:hover:border-gray-600">
+              class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select an insurance product</option>
             </select>
             <span
@@ -247,8 +246,7 @@
           </div>
         </div>
       </div>
-      <div
-        class="bg-surface-light dark:bg-surface-dark rounded-2xl border border-border-soft dark:border-border-dark overflow-hidden shadow-xl shadow-black/5 dark:shadow-black/20">
+      <div class="vf-card vf-card--elevated overflow-hidden">
 
         <!-- Header -->
         <div
@@ -280,8 +278,7 @@
               </div>
             </div>
 
-            <div
-              class="flex flex-col gap-2 text-sm text-text-secondary dark:text-gray-400 bg-white dark:bg-gray-800/50 p-4 rounded-lg border border-border-soft dark:border-border-dark">
+            <div class="vf-meta-list">
               <div class="flex items-center gap-2">
                 <span class="material-symbols-outlined text-gray-400 text-lg">history</span>
                 <span class="font-medium">Last Verified:</span>
@@ -426,7 +423,7 @@
     <!-- Modal evidence -->
     <div id="modal" class="fixed inset-0 bg-black/40 hidden items-center justify-center p-4 z-50">
       <div
-        class="w-full max-w-3xl bg-white dark:bg-[#111418] rounded-xl border border-border-soft dark:border-border-dark shadow-lg">
+        class="vf-modal-shell">
         <div class="flex items-center justify-between p-4 border-b border-border-soft dark:border-border-dark">
           <div class="font-bold text-text-primary dark:text-white">Evidence</div>
           <button id="closeModal"

--- a/ui/index.html
+++ b/ui/index.html
@@ -81,13 +81,24 @@
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
     rel="stylesheet" />
 
-
-
+  <style>
+    /* Reduced-motion guard -- mirrors visafact.css @media block.
+       Applied here so the standalone UI respects prefers-reduced-motion
+       without relying on the Hugo-served visafact.css. */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration:        0.01ms !important;
+        animation-iteration-count: 1      !important;
+        transition-duration:       0.01ms !important;
+        scroll-behavior:           auto   !important;
+      }
+    }
+  </style>
 
 </head>
 
 <body
-  class="bg-background-light dark:bg-background-dark min-h-screen font-body text-text-primary dark:text-white transition-colors duration-200">
+  class="bg-background-light dark:bg-background-dark min-h-screen font-body text-text-primary dark:text-white">
   <a href="#main-content"
     class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-primary text-white px-4 py-2 rounded z-50">Skip to main content</a>
 


### PR DESCRIPTION
## Summary

Presentation-only visual modernization of the Hugo + Tailwind site and the standalone `ui/index.html` checker, executed in 5 phases per `.sisyphus/plans/visual-modernization.md`. No functional code, data, routes, or compliance-engine behavior changed.

- **Phase 1 — Design tokens:** single `--vf-*` custom-property layer (color/radius/elevation/spacing/type/motion); Tailwind `theme.extend` now references the tokens. Brand refined per plan default: navy `#1e3a5f→#19335a`, gold `#c9a227→#d4a51e`.
- **Phase 2 — Typography & spacing:** deliberate type scale, tabular figures on result numerics, font preconnect.
- **Phase 3 — Components:** `.vf-*` classes (pill, card, field, meta-list, modal, refined header); JS-controlled elements styled by ID-scoped selectors (no `.vf-*` on JS-overwritten nodes); stamp-badge rotation `-2deg→-0.6deg` (class name preserved).
- **Phase 4 — Home:** evidence-first hero, "why this is different" section, single CTA panel with `snapshot=` deep link.
- **Phase 5 — Motion & polish:** 3 keyframe groups consolidated to 2, `prefers-reduced-motion` guards (site-wide + standalone UI), paper-grain removed, theme-toggle color-flash removed.

## Guardrails verified (locally)
- No edits to the `themes/PaperMod` submodule, `data/`, `tools/`, `hugo.toml`, `package.json`, `postcss.config.js`.
- `ui/index.html`: ASCII-only (0 non-ASCII), 53,995 B (<100 KB), inline JS logic untouched, all tested substrings (`escapeHtml`/`sanitizeUrl`/`stamp-badge`/`status === "RED"`/`offerCta`/`data-cta-disclosure`/`vf-region-select`) preserved, 3 inline scripts parse.
- `pnpm run build:css` + `hugo --minify` build clean. `lint_content.py` passes (0 errors). No new `seo_audit` regressions (the pre-existing traps/guides failures are untouched by this branch).

## CI
- `ui-compliance` ✅ green on HEAD.
- Note: the pre-existing `seo_audit` failures on `content/traps/_index.md` + `content/guides/_index.md` block the **deploy** pipeline and are tracked separately — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)