### PR TITLE
fix(seo): unblock deploy — satisfy SEO audit on traps/guides indexes

### DIFF
--- a/content/guides/_index.md
+++ b/content/guides/_index.md
@@ -10,6 +10,7 @@ Use these guides to understand how VisaFact evaluates requirements and how to pr
 - Start with [How to Read VisaFact Results](/guides/how-to-read-results/)
 - Learn [Compliance Status Meaning](/guides/compliance-status-meaning/)
 - Use the [Compliance Checker](/ui/)
+- Browse route-specific requirements on the [visa pages](/visas/)
 
 ## What the authority requires
 

--- a/content/traps/_index.md
+++ b/content/traps/_index.md
@@ -10,6 +10,7 @@ These trap writeups highlight recurring failure patterns we observe in authority
 - Review [Spain DNV Insurance Mistakes](/traps/spain-dnv-insurance-mistakes/)
 - Review [Germany Travel Insurance Rejected](/traps/germany-travel-insurance-rejected/)
 - Run your policy through the [Compliance Checker](/ui/)
+- Cross-check the route requirements on the [visa pages](/visas/) and read how we evaluate evidence in the [methodology](/methodology/) before you submit
 
 ## What the authority requires
 


### PR DESCRIPTION
## Summary

Fixes the pre-existing `seo_audit` gate failures that block the **deploy** pipeline (`pages.yml`), unrelated to any feature work:

- `content/traps/_index.md` — was 149 words (< 150 min), missing the required `/methodology` link, and missing a `/posts/` or `/visas/` link. Added one linking sentence covering both required links (also clears the word count).
- `content/guides/_index.md` — was missing a `/posts/` or `/visas/` link. Added a `/visas/` bullet.

## Verification (local)
- `python3 tools/seo_audit.py --config tools/seo_thresholds.json` → **SEO audit passed.**
- `python3 tools/lint_content.py` → 0 errors.
- No banned words introduced; required sections and `snapshot=` deep links untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)