### PR TITLE
fix(ui): graceful fallback when a pinned snapshot is missing

### DIFF
--- a/layouts/shortcodes/vf-home.html
+++ b/layouts/shortcodes/vf-home.html
@@ -52,7 +52,7 @@
       <div class="vf-why-icon" aria-hidden="true">&#128274;</div>
       <div>
         <h3>Snapshot-reproducible</h3>
-        <p>Results are tied to a named data snapshot. A deep link to a past result always returns the same verdict — even if requirements changed after the snapshot date.</p>
+        <p>Every result is tied to a named data snapshot and links straight to the evidence behind it, so a decision can always be traced to the exact sources it was based on.</p>
       </div>
     </div>
 
@@ -62,6 +62,6 @@
 <section class="vf-try-checker" aria-labelledby="try-heading">
   <h2 id="try-heading">Check your insurance now</h2>
   <p>Select a visa route and an insurance product. The engine compares product evidence against official authority requirements and returns GREEN, RED, or UNKNOWN.</p>
-  <a class="vf-cta" href="/ui/?snapshot=releases/2026-01-15">Open compliance checker</a>
+  <a class="vf-cta" href="/ui/">Open compliance checker</a>
   <p class="vf-try-note">Not legal advice. Results are evidence-based, not legal determinations. Always confirm requirements with the issuing authority before submitting an application.</p>
 </section>

--- a/ui/index.html
+++ b/ui/index.html
@@ -1068,12 +1068,38 @@
       }
     }
 
+    function showSnapshotFallbackNotice() {
+      const main = document.querySelector("main");
+      if (!main) return;
+      const note = document.createElement("div");
+      note.className = "max-w-3xl mx-auto mb-4 px-4 py-3 rounded-lg border border-border-soft bg-surface-light dark:bg-surface-dark text-sm text-text-secondary";
+      note.setAttribute("role", "status");
+      note.textContent = 'Snapshot "' + SNAPSHOT_PARAM + '" is not available; showing the latest evidence instead.';
+      main.insertBefore(note, main.firstChild);
+    }
+
     async function init() {
       $("loadingState").classList.remove("hidden");
       try {
-        const res = await fetch(DATA_URL, { cache: "no-store" });
-        const raw = await res.json();
+        let raw;
+        let usedSnapshotFallback = false;
+        try {
+          const res = await fetch(DATA_URL, { cache: "no-store" });
+          if (!res.ok) throw new Error("snapshot fetch failed: " + res.status);
+          raw = await res.json();
+        } catch (snapErr) {
+          const latestUrl = resolveDataUrl(location.pathname, "");
+          if (SNAPSHOT_PARAM && latestUrl !== DATA_URL) {
+            const resLatest = await fetch(latestUrl, { cache: "no-store" });
+            if (!resLatest.ok) throw snapErr;
+            raw = await resLatest.json();
+            usedSnapshotFallback = true;
+          } else {
+            throw snapErr;
+          }
+        }
         INDEX = normalizeIndex(raw);
+        if (usedSnapshotFallback) showSnapshotFallbackNotice();
         initRegionSelector();
         initCookieBanner();
 


### PR DESCRIPTION
## Problem (root cause)

Deep links like `/ui/?snapshot=releases/2026-01-15` fetch `../snapshots/<id>/ui_index.json`, which **404s in production**. CI only builds/deploys the current build-time snapshot; historical snapshots are gitignored and never reach CI, while content pins older snapshot IDs (14× `releases/2026-01-15`, plus others). The checker then hard-failed with "Failed to load data" — the entire checker broke from a clickable deep link, including the home CTA.

## Fix

- **Checker resilience** (`ui/index.html`): if the snapshot-specific fetch fails, fall back to the latest `data/ui_index.json` and show a non-blocking notice ("Snapshot X is not available; showing the latest evidence instead"). The snapshot id is rendered via `textContent` (no injection). All pinned deep links work again.
- **Home CTA** (`vf-home.html`): point "Open compliance checker" at `/ui/` (latest) so the primary entry loads cleanly.
- **Wording**: soften the home "reproducible" claim to match actual behavior.

## Verification
- Browser test (local hugo server): `/ui/?snapshot=releases/2026-01-15` → snapshot 404s → checker falls back to latest, dropdowns populate, notice shown. No "Failed to load data".
- `ui_compliance_tests` pass; ASCII-only; `escapeHtml`/`sanitizeUrl` and tested substrings intact; inline scripts parse; 55 KB (<100 KB); `hugo --minify` + `lint_content` clean.

## Note (out of scope)
True snapshot reproducibility (deploying historical snapshots) remains a separate infra decision — the referenced historical snapshots don't exist to deploy. This change makes the feature degrade gracefully rather than break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)