### PR TITLE
feat(route): add Greece Digital Nomad Visa route (evidence-based)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,9 @@
 # PowerShell scripts run on Windows — keep CRLF
 *.ps1   text eol=crlf
 
+# Evidence sources are byte-exact snapshots — never normalize (sha256 is validated)
+sources/**   -text
+
 # Binary assets — never normalize
 *.png   binary
 *.jpg   binary

--- a/content/posts/greece-dnv-insurance.md
+++ b/content/posts/greece-dnv-insurance.md
@@ -1,0 +1,103 @@
+---
+title: "Greece Digital Nomad Visa insurance requirements (evidence-based)"
+date: 2026-06-08
+description: "Evidence-based summary of the insurance requirement for the Greece Digital Nomad Visa, based on the source the Hellenic MFA designates."
+tags: ["greece", "dnv", "insurance", "compliance"]
+faq:
+  - question: "Is insurance required for the Greece Digital Nomad Visa?"
+    answer: "Yes. The Work From Greece portal that the Hellenic Ministry of Foreign Affairs designates for visa information lists travel insurance among the required documents."
+  - question: "Does Greece state a coverage amount or require a Greek-authorized insurer?"
+    answer: "The designated source does not state a coverage minimum or an insurer-authorization rule, so the checker records those as UNKNOWN rather than inferring them."
+  - question: "Why do products show GREEN for this route?"
+    answer: "The snapshot encodes only the mandatory-insurance rule. Any insurance product satisfies that single rule, so it shows GREEN; stricter attributes are not modeled because the source does not state them."
+---
+
+## Short answer
+
+For the Greece Digital Nomad Visa (National Type D visa), insurance is a required document. The Hellenic Ministry of Foreign Affairs Digital Nomad Visa page does not publish a detailed checklist itself; it directs applicants to the Work From Greece portal, whose required-documents list includes travel insurance (Source: `GR_WORKFROMGREECE_DNV_2026`, locator: Required documents list; verified 2026-06-08). The checker therefore models a single rule for this route — insurance is mandatory — and leaves coverage amount and insurer authorization as UNKNOWN because the source does not state them.
+
+## Key findings at a glance
+
+| Item | Value |
+|---|---|
+| Route | Greece Digital Nomad Visa (National Type D) |
+| Authority | Hellenic Ministry of Foreign Affairs |
+| Evidence verified | 2026-06-08 |
+| Snapshot | releases/2026-01-15 |
+| Modeled rule | Insurance is mandatory |
+
+## What the authority requires
+
+- Insurance is a required document for the visa application. (Source: `GR_WORKFROMGREECE_DNV_2026`, locator: Required documents list; verified 2026-06-08)
+- The designated source lists travel insurance and does not state a coverage minimum, an insurer-authorization rule, or a deductible restriction. Those attributes are treated as UNKNOWN.
+
+Normalized requirements table:
+
+| Requirement | Source URL | Locator | Verified date |
+|---|---|---|---|
+| Insurance is mandatory | https://workfromgreece.gr/setting-up-in-greece/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one/ | Required documents list | 2026-06-08 |
+
+## Verified requirements (PASS/FAIL/UNKNOWN)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Insurance is mandatory | PASS | Work From Greece required-documents list |
+| Minimum coverage amount specified | UNKNOWN | Not stated in the designated source |
+| Insurer authorization specified | UNKNOWN | Not stated in the designated source |
+
+## How we evaluate
+
+The checker compares each modeled requirement against product evidence. For this route only the mandatory-insurance rule is encoded, because that is the only insurance condition the designated source states. If a requirement is not stated in the source, it is treated as UNKNOWN rather than inferred, which keeps the result aligned with evidence-first rules. See /methodology/ for the full logic and the UNKNOWN > Wrong principle.
+
+## Proof package checklist
+
+- A valid insurance policy or certificate covering your stay, ready to submit with the application.
+- The current required-documents list from the Work From Greece portal, so each item can be matched at submission time.
+
+## Common rejection traps
+
+- Assuming a coverage amount or insurer-authorization rule that this route's designated source does not state.
+- Submitting documentation that does not clearly evidence insurance among the required items.
+
+## FAQ
+
+**Q: Is insurance required for the Greece Digital Nomad Visa?**
+**A:** Yes. The Work From Greece portal that the Hellenic MFA designates lists travel insurance among the required documents (Source: `GR_WORKFROMGREECE_DNV_2026`, locator: Required documents list; verified 2026-06-08).
+
+**Q: Does Greece state a coverage amount or require a Greek-authorized insurer?**
+**A:** No. The designated source does not state a coverage minimum or an insurer-authorization rule, so those are recorded as UNKNOWN.
+
+**Q: Why do products show GREEN for this route?**
+**A:** The snapshot encodes only the mandatory-insurance rule, so any insurance product satisfies it. Stricter attributes are not modeled because the source does not state them.
+
+## Check in the engine
+
+Use [the compliance checker](/ui/) with the current snapshot for this route:
+
+{{< checker_cta visa="GR_DNV_MFA_2026" snapshot="releases/2026-01-15" >}}
+
+## Related reading
+
+- [Greece Digital Nomad Visa requirements (route page)](/visas/greece/digital-nomad-visa/national-visa-type-d/)
+- [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## Where to buy compliant insurance for Greece Digital Nomad Visa
+
+Compliant products for this route (those showing GREEN in the checker) will be listed here once the requirement is confirmed against a primary Hellenic authority source. The current evidence comes from the portal the MFA designates and models only that insurance is mandatory, so no product is singled out on this page yet.
+
+> Use the compliance checker to see current GREEN products for this route.
+
+*No affiliate links on this page at this time. We only link to products once their GREEN status rests on a primary authority source. See [affiliate disclosure](/affiliate-disclosure/).*
+
+## Disclaimer + Affiliate disclosure
+
+Not legal advice. Compliance results are evidence-based snapshots.
+
+If an affiliate link is present, it appears only after results and does not change the compliance outcome.
+
+Last updated: 2026-06-08
+
+## Evidence log
+
+- Source: GR_WORKFROMGREECE_DNV_2026

--- a/content/visas/greece/digital-nomad-visa/_index.md
+++ b/content/visas/greece/digital-nomad-visa/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Greece Digital Nomad Visa"
+visa_group: "greece-digital-nomad-visa"
+description: "Insurance requirements for Greece Digital Nomad Visa - evidence-based compliance checker"
+---
+
+## Greece Digital Nomad Visa Requirements
+
+All requirements below are derived from official sources. Missing evidence means UNKNOWN.
+
+## Routes
+
+| Authority | Route | Last Verified | Details |
+| --- | --- | --- | --- |
+| Hellenic Ministry of Foreign Affairs | National Visa (Type D) | 2026-06-08 | [View requirements](/visas/greece/digital-nomad-visa/national-visa-type-d/) |
+
+## What the authority requires
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+## How we evaluate
+
+We compare these official requirements against insurance product specifications using our automated rule engine. Each requirement is matched to a product fact with evidence.
+
+## Check in the engine
+
+Try the compliance checker: [Open Checker](/ui/?visa=GR_DNV_MFA_2026&snapshot=2026-06-08)
+
+## Disclaimer
+
+This is not legal advice. VisaFact provides evidence-based compliance checking only. Final visa decisions are made by government authorities. A GREEN result does not ensure visa approval.
+
+## Affiliate disclosure
+
+If affiliate links appear, they are shown only after compliance results and do not influence the compliance evaluation in any way.
+
+## Evidence log
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+
+{{< checker_cta visa="GR_DNV_MFA_2026" snapshot="2026-06-08" >}}

--- a/content/visas/greece/digital-nomad-visa/national-visa-type-d/index.md
+++ b/content/visas/greece/digital-nomad-visa/national-visa-type-d/index.md
@@ -1,0 +1,98 @@
+---
+title: "Greece Digital Nomad Visa - National Visa (Type D)"
+visa_id: "GR_DNV_MFA_2026"
+last_verified: "2026-06-08"
+source_ids: ["GR_WORKFROMGREECE_DNV_2026"]
+description: "Official insurance requirements for Greece Digital Nomad Visa via National Visa (Type D)"
+faq:
+  - question: "Is insurance required for the Greece Digital Nomad Visa?"
+    answer: "Yes. The Work From Greece portal that the Hellenic MFA designates for visa information lists travel insurance among the required documents."
+  - question: "Does Greece state a coverage amount or require a Greek-authorized insurer?"
+    answer: "The designated source does not state a coverage minimum or an insurer-authorization rule, so the engine records those as UNKNOWN rather than inferring them."
+  - question: "Is travel insurance accepted for this route?"
+    answer: "The designated required-documents list names travel insurance, so the current snapshot models only that insurance is mandatory."
+---
+
+## Greece Digital Nomad Visa
+
+**Route:** National Visa (Type D)  
+**Authority:** Hellenic Ministry of Foreign Affairs  
+**Last Verified:** 2026-06-08
+
+## Requirements
+
+| Requirement | Operator | Value | Evidence |
+| --- | --- | --- | --- |
+| `insurance.mandatory` | `==` | Yes | *Required documents list (Work From Greece, the portal the Hellenic MFA Digital Nomad Visa page designates for all relevant information)*: "Your travel insurance..." ([source](/sources/GR_WORKFROMGREECE_DNV_2026-06-08.html)) |
+
+## Source Documents
+
+- **GR_WORKFROMGREECE_DNV_2026**: [Local copy](/sources/GR_WORKFROMGREECE_DNV_2026-06-08.html) | [Original](https://workfromgreece.gr/setting-up-in-greece/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one/) | Retrieved: 2026-06-08
+
+## Related reading
+
+- [Greece Digital Nomad Visa insurance requirements](/posts/greece-dnv-insurance/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## What the authority requires
+
+The points below are taken directly from the official source for the Greece Digital Nomad Visa (National Visa (Type D)) route. Each one is recorded with a source identifier and a locator so it can be traced back to the original document. Where the source is silent on a point, the engine records UNKNOWN instead of inferring an answer.
+
+- The authority requires that insurance is mandatory.
+
+This route is defined by a small number of explicit insurance points, which keeps the evidence trail short but also unusually clear. A concise official requirement still has to be matched precisely: a product is only GREEN here when its documented terms line up with the wording above, and a route with few stated rules does not imply that any policy will be accepted. Where the authority is silent, the engine deliberately holds the status at UNKNOWN or NOT_REQUIRED rather than reading extra conditions into the source, so the page reflects exactly what the document states and nothing more. Applicants on routes like this one should still keep the underlying policy wording on hand, because a consular officer may ask to see how each stated point is met even when the published checklist is short.
+
+## How we evaluate
+
+Every requirement is compared against the documented specification of each insurance product using an automated rule engine. A product is marked GREEN for a requirement only when product evidence explicitly satisfies it; a conflict produces RED; and absent evidence produces UNKNOWN rather than a guess. The route status is the combination of its per-requirement outcomes.
+
+- Rule `insurance.mandatory == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+
+## How each compliance status is decided for this route
+
+GREEN means every recorded requirement is satisfied by product evidence. RED means at least one requirement is contradicted by the product evidence. YELLOW means the evidence is partial: some requirements are met while others lack full proof. UNKNOWN means a requirement exists but the product evidence does not address it, so no claim is made. NOT_REQUIRED means the authority does not impose an insurance requirement for the route, which is itself an evidence-based finding drawn from the official document. A GREEN result reflects the evidence on the snapshot date and is not an assurance of a visa outcome, which always rests with the issuing authority.
+
+## Reading the evidence and snapshots
+
+Each requirement above links to a primary source through a source identifier and a locator (for example a page number, article, or section). The underlying documents are listed under Source Documents and are stored alongside this dataset so the wording can be checked directly. Results are tied to a dated snapshot (`2026-06-08`): a deep link to a past snapshot returns the same verdict even if the authority later changes its rules, which keeps every decision reproducible and auditable.
+
+## Proof package checklist
+
+Before applying for this route, prepare the following so the policy can be checked against each requirement:
+
+- A policy certificate that states the coverage limits, any deductible or co-payment, and the covered period.
+- Written confirmation of the insurer's status where the route requires authorization in a specific country.
+- Documentation that the coverage spans the full authorized stay rather than a partial term.
+- The official source wording for the route, so each clause can be matched to the requirements above.
+
+## Common questions
+
+**Is insurance required for the Greece Digital Nomad Visa?**  
+Yes. The Work From Greece portal that the Hellenic MFA designates for visa information lists travel insurance among the required documents.
+
+**Does Greece state a coverage amount or require a Greek-authorized insurer?**  
+The designated source does not state a coverage minimum or an insurer-authorization rule, so the engine records those as UNKNOWN rather than inferring them.
+
+**Is travel insurance accepted for this route?**  
+The designated required-documents list names travel insurance, so the current snapshot models only that insurance is mandatory.
+
+## Check in the engine
+
+Run a specific product against this route in the compliance checker: [Open Checker](/ui/?visa=GR_DNV_MFA_2026&snapshot=2026-06-08). The checker shows the per-requirement outcome and the evidence behind each one.
+
+## Disclaimer
+
+This page is not legal advice. VisaFact provides evidence-based compliance checking only, and final visa decisions are made by government authorities. A GREEN result reflects documented evidence on the snapshot date; it does not ensure that a visa application will succeed. Always confirm the current requirements with the issuing authority before submitting an application.
+
+## Affiliate disclosure
+
+If affiliate links appear on related pages, they are shown only after the compliance result and never change the evaluation, which is generated independently from the official evidence.
+
+## Evidence log
+
+Each entry pairs a requirement with the source identifier and locator it was drawn from:
+
+- `insurance.mandatory` <- GR_WORKFROMGREECE_DNV_2026 (Required documents list (Work From Greece, the portal the Hellenic MFA Digital Nomad Visa page designates for all relevant information)): "Your travel insurance"
+
+
+{{< checker_cta visa="GR_DNV_MFA_2026" snapshot="2026-06-08" >}}

--- a/data/mappings/GR_DNV_MFA_2026__ASISA_HEALTH_RESIDENTS_2026.json
+++ b/data/mappings/GR_DNV_MFA_2026__ASISA_HEALTH_RESIDENTS_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "GR_DNV_MFA_2026",
+  "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/GR_DNV_MFA_2026__DKV_VISADO_2026.json
+++ b/data/mappings/GR_DNV_MFA_2026__DKV_VISADO_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "GR_DNV_MFA_2026",
+  "product_id": "DKV_VISADO_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/GR_DNV_MFA_2026__GENERIC_EXPAT_COMPLETE_2026.json
+++ b/data/mappings/GR_DNV_MFA_2026__GENERIC_EXPAT_COMPLETE_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "GR_DNV_MFA_2026",
+  "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/GR_DNV_MFA_2026__GENKI_TRAVELER_2026.json
+++ b/data/mappings/GR_DNV_MFA_2026__GENKI_TRAVELER_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "GR_DNV_MFA_2026",
+  "product_id": "GENKI_TRAVELER_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/GR_DNV_MFA_2026__SAFETYWING_NOMAD_2026.json
+++ b/data/mappings/GR_DNV_MFA_2026__SAFETYWING_NOMAD_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "GR_DNV_MFA_2026",
+  "product_id": "SAFETYWING_NOMAD_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/GR_DNV_MFA_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
+++ b/data/mappings/GR_DNV_MFA_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "GR_DNV_MFA_2026",
+  "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/GR_DNV_MFA_2026__WORLDNOMADS_EXPLORER_2026.json
+++ b/data/mappings/GR_DNV_MFA_2026__WORLDNOMADS_EXPLORER_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "GR_DNV_MFA_2026",
+  "product_id": "WORLDNOMADS_EXPLORER_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/ui_index.json
+++ b/data/ui_index.json
@@ -1,6 +1,6 @@
 {
-  "built_at": "2026-02-12T22:36:14.911354+00:00",
-  "snapshot_id": "2026-02-12",
+  "built_at": "2026-06-08T05:14:00.324986+00:00",
+  "snapshot_id": "2026-06-08",
   "visas": [
     {
       "id": "CR_DN_DECREE_43619_2026",
@@ -210,6 +210,37 @@
               "source_id": "BLS_ES_DNV_LONDON_2026",
               "locator": "page 2, item 9",
               "excerpt": "with no excess or co-payments, nor moratorium"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "GR_DNV_MFA_2026",
+      "country": "Greece",
+      "visa_name": "Digital Nomad Visa",
+      "route": "National Visa (Type D)",
+      "authority": "Hellenic Ministry of Foreign Affairs",
+      "last_verified": "2026-06-08",
+      "sources": [
+        {
+          "source_id": "GR_WORKFROMGREECE_DNV_2026",
+          "url": "https://workfromgreece.gr/setting-up-in-greece/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one/",
+          "retrieved_at": "2026-06-08T00:00:00Z",
+          "sha256": "4264aae1c635faa665fb3afc374c535890890ed84cbaf2517ac1831f5682d1ea",
+          "local_path": "sources/GR_WORKFROMGREECE_DNV_2026-06-08.html"
+        }
+      ],
+      "requirements": [
+        {
+          "key": "insurance.mandatory",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "GR_WORKFROMGREECE_DNV_2026",
+              "locator": "Required documents list (Work From Greece, the portal the Hellenic MFA Digital Nomad Visa page designates for all relevant information)",
+              "excerpt": "Your travel insurance"
             }
           ]
         }
@@ -963,6 +994,62 @@
       "last_verified": "2026-01-15"
     },
     {
+      "visa_id": "GR_DNV_MFA_2026",
+      "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "GR_DNV_MFA_2026",
+      "product_id": "DKV_VISADO_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "GR_DNV_MFA_2026",
+      "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "GR_DNV_MFA_2026",
+      "product_id": "GENKI_TRAVELER_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "GR_DNV_MFA_2026",
+      "product_id": "SAFETYWING_NOMAD_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "GR_DNV_MFA_2026",
+      "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "GR_DNV_MFA_2026",
+      "product_id": "WORLDNOMADS_EXPLORER_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
       "visa_id": "MT_NOMAD_RESIDENCY_2026",
       "product_id": "ASISA_HEALTH_RESIDENTS_2026",
       "status": "UNKNOWN",
@@ -1383,6 +1470,13 @@
       "retrieved_at": "2026-01-15T00:00:00Z",
       "sha256": "8160cdbe0996621dc0091be0e858b56fb956df38cf51e3b943d905f38d2d98fa",
       "local_path": "sources/GENKI_TRAVELER_COVERAGE_2026-01-15.html"
+    },
+    "GR_WORKFROMGREECE_DNV_2026": {
+      "source_id": "GR_WORKFROMGREECE_DNV_2026",
+      "url": "https://workfromgreece.gr/setting-up-in-greece/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one/",
+      "retrieved_at": "2026-06-08T00:00:00Z",
+      "sha256": "4264aae1c635faa665fb3afc374c535890890ed84cbaf2517ac1831f5682d1ea",
+      "local_path": "sources/GR_WORKFROMGREECE_DNV_2026-06-08.html"
     },
     "MT_RESIDENCY_FAQ_2026": {
       "source_id": "MT_RESIDENCY_FAQ_2026",

--- a/data/visas/GR/DNV/mfa/2026-06-08/visa_facts.json
+++ b/data/visas/GR/DNV/mfa/2026-06-08/visa_facts.json
@@ -1,0 +1,31 @@
+{
+  "id": "GR_DNV_MFA_2026",
+  "country": "Greece",
+  "visa_name": "Digital Nomad Visa",
+  "route": "National Visa (Type D)",
+  "authority": "Hellenic Ministry of Foreign Affairs",
+  "last_verified": "2026-06-08",
+  "sources": [
+    {
+      "source_id": "GR_WORKFROMGREECE_DNV_2026",
+      "url": "https://workfromgreece.gr/setting-up-in-greece/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one/",
+      "retrieved_at": "2026-06-08T00:00:00Z",
+      "sha256": "4264aae1c635faa665fb3afc374c535890890ed84cbaf2517ac1831f5682d1ea",
+      "local_path": "sources/GR_WORKFROMGREECE_DNV_2026-06-08.html"
+    }
+  ],
+  "requirements": [
+    {
+      "key": "insurance.mandatory",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "GR_WORKFROMGREECE_DNV_2026",
+          "locator": "Required documents list (Work From Greece, the portal the Hellenic MFA Digital Nomad Visa page designates for all relevant information)",
+          "excerpt": "Your travel insurance"
+        }
+      ]
+    }
+  ]
+}

--- a/sources/GR_WORKFROMGREECE_DNV_2026-06-08.html
+++ b/sources/GR_WORKFROMGREECE_DNV_2026-06-08.html
@@ -1,0 +1,2046 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="profile" href="https://gmpg.org/xfn/11"> 
+	<meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+<!-- Google Tag Manager --> <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-PVJD4J5');</script> <!-- End Google Tag Manager -->		<link rel="apple-touch-icon" sizes="180x180" href="https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/favicon/apple-touch-icon.png">
+		<link rel="icon" type="image/png" sizes="32x32" href="https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/favicon/favicon-32x32.png">
+		<link rel="icon" type="image/png" sizes="16x16" href="https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/favicon/favicon-16x16.png">
+				<script>
+		(function(){
+			window.ecsSchemeConfig={systemAuto:false};
+			var m=document.cookie.match(/(?:^|;\s*)ecs_color_scheme=([^;]+)/);
+			if(m&&m[1]==='alt'){
+				document.documentElement.setAttribute('data-ecs-scheme','alt');
+			}else if(!m&&false){
+				if(window.matchMedia&&window.matchMedia('(prefers-color-scheme:dark)').matches){
+					document.documentElement.setAttribute('data-ecs-scheme','alt');
+				}
+			}
+		})();
+		</script>
+		
+	<!-- This site is optimized with the Yoast SEO plugin v27.6 - https://yoast.com/product/yoast-seo-wordpress/ -->
+	<title>How to get a Digital Nomad Visa for Greece | Work From Greece</title>
+	<meta name="description" content="All your questions answered about how to apply for a Digital Nomad Visa for Greece (Who is eligible, how to apply, how much it costs and how long you can stay in Greece)" />
+	<link rel="canonical" href="https://workfromgreece.gr/setting-up-in-greece/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one/" />
+	<meta property="og:locale" content="en_US" />
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content="How to get a Digital Nomad Visa for Greece" />
+	<meta property="og:description" content="All your questions answered about how to apply for a Digital Nomad Visa for Greece (Who is eligible, how to apply, how much it costs and how long you can stay in Greece)" />
+	<meta property="og:url" content="https://workfromgreece.gr/setting-up-in-greece/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one/" />
+	<meta property="og:site_name" content="Digital Nomads" />
+	<meta property="article:publisher" content="https://www.facebook.com/WorkFromGR" />
+	<meta property="article:author" content="https://www.facebook.com/WorkFromGR/" />
+	<meta property="article:published_time" content="2023-05-25T14:04:20+00:00" />
+	<meta property="article:modified_time" content="2026-04-21T15:14:20+00:00" />
+	<meta property="og:image" content="https://workfromgreece.gr/wp-content/uploads/2023/05/How-to-get-a-Digital-Nomad-Visa-for-Greece.jpg" />
+	<meta property="og:image:width" content="1920" />
+	<meta property="og:image:height" content="1080" />
+	<meta property="og:image:type" content="image/jpeg" />
+	<meta name="author" content="Work From Greece Team" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content="How to get a Digital Nomad Visa for Greece" />
+	<meta name="twitter:description" content="All your questions answered about how to apply for a Digital Nomad Visa for Greece (Who is eligible, how to apply, how much it costs and how long you can stay in Greece)" />
+	<meta name="twitter:image" content="https://workfromgreece.gr/wp-content/uploads/2023/05/How-to-get-a-Digital-Nomad-Visa-for-Greece.jpg" />
+	<meta name="twitter:creator" content="@workfrom_Greece" />
+	<meta name="twitter:site" content="@workfrom_Greece" />
+	<meta name="twitter:label1" content="Written by" />
+	<meta name="twitter:data1" content="Work From Greece Team" />
+	<meta name="twitter:label2" content="Est. reading time" />
+	<meta name="twitter:data2" content="7 minutes" />
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https:\/\/schema.org","@graph":[{"@type":["Article","BlogPosting"],"@id":"https:\/\/workfromgreece.gr\/setting-up-in-greece\/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one\/#article","isPartOf":{"@id":"https:\/\/workfromgreece.gr\/setting-up-in-greece\/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one\/"},"author":{"name":"Work From Greece Team","@id":"https:\/\/workfromgreece.gr\/#\/schema\/person\/9261ad73db3ee1e4c7faa79c852adc55"},"headline":"The Digital Nomad Visa for Greece: Who is eligible and how to get one","datePublished":"2023-05-25T14:04:20+00:00","dateModified":"2026-04-21T15:14:20+00:00","mainEntityOfPage":{"@id":"https:\/\/workfromgreece.gr\/setting-up-in-greece\/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one\/"},"wordCount":1242,"publisher":{"@id":"https:\/\/workfromgreece.gr\/#organization"},"image":{"@id":"https:\/\/workfromgreece.gr\/setting-up-in-greece\/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one\/#primaryimage"},"thumbnailUrl":"https:\/\/workfromgreece.gr\/wp-content\/uploads\/2023\/05\/How-to-get-a-Digital-Nomad-Visa-for-Greece.jpg","keywords":["Travel Tips","visa"],"articleSection":["Setting Up in Greece"],"inLanguage":"en-US"},{"@type":"WebPage","@id":"https:\/\/workfromgreece.gr\/setting-up-in-greece\/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one\/","url":"https:\/\/workfromgreece.gr\/setting-up-in-greece\/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one\/","name":"How to get a Digital Nomad Visa for Greece | Work From Greece","isPartOf":{"@id":"https:\/\/workfromgreece.gr\/#website"},"primaryImageOfPage":{"@id":"https:\/\/workfromgreece.gr\/setting-up-in-greece\/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one\/#primaryimage"},"image":{"@id":"https:\/\/workfromgreece.gr\/setting-up-in-greece\/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one\/#primaryimage"},"thumbnailUrl":"https:\/\/workfromgreece.gr\/wp-content\/uploads\/2023\/05\/How-to-get-a-Digital-Nomad-Visa-for-Greece.jpg","datePublished":"2023-05-25T14:04:20+00:00","dateModified":"2026-04-21T15:14:20+00:00","description":"All your questions answered about how to apply for a Digital Nomad Visa for Greece (Who is eligible, how to apply, how much it costs and how long you can stay in Greece)","breadcrumb":{"@id":"https:\/\/workfromgreece.gr\/setting-up-in-greece\/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one\/#breadcrumb"},"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["https:\/\/workfromgreece.gr\/setting-up-in-greece\/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one\/"]}]},{"@type":"ImageObject","inLanguage":"en-US","@id":"https:\/\/workfromgreece.gr\/setting-up-in-greece\/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one\/#primaryimage","url":"https:\/\/workfromgreece.gr\/wp-content\/uploads\/2023\/05\/How-to-get-a-Digital-Nomad-Visa-for-Greece.jpg","contentUrl":"https:\/\/workfromgreece.gr\/wp-content\/uploads\/2023\/05\/How-to-get-a-Digital-Nomad-Visa-for-Greece.jpg","width":1920,"height":1080},{"@type":"BreadcrumbList","@id":"https:\/\/workfromgreece.gr\/setting-up-in-greece\/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one\/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Home","item":"https:\/\/workfromgreece.gr\/"},{"@type":"ListItem","position":2,"name":"Blog","item":"https:\/\/workfromgreece.gr\/blog\/"},{"@type":"ListItem","position":3,"name":"Setting Up in Greece","item":"https:\/\/workfromgreece.gr\/.\/setting-up-in-greece\/"},{"@type":"ListItem","position":4,"name":"The Digital Nomad Visa for Greece: Who is eligible and how to get one"}]},{"@type":"WebSite","@id":"https:\/\/workfromgreece.gr\/#website","url":"https:\/\/workfromgreece.gr\/","name":"Work From Greece","description":"Become a Digital Nomad in Greece!","publisher":{"@id":"https:\/\/workfromgreece.gr\/#organization"},"potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https:\/\/workfromgreece.gr\/?s={search_term_string}"},"query-input":{"@type":"PropertyValueSpecification","valueRequired":true,"valueName":"search_term_string"}}],"inLanguage":"en-US"},{"@type":"Organization","@id":"https:\/\/workfromgreece.gr\/#organization","name":"Work From Greece","url":"https:\/\/workfromgreece.gr\/","logo":{"@type":"ImageObject","inLanguage":"en-US","@id":"https:\/\/workfromgreece.gr\/#\/schema\/logo\/image\/","url":"https:\/\/workfromgreece.gr\/wp-content\/uploads\/2021\/11\/WORKFROMGREECE_SoMe_Logos-01.jpg","contentUrl":"https:\/\/workfromgreece.gr\/wp-content\/uploads\/2021\/11\/WORKFROMGREECE_SoMe_Logos-01.jpg","width":1200,"height":1200,"caption":"Work From Greece"},"image":{"@id":"https:\/\/workfromgreece.gr\/#\/schema\/logo\/image\/"},"sameAs":["https:\/\/www.facebook.com\/WorkFromGR","https:\/\/x.com\/workfrom_Greece","https:\/\/www.instagram.com\/workfromgreece_\/","https:\/\/www.linkedin.com\/company\/workfromgreece\/","https:\/\/www.tiktok.com\/@workfromgreece"]},{"@type":"Person","@id":"https:\/\/workfromgreece.gr\/#\/schema\/person\/9261ad73db3ee1e4c7faa79c852adc55","name":"Work From Greece Team","image":{"@type":"ImageObject","inLanguage":"en-US","@id":"https:\/\/workfromgreece.gr\/wp-content\/uploads\/2025\/06\/WFG-logo-150x150.jpg","url":"https:\/\/workfromgreece.gr\/wp-content\/uploads\/2025\/06\/WFG-logo-150x150.jpg","contentUrl":"https:\/\/workfromgreece.gr\/wp-content\/uploads\/2025\/06\/WFG-logo-150x150.jpg","caption":"Work From Greece Team"},"description":"Your one-stop-shop for Digital Nomads looking to live and work in Greece","sameAs":["https:\/\/www.facebook.com\/WorkFromGR\/","https:\/\/www.instagram.com\/workfromgreece_\/?hl=en"],"url":"https:\/\/workfromgreece.gr\/author\/work-from-greece-team\/"}]}</script>
+	<!-- / Yoast SEO plugin. -->
+
+
+<link rel='dns-prefetch' href='//cdn.jsdelivr.net' />
+<link rel='dns-prefetch' href='//code.jquery.com' />
+<link rel='dns-prefetch' href='//fonts.googleapis.com' />
+<link rel="alternate" type="application/rss+xml" title="Digital Nomads &raquo; Feed" href="https://workfromgreece.gr/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Digital Nomads &raquo; Comments Feed" href="https://workfromgreece.gr/comments/feed/" />
+<link rel="alternate" type="text/calendar" title="Digital Nomads &raquo; iCal Feed" href="https://workfromgreece.gr/events/?ical=1" />
+<link rel="alternate" title="oEmbed (JSON)" type="application/json+oembed" href="https://workfromgreece.gr/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fworkfromgreece.gr%2Fsetting-up-in-greece%2Fthe-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one%2F" />
+<link rel="alternate" title="oEmbed (XML)" type="text/xml+oembed" href="https://workfromgreece.gr/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fworkfromgreece.gr%2Fsetting-up-in-greece%2Fthe-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one%2F&#038;format=xml" />
+<style id="wp-img-auto-sizes-contain-inline-css">
+img:is([sizes=auto i],[sizes^="auto," i]){contain-intrinsic-size:3000px 1500px}
+/*# sourceURL=wp-img-auto-sizes-contain-inline-css */
+</style>
+<link rel='stylesheet' id='astra-theme-css-css' href='https://workfromgreece.gr/wp-content/themes/astra/assets/css/minified/style.min.css?ver=4.12.0' media='all' />
+<style id="astra-theme-css-inline-css">
+.ast-no-sidebar .entry-content .alignfull {margin-left: calc( -50vw + 50%);margin-right: calc( -50vw + 50%);max-width: 100vw;width: 100vw;}.ast-no-sidebar .entry-content .alignwide {margin-left: calc(-41vw + 50%);margin-right: calc(-41vw + 50%);max-width: unset;width: unset;}.ast-no-sidebar .entry-content .alignfull .alignfull,.ast-no-sidebar .entry-content .alignfull .alignwide,.ast-no-sidebar .entry-content .alignwide .alignfull,.ast-no-sidebar .entry-content .alignwide .alignwide,.ast-no-sidebar .entry-content .wp-block-column .alignfull,.ast-no-sidebar .entry-content .wp-block-column .alignwide{width: 100%;margin-left: auto;margin-right: auto;}.wp-block-gallery,.blocks-gallery-grid {margin: 0;}.wp-block-separator {max-width: 100px;}.wp-block-separator.is-style-wide,.wp-block-separator.is-style-dots {max-width: none;}.entry-content .has-2-columns .wp-block-column:first-child {padding-right: 10px;}.entry-content .has-2-columns .wp-block-column:last-child {padding-left: 10px;}@media (max-width: 782px) {.entry-content .wp-block-columns .wp-block-column {flex-basis: 100%;}.entry-content .has-2-columns .wp-block-column:first-child {padding-right: 0;}.entry-content .has-2-columns .wp-block-column:last-child {padding-left: 0;}}body .entry-content .wp-block-latest-posts {margin-left: 0;}body .entry-content .wp-block-latest-posts li {list-style: none;}.ast-no-sidebar .ast-container .entry-content .wp-block-latest-posts {margin-left: 0;}.ast-header-break-point .entry-content .alignwide {margin-left: auto;margin-right: auto;}.entry-content .blocks-gallery-item img {margin-bottom: auto;}.wp-block-pullquote {border-top: 4px solid #555d66;border-bottom: 4px solid #555d66;color: #40464d;}:root{--ast-post-nav-space:0;--ast-container-default-xlg-padding:6.67em;--ast-container-default-lg-padding:5.67em;--ast-container-default-slg-padding:4.34em;--ast-container-default-md-padding:3.34em;--ast-container-default-sm-padding:6.67em;--ast-container-default-xs-padding:2.4em;--ast-container-default-xxs-padding:1.4em;--ast-code-block-background:#EEEEEE;--ast-comment-inputs-background:#FAFAFA;--ast-normal-container-width:1200px;--ast-narrow-container-width:750px;--ast-blog-title-font-weight:normal;--ast-blog-meta-weight:inherit;--ast-global-color-primary:var(--ast-global-color-5);--ast-global-color-secondary:var(--ast-global-color-4);--ast-global-color-alternate-background:var(--ast-global-color-7);--ast-global-color-subtle-background:var(--ast-global-color-6);--ast-bg-style-guide:var( --ast-global-color-secondary,--ast-global-color-5 );--ast-shadow-style-guide:0px 0px 4px 0 #00000057;--ast-global-dark-bg-style:#fff;--ast-global-dark-lfs:#fbfbfb;--ast-widget-bg-color:#fafafa;--ast-wc-container-head-bg-color:#fbfbfb;--ast-title-layout-bg:#eeeeee;--ast-search-border-color:#e7e7e7;--ast-lifter-hover-bg:#e6e6e6;--ast-gallery-block-color:#000;--srfm-color-input-label:var(--ast-global-color-2);}html{font-size:93.75%;}a,.page-title{color:var(--ast-global-color-0);}a:hover,a:focus{color:var(--ast-global-color-1);}body,button,input,select,textarea,.ast-button,.ast-custom-button{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen-Sans,Ubuntu,Cantarell,Helvetica Neue,sans-serif;font-weight:inherit;font-size:15px;font-size:1rem;line-height:var(--ast-body-line-height,1.65em);}blockquote{color:var(--ast-global-color-3);}.ast-site-identity .site-title a{color:var(--ast-global-color-2);}.site-title{font-size:35px;font-size:2.3333333333333rem;display:none;}.site-header .site-description{font-size:15px;font-size:1rem;display:none;}.entry-title{font-size:26px;font-size:1.7333333333333rem;}.archive .ast-article-post .ast-article-inner,.blog .ast-article-post .ast-article-inner,.archive .ast-article-post .ast-article-inner:hover,.blog .ast-article-post .ast-article-inner:hover{overflow:hidden;}h1,.entry-content :where(h1){font-size:40px;font-size:2.6666666666667rem;line-height:1.4em;}h2,.entry-content :where(h2){font-size:32px;font-size:2.1333333333333rem;line-height:1.3em;}h3,.entry-content :where(h3){font-size:26px;font-size:1.7333333333333rem;line-height:1.3em;}h4,.entry-content :where(h4){font-size:24px;font-size:1.6rem;line-height:1.2em;}h5,.entry-content :where(h5){font-size:20px;font-size:1.3333333333333rem;line-height:1.2em;}h6,.entry-content :where(h6){font-size:16px;font-size:1.0666666666667rem;line-height:1.25em;}::selection{background-color:var(--ast-global-color-0);color:#ffffff;}body,h1,h2,h3,h4,h5,h6,.entry-title a,.entry-content :where(h1,h2,h3,h4,h5,h6){color:var(--ast-global-color-3);}.tagcloud a:hover,.tagcloud a:focus,.tagcloud a.current-item{color:#ffffff;border-color:var(--ast-global-color-0);background-color:var(--ast-global-color-0);}input:focus,input[type="text"]:focus,input[type="email"]:focus,input[type="url"]:focus,input[type="password"]:focus,input[type="reset"]:focus,input[type="search"]:focus,textarea:focus{border-color:var(--ast-global-color-0);}input[type="radio"]:checked,input[type=reset],input[type="checkbox"]:checked,input[type="checkbox"]:hover:checked,input[type="checkbox"]:focus:checked,input[type=range]::-webkit-slider-thumb{border-color:var(--ast-global-color-0);background-color:var(--ast-global-color-0);box-shadow:none;}.site-footer a:hover + .post-count,.site-footer a:focus + .post-count{background:var(--ast-global-color-0);border-color:var(--ast-global-color-0);}.single .nav-links .nav-previous,.single .nav-links .nav-next{color:var(--ast-global-color-0);}.entry-meta,.entry-meta *{line-height:1.45;color:var(--ast-global-color-0);}.entry-meta a:not(.ast-button):hover,.entry-meta a:not(.ast-button):hover *,.entry-meta a:not(.ast-button):focus,.entry-meta a:not(.ast-button):focus *,.page-links > .page-link,.page-links .page-link:hover,.post-navigation a:hover{color:var(--ast-global-color-1);}#cat option,.secondary .calendar_wrap thead a,.secondary .calendar_wrap thead a:visited{color:var(--ast-global-color-0);}.secondary .calendar_wrap #today,.ast-progress-val span{background:var(--ast-global-color-0);}.secondary a:hover + .post-count,.secondary a:focus + .post-count{background:var(--ast-global-color-0);border-color:var(--ast-global-color-0);}.calendar_wrap #today > a{color:#ffffff;}.page-links .page-link,.single .post-navigation a{color:var(--ast-global-color-0);}.ast-search-menu-icon .search-form button.search-submit{padding:0 4px;}.ast-search-menu-icon form.search-form{padding-right:0;}.ast-header-search .ast-search-menu-icon.ast-dropdown-active .search-form,.ast-header-search .ast-search-menu-icon.ast-dropdown-active .search-field:focus{transition:all 0.2s;}.search-form input.search-field:focus{outline:none;}.widget-title,.widget .wp-block-heading{font-size:21px;font-size:1.4rem;color:var(--ast-global-color-3);}.ast-search-menu-icon.slide-search a:focus-visible:focus-visible,.astra-search-icon:focus-visible,#close:focus-visible,a:focus-visible,.ast-menu-toggle:focus-visible,.site .skip-link:focus-visible,.wp-block-loginout input:focus-visible,.wp-block-search.wp-block-search__button-inside .wp-block-search__inside-wrapper,.ast-header-navigation-arrow:focus-visible,.ast-orders-table__row .ast-orders-table__cell:focus-visible,a#ast-apply-coupon:focus-visible,#ast-apply-coupon:focus-visible,#close:focus-visible,.button.search-submit:focus-visible,#search_submit:focus,.normal-search:focus-visible,.ast-header-account-wrap:focus-visible,.astra-cart-drawer-close:focus,.ast-single-variation:focus,.ast-button:focus,.ast-builder-button-wrap:has(.ast-custom-button-link:focus),.ast-builder-button-wrap .ast-custom-button-link:focus{outline-style:dotted;outline-color:inherit;outline-width:thin;}input:focus,input[type="text"]:focus,input[type="email"]:focus,input[type="url"]:focus,input[type="password"]:focus,input[type="reset"]:focus,input[type="search"]:focus,input[type="number"]:focus,textarea:focus,.wp-block-search__input:focus,[data-section="section-header-mobile-trigger"] .ast-button-wrap .ast-mobile-menu-trigger-minimal:focus,.ast-mobile-popup-drawer.active .menu-toggle-close:focus,#ast-scroll-top:focus,#coupon_code:focus,#ast-coupon-code:focus{border-style:dotted;border-color:inherit;border-width:thin;}input{outline:none;}.main-header-menu .menu-link,.ast-header-custom-item a{color:var(--ast-global-color-3);}.main-header-menu .menu-item:hover > .menu-link,.main-header-menu .menu-item:hover > .ast-menu-toggle,.main-header-menu .ast-masthead-custom-menu-items a:hover,.main-header-menu .menu-item.focus > .menu-link,.main-header-menu .menu-item.focus > .ast-menu-toggle,.main-header-menu .current-menu-item > .menu-link,.main-header-menu .current-menu-ancestor > .menu-link,.main-header-menu .current-menu-item > .ast-menu-toggle,.main-header-menu .current-menu-ancestor > .ast-menu-toggle{color:var(--ast-global-color-0);}.header-main-layout-3 .ast-main-header-bar-alignment{margin-right:auto;}.header-main-layout-2 .site-header-section-left .ast-site-identity{text-align:left;}.ast-logo-title-inline .site-logo-img{padding-right:1em;}.site-logo-img img{ transition:all 0.2s linear;}body .ast-oembed-container *{position:absolute;top:0;width:100%;height:100%;left:0;}body .wp-block-embed-pocket-casts .ast-oembed-container *{position:unset;}.ast-header-break-point .ast-mobile-menu-buttons-minimal.menu-toggle{background:transparent;color:var(--ast-global-color-0);}.ast-header-break-point .ast-mobile-menu-buttons-outline.menu-toggle{background:transparent;border:1px solid var(--ast-global-color-0);color:var(--ast-global-color-0);}.ast-header-break-point .ast-mobile-menu-buttons-fill.menu-toggle{background:var(--ast-global-color-0);}.ast-single-post-featured-section + article {margin-top: 2em;}.site-content .ast-single-post-featured-section img {width: 100%;overflow: hidden;object-fit: cover;}.site > .ast-single-related-posts-container {margin-top: 0;}@media (min-width: 769px) {.ast-desktop .ast-container--narrow {max-width: var(--ast-narrow-container-width);margin: 0 auto;}}.ast-page-builder-template .hentry {margin: 0;}.ast-page-builder-template .site-content > .ast-container {max-width: 100%;padding: 0;}.ast-page-builder-template .site .site-content #primary {padding: 0;margin: 0;}.ast-page-builder-template .no-results {text-align: center;margin: 4em auto;}.ast-page-builder-template .ast-pagination {padding: 2em;}.ast-page-builder-template .entry-header.ast-no-title.ast-no-thumbnail {margin-top: 0;}.ast-page-builder-template .entry-header.ast-header-without-markup {margin-top: 0;margin-bottom: 0;}.ast-page-builder-template .entry-header.ast-no-title.ast-no-meta {margin-bottom: 0;}.ast-page-builder-template.single .post-navigation {padding-bottom: 2em;}.ast-page-builder-template.single-post .site-content > .ast-container {max-width: 100%;}.ast-page-builder-template .entry-header {margin-top: 4em;margin-left: auto;margin-right: auto;padding-left: 20px;padding-right: 20px;}.single.ast-page-builder-template .entry-header {padding-left: 20px;padding-right: 20px;}.ast-page-builder-template .ast-archive-description {margin: 4em auto 0;padding-left: 20px;padding-right: 20px;}.ast-page-builder-template.ast-no-sidebar .entry-content .alignwide {margin-left: 0;margin-right: 0;}.footer-adv .footer-adv-overlay{border-top-style:solid;border-top-color:#7a7a7a;}@media( max-width: 420px ) {.single .nav-links .nav-previous,.single .nav-links .nav-next {width: 100%;text-align: center;}}.wp-block-buttons.aligncenter{justify-content:center;}@media (max-width:782px){.entry-content .wp-block-columns .wp-block-column{margin-left:0px;}}.wp-block-image.aligncenter{margin-left:auto;margin-right:auto;}.wp-block-table.aligncenter{margin-left:auto;margin-right:auto;}.wp-block-buttons .wp-block-button.is-style-outline .wp-block-button__link.wp-element-button,.ast-outline-button,.wp-block-uagb-buttons-child .uagb-buttons-repeater.ast-outline-button{border-top-width:2px;border-right-width:2px;border-bottom-width:2px;border-left-width:2px;font-family:inherit;font-weight:inherit;line-height:1em;}.wp-block-button .wp-block-button__link.wp-element-button.is-style-outline:not(.has-background),.wp-block-button.is-style-outline>.wp-block-button__link.wp-element-button:not(.has-background),.ast-outline-button{background-color:transparent;}.entry-content[data-ast-blocks-layout] > figure{margin-bottom:1em;}.elementor-widget-container .elementor-loop-container .e-loop-item[data-elementor-type="loop-item"]{width:100%;}@media (max-width:768px){.ast-left-sidebar #content > .ast-container{display:flex;flex-direction:column-reverse;width:100%;}.ast-separate-container .ast-article-post,.ast-separate-container .ast-article-single{padding:1.5em 2.14em;}.ast-author-box img.avatar{margin:20px 0 0 0;}}@media (min-width:769px){.ast-separate-container.ast-right-sidebar #primary,.ast-separate-container.ast-left-sidebar #primary{border:0;}.search-no-results.ast-separate-container #primary{margin-bottom:4em;}}.menu-toggle,button,.ast-button,.ast-custom-button,.button,input#submit,input[type="button"],input[type="submit"],input[type="reset"]{color:#ffffff;border-color:var(--ast-global-color-0);background-color:var(--ast-global-color-0);padding-top:10px;padding-right:40px;padding-bottom:10px;padding-left:40px;font-family:inherit;font-weight:inherit;}button:focus,.menu-toggle:hover,button:hover,.ast-button:hover,.ast-custom-button:hover .button:hover,.ast-custom-button:hover,input[type=reset]:hover,input[type=reset]:focus,input#submit:hover,input#submit:focus,input[type="button"]:hover,input[type="button"]:focus,input[type="submit"]:hover,input[type="submit"]:focus{color:#ffffff;background-color:var(--ast-global-color-1);border-color:var(--ast-global-color-1);}@media (max-width:768px){.ast-mobile-header-stack .main-header-bar .ast-search-menu-icon{display:inline-block;}.ast-header-break-point.ast-header-custom-item-outside .ast-mobile-header-stack .main-header-bar .ast-search-icon{margin:0;}.ast-comment-avatar-wrap img{max-width:2.5em;}.ast-comment-meta{padding:0 1.8888em 1.3333em;}.ast-separate-container .ast-comment-list li.depth-1{padding:1.5em 2.14em;}.ast-separate-container .comment-respond{padding:2em 2.14em;}}@media (min-width:544px){.ast-container{max-width:100%;}}@media (max-width:544px){.ast-separate-container .ast-article-post,.ast-separate-container .ast-article-single,.ast-separate-container .comments-title,.ast-separate-container .ast-archive-description{padding:1.5em 1em;}.ast-separate-container #content .ast-container{padding-left:0.54em;padding-right:0.54em;}.ast-separate-container .ast-comment-list .bypostauthor{padding:.5em;}.ast-search-menu-icon.ast-dropdown-active .search-field{width:170px;}.site-branding img,.site-header .site-logo-img .custom-logo-link img{max-width:100%;}} #ast-mobile-header .ast-site-header-cart-li a{pointer-events:none;}.ast-no-sidebar.ast-separate-container .entry-content .alignfull {margin-left: -6.67em;margin-right: -6.67em;width: auto;}@media (max-width: 1200px) {.ast-no-sidebar.ast-separate-container .entry-content .alignfull {margin-left: -2.4em;margin-right: -2.4em;}}@media (max-width: 768px) {.ast-no-sidebar.ast-separate-container .entry-content .alignfull {margin-left: -2.14em;margin-right: -2.14em;}}@media (max-width: 544px) {.ast-no-sidebar.ast-separate-container .entry-content .alignfull {margin-left: -1em;margin-right: -1em;}}.ast-no-sidebar.ast-separate-container .entry-content .alignwide {margin-left: -20px;margin-right: -20px;}.ast-no-sidebar.ast-separate-container .entry-content .wp-block-column .alignfull,.ast-no-sidebar.ast-separate-container .entry-content .wp-block-column .alignwide {margin-left: auto;margin-right: auto;width: 100%;}@media (max-width:768px){.site-title{display:none;}.site-header .site-description{display:none;}h1,.entry-content :where(h1){font-size:30px;}h2,.entry-content :where(h2){font-size:25px;}h3,.entry-content :where(h3){font-size:20px;}}@media (max-width:544px){.site-title{display:none;}.site-header .site-description{display:none;}h1,.entry-content :where(h1){font-size:30px;}h2,.entry-content :where(h2){font-size:25px;}h3,.entry-content :where(h3){font-size:20px;}}@media (max-width:768px){html{font-size:85.5%;}}@media (max-width:544px){html{font-size:85.5%;}}@media (min-width:769px){.ast-container{max-width:1240px;}}@font-face {font-family: "Astra";src: url(https://workfromgreece.gr/wp-content/themes/astra/assets/fonts/astra.woff) format("woff"),url(https://workfromgreece.gr/wp-content/themes/astra/assets/fonts/astra.ttf) format("truetype"),url(https://workfromgreece.gr/wp-content/themes/astra/assets/fonts/astra.svg#astra) format("svg");font-weight: normal;font-style: normal;font-display: fallback;}@media (max-width:921px) {.main-header-bar .main-header-bar-navigation{display:none;}}.ast-desktop .main-header-menu.submenu-with-border .sub-menu,.ast-desktop .main-header-menu.submenu-with-border .astra-full-megamenu-wrapper{border-color:var(--ast-global-color-0);}.ast-desktop .main-header-menu.submenu-with-border .sub-menu{border-top-width:2px;border-style:solid;}.ast-desktop .main-header-menu.submenu-with-border .sub-menu .sub-menu{top:-2px;}.ast-desktop .main-header-menu.submenu-with-border .sub-menu .menu-link,.ast-desktop .main-header-menu.submenu-with-border .children .menu-link{border-bottom-width:0px;border-style:solid;border-color:#eaeaea;}@media (min-width:769px){.main-header-menu .sub-menu .menu-item.ast-left-align-sub-menu:hover > .sub-menu,.main-header-menu .sub-menu .menu-item.ast-left-align-sub-menu.focus > .sub-menu{margin-left:-0px;}}.site .comments-area{padding-bottom:3em;}.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .main-header-bar-navigation .ast-search-icon {display: none;}.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-form {padding: 0;display: block;overflow: hidden;}.ast-header-break-point .ast-header-custom-item .widget:last-child {margin-bottom: 1em;}.ast-header-custom-item .widget {margin: 0.5em;display: inline-block;vertical-align: middle;}.ast-header-custom-item .widget p {margin-bottom: 0;}.ast-header-custom-item .widget li {width: auto;}.ast-header-custom-item-inside .button-custom-menu-item .menu-link {display: none;}.ast-header-custom-item-inside.ast-header-break-point .button-custom-menu-item .ast-custom-button-link {display: none;}.ast-header-custom-item-inside.ast-header-break-point .button-custom-menu-item .menu-link {display: block;}.ast-header-break-point.ast-header-custom-item-outside .main-header-bar .ast-search-icon {margin-right: 1em;}.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-field,.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon.ast-inline-search .search-field {width: 100%;padding-right: 5.5em;}.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-submit {display: block;position: absolute;height: 100%;top: 0;right: 0;padding: 0 1em;border-radius: 0;}.ast-header-break-point .ast-header-custom-item .ast-masthead-custom-menu-items {padding-left: 20px;padding-right: 20px;margin-bottom: 1em;margin-top: 1em;}.ast-header-custom-item-inside.ast-header-break-point .button-custom-menu-item {padding-left: 0;padding-right: 0;margin-top: 0;margin-bottom: 0;}.astra-icon-down_arrow::after {content: "\e900";font-family: Astra;}.astra-icon-close::after {content: "\e5cd";font-family: Astra;}.astra-icon-drag_handle::after {content: "\e25d";font-family: Astra;}.astra-icon-format_align_justify::after {content: "\e235";font-family: Astra;}.astra-icon-menu::after {content: "\e5d2";font-family: Astra;}.astra-icon-reorder::after {content: "\e8fe";font-family: Astra;}.astra-icon-search::after {content: "\e8b6";font-family: Astra;}.astra-icon-zoom_in::after {content: "\e56b";font-family: Astra;}.astra-icon-check-circle::after {content: "\e901";font-family: Astra;}.astra-icon-shopping-cart::after {content: "\f07a";font-family: Astra;}.astra-icon-shopping-bag::after {content: "\f290";font-family: Astra;}.astra-icon-shopping-basket::after {content: "\f291";font-family: Astra;}.astra-icon-circle-o::after {content: "\e903";font-family: Astra;}.astra-icon-certificate::after {content: "\e902";font-family: Astra;}blockquote {padding: 1.2em;}:root .has-ast-global-color-0-color{color:var(--ast-global-color-0);}:root .has-ast-global-color-0-background-color{background-color:var(--ast-global-color-0);}:root .wp-block-button .has-ast-global-color-0-color{color:var(--ast-global-color-0);}:root .wp-block-button .has-ast-global-color-0-background-color{background-color:var(--ast-global-color-0);}:root .has-ast-global-color-1-color{color:var(--ast-global-color-1);}:root .has-ast-global-color-1-background-color{background-color:var(--ast-global-color-1);}:root .wp-block-button .has-ast-global-color-1-color{color:var(--ast-global-color-1);}:root .wp-block-button .has-ast-global-color-1-background-color{background-color:var(--ast-global-color-1);}:root .has-ast-global-color-2-color{color:var(--ast-global-color-2);}:root .has-ast-global-color-2-background-color{background-color:var(--ast-global-color-2);}:root .wp-block-button .has-ast-global-color-2-color{color:var(--ast-global-color-2);}:root .wp-block-button .has-ast-global-color-2-background-color{background-color:var(--ast-global-color-2);}:root .has-ast-global-color-3-color{color:var(--ast-global-color-3);}:root .has-ast-global-color-3-background-color{background-color:var(--ast-global-color-3);}:root .wp-block-button .has-ast-global-color-3-color{color:var(--ast-global-color-3);}:root .wp-block-button .has-ast-global-color-3-background-color{background-color:var(--ast-global-color-3);}:root .has-ast-global-color-4-color{color:var(--ast-global-color-4);}:root .has-ast-global-color-4-background-color{background-color:var(--ast-global-color-4);}:root .wp-block-button .has-ast-global-color-4-color{color:var(--ast-global-color-4);}:root .wp-block-button .has-ast-global-color-4-background-color{background-color:var(--ast-global-color-4);}:root .has-ast-global-color-5-color{color:var(--ast-global-color-5);}:root .has-ast-global-color-5-background-color{background-color:var(--ast-global-color-5);}:root .wp-block-button .has-ast-global-color-5-color{color:var(--ast-global-color-5);}:root .wp-block-button .has-ast-global-color-5-background-color{background-color:var(--ast-global-color-5);}:root .has-ast-global-color-6-color{color:var(--ast-global-color-6);}:root .has-ast-global-color-6-background-color{background-color:var(--ast-global-color-6);}:root .wp-block-button .has-ast-global-color-6-color{color:var(--ast-global-color-6);}:root .wp-block-button .has-ast-global-color-6-background-color{background-color:var(--ast-global-color-6);}:root .has-ast-global-color-7-color{color:var(--ast-global-color-7);}:root .has-ast-global-color-7-background-color{background-color:var(--ast-global-color-7);}:root .wp-block-button .has-ast-global-color-7-color{color:var(--ast-global-color-7);}:root .wp-block-button .has-ast-global-color-7-background-color{background-color:var(--ast-global-color-7);}:root .has-ast-global-color-8-color{color:var(--ast-global-color-8);}:root .has-ast-global-color-8-background-color{background-color:var(--ast-global-color-8);}:root .wp-block-button .has-ast-global-color-8-color{color:var(--ast-global-color-8);}:root .wp-block-button .has-ast-global-color-8-background-color{background-color:var(--ast-global-color-8);}:root{--ast-global-color-0:#0170B9;--ast-global-color-1:#3a3a3a;--ast-global-color-2:#3a3a3a;--ast-global-color-3:#4B4F58;--ast-global-color-4:#F5F5F5;--ast-global-color-5:#FFFFFF;--ast-global-color-6:#E5E5E5;--ast-global-color-7:#424242;--ast-global-color-8:#000000;}:root {--ast-border-color : #dddddd;}#masthead .ast-container,.ast-header-breadcrumb .ast-container{max-width:100%;padding-left:35px;padding-right:35px;}@media (max-width:921px){#masthead .ast-container,.ast-header-breadcrumb .ast-container{padding-left:20px;padding-right:20px;}}.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .main-header-bar-navigation .ast-search-icon {display: none;}.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-form {padding: 0;display: block;overflow: hidden;}.ast-header-break-point .ast-header-custom-item .widget:last-child {margin-bottom: 1em;}.ast-header-custom-item .widget {margin: 0.5em;display: inline-block;vertical-align: middle;}.ast-header-custom-item .widget p {margin-bottom: 0;}.ast-header-custom-item .widget li {width: auto;}.ast-header-custom-item-inside .button-custom-menu-item .menu-link {display: none;}.ast-header-custom-item-inside.ast-header-break-point .button-custom-menu-item .ast-custom-button-link {display: none;}.ast-header-custom-item-inside.ast-header-break-point .button-custom-menu-item .menu-link {display: block;}.ast-header-break-point.ast-header-custom-item-outside .main-header-bar .ast-search-icon {margin-right: 1em;}.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-field,.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon.ast-inline-search .search-field {width: 100%;padding-right: 5.5em;}.ast-header-break-point.ast-header-custom-item-inside .main-header-bar .ast-search-menu-icon .search-submit {display: block;position: absolute;height: 100%;top: 0;right: 0;padding: 0 1em;border-radius: 0;}.ast-header-break-point .ast-header-custom-item .ast-masthead-custom-menu-items {padding-left: 20px;padding-right: 20px;margin-bottom: 1em;margin-top: 1em;}.ast-header-custom-item-inside.ast-header-break-point .button-custom-menu-item {padding-left: 0;padding-right: 0;margin-top: 0;margin-bottom: 0;}.astra-icon-down_arrow::after {content: "\e900";font-family: Astra;}.astra-icon-close::after {content: "\e5cd";font-family: Astra;}.astra-icon-drag_handle::after {content: "\e25d";font-family: Astra;}.astra-icon-format_align_justify::after {content: "\e235";font-family: Astra;}.astra-icon-menu::after {content: "\e5d2";font-family: Astra;}.astra-icon-reorder::after {content: "\e8fe";font-family: Astra;}.astra-icon-search::after {content: "\e8b6";font-family: Astra;}.astra-icon-zoom_in::after {content: "\e56b";font-family: Astra;}.astra-icon-check-circle::after {content: "\e901";font-family: Astra;}.astra-icon-shopping-cart::after {content: "\f07a";font-family: Astra;}.astra-icon-shopping-bag::after {content: "\f290";font-family: Astra;}.astra-icon-shopping-basket::after {content: "\f291";font-family: Astra;}.astra-icon-circle-o::after {content: "\e903";font-family: Astra;}.astra-icon-certificate::after {content: "\e902";font-family: Astra;}blockquote {padding: 1.2em;}:root .has-ast-global-color-0-color{color:var(--ast-global-color-0);}:root .has-ast-global-color-0-background-color{background-color:var(--ast-global-color-0);}:root .wp-block-button .has-ast-global-color-0-color{color:var(--ast-global-color-0);}:root .wp-block-button .has-ast-global-color-0-background-color{background-color:var(--ast-global-color-0);}:root .has-ast-global-color-1-color{color:var(--ast-global-color-1);}:root .has-ast-global-color-1-background-color{background-color:var(--ast-global-color-1);}:root .wp-block-button .has-ast-global-color-1-color{color:var(--ast-global-color-1);}:root .wp-block-button .has-ast-global-color-1-background-color{background-color:var(--ast-global-color-1);}:root .has-ast-global-color-2-color{color:var(--ast-global-color-2);}:root .has-ast-global-color-2-background-color{background-color:var(--ast-global-color-2);}:root .wp-block-button .has-ast-global-color-2-color{color:var(--ast-global-color-2);}:root .wp-block-button .has-ast-global-color-2-background-color{background-color:var(--ast-global-color-2);}:root .has-ast-global-color-3-color{color:var(--ast-global-color-3);}:root .has-ast-global-color-3-background-color{background-color:var(--ast-global-color-3);}:root .wp-block-button .has-ast-global-color-3-color{color:var(--ast-global-color-3);}:root .wp-block-button .has-ast-global-color-3-background-color{background-color:var(--ast-global-color-3);}:root .has-ast-global-color-4-color{color:var(--ast-global-color-4);}:root .has-ast-global-color-4-background-color{background-color:var(--ast-global-color-4);}:root .wp-block-button .has-ast-global-color-4-color{color:var(--ast-global-color-4);}:root .wp-block-button .has-ast-global-color-4-background-color{background-color:var(--ast-global-color-4);}:root .has-ast-global-color-5-color{color:var(--ast-global-color-5);}:root .has-ast-global-color-5-background-color{background-color:var(--ast-global-color-5);}:root .wp-block-button .has-ast-global-color-5-color{color:var(--ast-global-color-5);}:root .wp-block-button .has-ast-global-color-5-background-color{background-color:var(--ast-global-color-5);}:root .has-ast-global-color-6-color{color:var(--ast-global-color-6);}:root .has-ast-global-color-6-background-color{background-color:var(--ast-global-color-6);}:root .wp-block-button .has-ast-global-color-6-color{color:var(--ast-global-color-6);}:root .wp-block-button .has-ast-global-color-6-background-color{background-color:var(--ast-global-color-6);}:root .has-ast-global-color-7-color{color:var(--ast-global-color-7);}:root .has-ast-global-color-7-background-color{background-color:var(--ast-global-color-7);}:root .wp-block-button .has-ast-global-color-7-color{color:var(--ast-global-color-7);}:root .wp-block-button .has-ast-global-color-7-background-color{background-color:var(--ast-global-color-7);}:root .has-ast-global-color-8-color{color:var(--ast-global-color-8);}:root .has-ast-global-color-8-background-color{background-color:var(--ast-global-color-8);}:root .wp-block-button .has-ast-global-color-8-color{color:var(--ast-global-color-8);}:root .wp-block-button .has-ast-global-color-8-background-color{background-color:var(--ast-global-color-8);}:root{--ast-global-color-0:#0170B9;--ast-global-color-1:#3a3a3a;--ast-global-color-2:#3a3a3a;--ast-global-color-3:#4B4F58;--ast-global-color-4:#F5F5F5;--ast-global-color-5:#FFFFFF;--ast-global-color-6:#E5E5E5;--ast-global-color-7:#424242;--ast-global-color-8:#000000;}:root {--ast-border-color : #dddddd;}#masthead .ast-container,.ast-header-breadcrumb .ast-container{max-width:100%;padding-left:35px;padding-right:35px;}@media (max-width:921px){#masthead .ast-container,.ast-header-breadcrumb .ast-container{padding-left:20px;padding-right:20px;}}.ast-single-entry-banner {-js-display: flex;display: flex;flex-direction: column;justify-content: center;text-align: center;position: relative;background: var(--ast-title-layout-bg);}.ast-single-entry-banner[data-banner-layout="layout-1"] {max-width: 1200px;background: inherit;padding: 20px 0;}.ast-single-entry-banner[data-banner-width-type="custom"] {margin: 0 auto;width: 100%;}.ast-single-entry-banner + .site-content .entry-header {margin-bottom: 0;}.site .ast-author-avatar {--ast-author-avatar-size: ;}a.ast-underline-text {text-decoration: underline;}.ast-container > .ast-terms-link {position: relative;display: block;}a.ast-button.ast-badge-tax {padding: 4px 8px;border-radius: 3px;font-size: inherit;}header.entry-header{text-align:left;}header.entry-header > *:not(:last-child){margin-bottom:10px;}@media (max-width:768px){header.entry-header{text-align:left;}}@media (max-width:544px){header.entry-header{text-align:left;}}.ast-archive-entry-banner {-js-display: flex;display: flex;flex-direction: column;justify-content: center;text-align: center;position: relative;background: var(--ast-title-layout-bg);}.ast-archive-entry-banner[data-banner-width-type="custom"] {margin: 0 auto;width: 100%;}.ast-archive-entry-banner[data-banner-layout="layout-1"] {background: inherit;padding: 20px 0;text-align: left;}body.archive .ast-archive-description{max-width:1200px;width:100%;text-align:left;padding-top:3em;padding-right:3em;padding-bottom:3em;padding-left:3em;}body.archive .ast-archive-description .ast-archive-title,body.archive .ast-archive-description .ast-archive-title *{font-size:40px;font-size:2.6666666666667rem;text-transform:capitalize;}body.archive .ast-archive-description > *:not(:last-child){margin-bottom:10px;}@media (max-width:768px){body.archive .ast-archive-description{text-align:left;}}@media (max-width:544px){body.archive .ast-archive-description{text-align:left;}}.ast-theme-transparent-header #masthead .site-logo-img .transparent-custom-logo .astra-logo-svg{width:150px;}.ast-theme-transparent-header #masthead .site-logo-img .transparent-custom-logo img{ max-width:150px; width:150px;}@media (max-width:768px){.ast-theme-transparent-header #masthead .site-logo-img .transparent-custom-logo .astra-logo-svg{width:120px;}.ast-theme-transparent-header #masthead .site-logo-img .transparent-custom-logo img{ max-width:120px; width:120px;}}@media (max-width:543px){.ast-theme-transparent-header #masthead .site-logo-img .transparent-custom-logo .astra-logo-svg{width:100px;}.ast-theme-transparent-header #masthead .site-logo-img .transparent-custom-logo img{ max-width:100px; width:100px;}}@media (min-width:768px){.ast-theme-transparent-header #masthead{position:absolute;left:0;right:0;}.ast-theme-transparent-header .main-header-bar,.ast-theme-transparent-header.ast-header-break-point .main-header-bar{background:none;}body.elementor-editor-active.ast-theme-transparent-header #masthead,.fl-builder-edit .ast-theme-transparent-header #masthead,body.vc_editor.ast-theme-transparent-header #masthead,body.brz-ed.ast-theme-transparent-header #masthead{z-index:0;}.ast-header-break-point.ast-replace-site-logo-transparent.ast-theme-transparent-header .custom-mobile-logo-link{display:none;}.ast-header-break-point.ast-replace-site-logo-transparent.ast-theme-transparent-header .transparent-custom-logo{display:inline-block;}.ast-theme-transparent-header .ast-above-header,.ast-theme-transparent-header .ast-above-header.ast-above-header-bar{background-image:none;background-color:transparent;}.ast-theme-transparent-header .ast-below-header,.ast-theme-transparent-header .ast-below-header.ast-below-header-bar{background-image:none;background-color:transparent;}}.ast-theme-transparent-header .ast-builder-menu .main-header-menu .menu-item .sub-menu .menu-link,.ast-theme-transparent-header .main-header-menu .menu-item .sub-menu .menu-link{background-color:transparent;}@media (max-width:768px){.ast-theme-transparent-header #masthead{position:absolute;left:0;right:0;}.ast-theme-transparent-header .main-header-bar,.ast-theme-transparent-header.ast-header-break-point .main-header-bar{background:none;}body.elementor-editor-active.ast-theme-transparent-header #masthead,.fl-builder-edit .ast-theme-transparent-header #masthead,body.vc_editor.ast-theme-transparent-header #masthead,body.brz-ed.ast-theme-transparent-header #masthead{z-index:0;}.ast-header-break-point.ast-replace-site-logo-transparent.ast-theme-transparent-header .custom-mobile-logo-link{display:none;}.ast-header-break-point.ast-replace-site-logo-transparent.ast-theme-transparent-header .transparent-custom-logo{display:inline-block;}.ast-theme-transparent-header .ast-above-header,.ast-theme-transparent-header .ast-above-header.ast-above-header-bar{background-image:none;background-color:transparent;}.ast-theme-transparent-header .ast-below-header,.ast-theme-transparent-header .ast-below-header.ast-below-header-bar{background-image:none;background-color:transparent;}}.ast-theme-transparent-header .main-header-bar,.ast-theme-transparent-header.ast-header-break-point .main-header-bar{border-bottom-style:none;}.ast-breadcrumbs .trail-browse,.ast-breadcrumbs .trail-items,.ast-breadcrumbs .trail-items li{display:inline-block;margin:0;padding:0;border:none;background:inherit;text-indent:0;text-decoration:none;}.ast-breadcrumbs .trail-browse{font-size:inherit;font-style:inherit;font-weight:inherit;color:inherit;}.ast-breadcrumbs .trail-items{list-style:none;}.trail-items li::after{padding:0 0.3em;content:"\00bb";}.trail-items li:last-of-type::after{display:none;}h1,h2,h3,h4,h5,h6,.entry-content :where(h1,h2,h3,h4,h5,h6){color:var(--ast-global-color-2);}.elementor-widget-heading .elementor-heading-title{margin:0;}.elementor-page .ast-menu-toggle{color:unset !important;background:unset !important;}.elementor-post.elementor-grid-item.hentry{margin-bottom:0;}.woocommerce div.product .elementor-element.elementor-products-grid .related.products ul.products li.product,.elementor-element .elementor-wc-products .woocommerce[class*='columns-'] ul.products li.product{width:auto;margin:0;float:none;}body .elementor hr{background-color:#ccc;margin:0;}.ast-left-sidebar .elementor-section.elementor-section-stretched,.ast-right-sidebar .elementor-section.elementor-section-stretched{max-width:100%;left:0 !important;}.elementor-posts-container [CLASS*="ast-width-"]{width:100%;}.elementor-template-full-width .ast-container{display:block;}.elementor-screen-only,.screen-reader-text,.screen-reader-text span,.ui-helper-hidden-accessible{top:0 !important;}@media (max-width:544px){.elementor-element .elementor-wc-products .woocommerce[class*="columns-"] ul.products li.product{width:auto;margin:0;}.elementor-element .woocommerce .woocommerce-result-count{float:none;}}.ast-header-break-point .main-header-bar{border-bottom-width:1px;}@media (min-width:769px){.main-header-bar{border-bottom-width:1px;}}.main-header-menu .menu-item, #astra-footer-menu .menu-item, .main-header-bar .ast-masthead-custom-menu-items{-js-display:flex;display:flex;-webkit-box-pack:center;-webkit-justify-content:center;-moz-box-pack:center;-ms-flex-pack:center;justify-content:center;-webkit-box-orient:vertical;-webkit-box-direction:normal;-webkit-flex-direction:column;-moz-box-orient:vertical;-moz-box-direction:normal;-ms-flex-direction:column;flex-direction:column;}.main-header-menu > .menu-item > .menu-link, #astra-footer-menu > .menu-item > .menu-link{height:100%;-webkit-box-align:center;-webkit-align-items:center;-moz-box-align:center;-ms-flex-align:center;align-items:center;-js-display:flex;display:flex;}.ast-primary-menu-disabled .main-header-bar .ast-masthead-custom-menu-items{flex:unset;}.main-header-menu .sub-menu .menu-item.menu-item-has-children > .menu-link:after{position:absolute;right:1em;top:50%;transform:translate(0,-50%) rotate(270deg);}.ast-header-break-point .main-header-bar .main-header-bar-navigation .page_item_has_children > .ast-menu-toggle::before, .ast-header-break-point .main-header-bar .main-header-bar-navigation .menu-item-has-children > .ast-menu-toggle::before, .ast-mobile-popup-drawer .main-header-bar-navigation .menu-item-has-children>.ast-menu-toggle::before, .ast-header-break-point .ast-mobile-header-wrap .main-header-bar-navigation .menu-item-has-children > .ast-menu-toggle::before{font-weight:bold;content:"\e900";font-family:Astra;text-decoration:inherit;display:inline-block;}.ast-header-break-point .main-navigation ul.sub-menu .menu-item .menu-link:before{content:"\e900";font-family:Astra;font-size:.65em;text-decoration:inherit;display:inline-block;transform:translate(0, -2px) rotateZ(270deg);margin-right:5px;}.widget_search .search-form:after{font-family:Astra;font-size:1.2em;font-weight:normal;content:"\e8b6";position:absolute;top:50%;right:15px;transform:translate(0, -50%);}.astra-search-icon::before{content:"\e8b6";font-family:Astra;font-style:normal;font-weight:normal;text-decoration:inherit;text-align:center;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;z-index:3;}.main-header-bar .main-header-bar-navigation .page_item_has_children > a:after, .main-header-bar .main-header-bar-navigation .menu-item-has-children > a:after, .menu-item-has-children .ast-header-navigation-arrow:after{content:"\e900";display:inline-block;font-family:Astra;font-size:.6rem;font-weight:bold;text-rendering:auto;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;margin-left:10px;line-height:normal;}.menu-item-has-children .sub-menu .ast-header-navigation-arrow:after{margin-left:0;}.ast-mobile-popup-drawer .main-header-bar-navigation .ast-submenu-expanded>.ast-menu-toggle::before{transform:rotateX(180deg);}.ast-header-break-point .main-header-bar-navigation .menu-item-has-children > .menu-link:after{display:none;}@media (min-width:769px){.ast-builder-menu .main-navigation > ul > li:last-child a{margin-right:0;}}.ast-separate-container .ast-article-inner{background-color:transparent;background-image:none;}.ast-separate-container .ast-article-post{background-color:var(--ast-global-color-5);}@media (max-width:768px){.ast-separate-container .ast-article-post{background-color:var(--ast-global-color-5);}}@media (max-width:544px){.ast-separate-container .ast-article-post{background-color:var(--ast-global-color-5);}}.ast-separate-container .ast-article-single:not(.ast-related-post), .ast-separate-container .error-404, .ast-separate-container .no-results, .single.ast-separate-container  .ast-author-meta, .ast-separate-container .related-posts-title-wrapper, .ast-separate-container .comments-count-wrapper, .ast-box-layout.ast-plain-container .site-content, .ast-padded-layout.ast-plain-container .site-content, .ast-separate-container .ast-archive-description, .ast-separate-container .comments-area .comment-respond, .ast-separate-container .comments-area .ast-comment-list li, .ast-separate-container .comments-area .comments-title{background-color:var(--ast-global-color-5);}@media (max-width:768px){.ast-separate-container .ast-article-single:not(.ast-related-post), .ast-separate-container .error-404, .ast-separate-container .no-results, .single.ast-separate-container  .ast-author-meta, .ast-separate-container .related-posts-title-wrapper, .ast-separate-container .comments-count-wrapper, .ast-box-layout.ast-plain-container .site-content, .ast-padded-layout.ast-plain-container .site-content, .ast-separate-container .ast-archive-description{background-color:var(--ast-global-color-5);}}@media (max-width:544px){.ast-separate-container .ast-article-single:not(.ast-related-post), .ast-separate-container .error-404, .ast-separate-container .no-results, .single.ast-separate-container  .ast-author-meta, .ast-separate-container .related-posts-title-wrapper, .ast-separate-container .comments-count-wrapper, .ast-box-layout.ast-plain-container .site-content, .ast-padded-layout.ast-plain-container .site-content, .ast-separate-container .ast-archive-description{background-color:var(--ast-global-color-5);}}.ast-separate-container.ast-two-container #secondary .widget{background-color:var(--ast-global-color-5);}@media (max-width:768px){.ast-separate-container.ast-two-container #secondary .widget{background-color:var(--ast-global-color-5);}}@media (max-width:544px){.ast-separate-container.ast-two-container #secondary .widget{background-color:var(--ast-global-color-5);}}:root{--e-global-color-astglobalcolor0:#0170B9;--e-global-color-astglobalcolor1:#3a3a3a;--e-global-color-astglobalcolor2:#3a3a3a;--e-global-color-astglobalcolor3:#4B4F58;--e-global-color-astglobalcolor4:#F5F5F5;--e-global-color-astglobalcolor5:#FFFFFF;--e-global-color-astglobalcolor6:#E5E5E5;--e-global-color-astglobalcolor7:#424242;--e-global-color-astglobalcolor8:#000000;}
+/*# sourceURL=astra-theme-css-inline-css */
+</style>
+<link rel='stylesheet' id='hfe-widgets-style-css' href='https://workfromgreece.gr/wp-content/plugins/header-footer-elementor/inc/widgets-css/frontend.css?ver=2.8.7' media='all' />
+<link rel='stylesheet' id='bdt-uikit-css' href='https://workfromgreece.gr/wp-content/plugins/bdthemes-element-pack/assets/css/bdt-uikit.css?ver=3.13.1' media='all' />
+<link rel='stylesheet' id='ep-helper-css' href='https://workfromgreece.gr/wp-content/plugins/bdthemes-element-pack/assets/css/ep-helper.css?ver=6.2.0' media='all' />
+<link rel='stylesheet' id='splw_index_style-css' href='https://workfromgreece.gr/wp-content/plugins/location-weather/includes/Blocks/build/style-index.css?ver=3.0.3' media='all' />
+<style id="global-styles-inline-css">
+:root{--wp--preset--aspect-ratio--square: 1;--wp--preset--aspect-ratio--4-3: 4/3;--wp--preset--aspect-ratio--3-4: 3/4;--wp--preset--aspect-ratio--3-2: 3/2;--wp--preset--aspect-ratio--2-3: 2/3;--wp--preset--aspect-ratio--16-9: 16/9;--wp--preset--aspect-ratio--9-16: 9/16;--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--color--ast-global-color-0: var(--ast-global-color-0);--wp--preset--color--ast-global-color-1: var(--ast-global-color-1);--wp--preset--color--ast-global-color-2: var(--ast-global-color-2);--wp--preset--color--ast-global-color-3: var(--ast-global-color-3);--wp--preset--color--ast-global-color-4: var(--ast-global-color-4);--wp--preset--color--ast-global-color-5: var(--ast-global-color-5);--wp--preset--color--ast-global-color-6: var(--ast-global-color-6);--wp--preset--color--ast-global-color-7: var(--ast-global-color-7);--wp--preset--color--ast-global-color-8: var(--ast-global-color-8);--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgb(6,147,227) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgb(252,185,0) 0%,rgb(255,105,0) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgb(255,105,0) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;--wp--preset--shadow--natural: 6px 6px 9px rgba(0, 0, 0, 0.2);--wp--preset--shadow--deep: 12px 12px 50px rgba(0, 0, 0, 0.4);--wp--preset--shadow--sharp: 6px 6px 0px rgba(0, 0, 0, 0.2);--wp--preset--shadow--outlined: 6px 6px 0px -3px rgb(255, 255, 255), 6px 6px rgb(0, 0, 0);--wp--preset--shadow--crisp: 6px 6px 0px rgb(0, 0, 0);}:root { --wp--style--global--content-size: var(--wp--custom--ast-content-width-size);--wp--style--global--wide-size: var(--wp--custom--ast-wide-width-size); }:where(body) { margin: 0; }.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }:where(.wp-site-blocks) > * { margin-block-start: 24px; margin-block-end: 0; }:where(.wp-site-blocks) > :first-child { margin-block-start: 0; }:where(.wp-site-blocks) > :last-child { margin-block-end: 0; }:root { --wp--style--block-gap: 24px; }:root :where(.is-layout-flow) > :first-child{margin-block-start: 0;}:root :where(.is-layout-flow) > :last-child{margin-block-end: 0;}:root :where(.is-layout-flow) > *{margin-block-start: 24px;margin-block-end: 0;}:root :where(.is-layout-constrained) > :first-child{margin-block-start: 0;}:root :where(.is-layout-constrained) > :last-child{margin-block-end: 0;}:root :where(.is-layout-constrained) > *{margin-block-start: 24px;margin-block-end: 0;}:root :where(.is-layout-flex){gap: 24px;}:root :where(.is-layout-grid){gap: 24px;}.is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}.is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}.is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}.is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}.is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}.is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}.is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}.is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}body .is-layout-flex{display: flex;}.is-layout-flex{flex-wrap: wrap;align-items: center;}.is-layout-flex > :is(*, div){margin: 0;}body .is-layout-grid{display: grid;}.is-layout-grid > :is(*, div){margin: 0;}body{padding-top: 0px;padding-right: 0px;padding-bottom: 0px;padding-left: 0px;}a:where(:not(.wp-element-button)){text-decoration: none;}:root :where(.wp-element-button, .wp-block-button__link){background-color: #32373c;border-width: 0;color: #fff;font-family: inherit;font-size: inherit;font-style: inherit;font-weight: inherit;letter-spacing: inherit;line-height: inherit;padding-top: calc(0.667em + 2px);padding-right: calc(1.333em + 2px);padding-bottom: calc(0.667em + 2px);padding-left: calc(1.333em + 2px);text-decoration: none;text-transform: inherit;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-ast-global-color-0-color{color: var(--wp--preset--color--ast-global-color-0) !important;}.has-ast-global-color-1-color{color: var(--wp--preset--color--ast-global-color-1) !important;}.has-ast-global-color-2-color{color: var(--wp--preset--color--ast-global-color-2) !important;}.has-ast-global-color-3-color{color: var(--wp--preset--color--ast-global-color-3) !important;}.has-ast-global-color-4-color{color: var(--wp--preset--color--ast-global-color-4) !important;}.has-ast-global-color-5-color{color: var(--wp--preset--color--ast-global-color-5) !important;}.has-ast-global-color-6-color{color: var(--wp--preset--color--ast-global-color-6) !important;}.has-ast-global-color-7-color{color: var(--wp--preset--color--ast-global-color-7) !important;}.has-ast-global-color-8-color{color: var(--wp--preset--color--ast-global-color-8) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-ast-global-color-0-background-color{background-color: var(--wp--preset--color--ast-global-color-0) !important;}.has-ast-global-color-1-background-color{background-color: var(--wp--preset--color--ast-global-color-1) !important;}.has-ast-global-color-2-background-color{background-color: var(--wp--preset--color--ast-global-color-2) !important;}.has-ast-global-color-3-background-color{background-color: var(--wp--preset--color--ast-global-color-3) !important;}.has-ast-global-color-4-background-color{background-color: var(--wp--preset--color--ast-global-color-4) !important;}.has-ast-global-color-5-background-color{background-color: var(--wp--preset--color--ast-global-color-5) !important;}.has-ast-global-color-6-background-color{background-color: var(--wp--preset--color--ast-global-color-6) !important;}.has-ast-global-color-7-background-color{background-color: var(--wp--preset--color--ast-global-color-7) !important;}.has-ast-global-color-8-background-color{background-color: var(--wp--preset--color--ast-global-color-8) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-ast-global-color-0-border-color{border-color: var(--wp--preset--color--ast-global-color-0) !important;}.has-ast-global-color-1-border-color{border-color: var(--wp--preset--color--ast-global-color-1) !important;}.has-ast-global-color-2-border-color{border-color: var(--wp--preset--color--ast-global-color-2) !important;}.has-ast-global-color-3-border-color{border-color: var(--wp--preset--color--ast-global-color-3) !important;}.has-ast-global-color-4-border-color{border-color: var(--wp--preset--color--ast-global-color-4) !important;}.has-ast-global-color-5-border-color{border-color: var(--wp--preset--color--ast-global-color-5) !important;}.has-ast-global-color-6-border-color{border-color: var(--wp--preset--color--ast-global-color-6) !important;}.has-ast-global-color-7-border-color{border-color: var(--wp--preset--color--ast-global-color-7) !important;}.has-ast-global-color-8-border-color{border-color: var(--wp--preset--color--ast-global-color-8) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+:root :where(.wp-block-icon svg){width: 24px;}
+:root :where(.wp-block-pullquote){font-size: 1.5em;line-height: 1.6;}
+/*# sourceURL=global-styles-inline-css */
+</style>
+<link rel='stylesheet' id='contact-form-7-css' href='https://workfromgreece.gr/wp-content/plugins/contact-form-7/includes/css/styles.css?ver=6.1.6' media='all' />
+<link rel='stylesheet' id='astra-contact-form-7-css' href='https://workfromgreece.gr/wp-content/themes/astra/assets/css/minified/compatibility/contact-form-7-main.min.css?ver=4.12.0' media='all' />
+<link rel='stylesheet' id='cookie-law-info-css' href='https://workfromgreece.gr/wp-content/plugins/cookie-law-info/legacy/public/css/cookie-law-info-public.css?ver=3.5.0' media='all' />
+<link rel='stylesheet' id='cookie-law-info-gdpr-css' href='https://workfromgreece.gr/wp-content/plugins/cookie-law-info/legacy/public/css/cookie-law-info-gdpr.css?ver=3.5.0' media='all' />
+<link rel='stylesheet' id='google-calendar-style-css' href='https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/addons/conversational-forms-pro/includes/calendar/google-calendar.css?ver=7.0' media='all' />
+<link rel='stylesheet' id='fullcalendar-style-css' href='https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/addons/conversational-forms-pro/includes/calendar/fullcalendar.min.css?ver=7.0' media='all' />
+<link rel='stylesheet' id='wpml-legacy-horizontal-list-0-css' href='https://workfromgreece.gr/wp-content/plugins/sitepress-multilingual-cms/templates/language-switchers/legacy-list-horizontal/style.min.css?ver=1' media='all' />
+<style id="wpml-legacy-horizontal-list-0-inline-css">
+.wpml-ls-statics-shortcode_actions{background-color:#ededed;}.wpml-ls-statics-shortcode_actions a, .wpml-ls-statics-shortcode_actions .wpml-ls-sub-menu a, .wpml-ls-statics-shortcode_actions .wpml-ls-sub-menu a:link, .wpml-ls-statics-shortcode_actions li:not(.wpml-ls-current-language) .wpml-ls-link, .wpml-ls-statics-shortcode_actions li:not(.wpml-ls-current-language) .wpml-ls-link:link {color:#c85ea2;}.wpml-ls-statics-shortcode_actions .wpml-ls-current-language > a {color:#c85ea2;}
+/*# sourceURL=wpml-legacy-horizontal-list-0-inline-css */
+</style>
+<link rel='stylesheet' id='tribe-events-v2-single-skeleton-css' href='https://workfromgreece.gr/wp-content/plugins/the-events-calendar/src/resources/css/tribe-events-single-skeleton.min.css?ver=6.6.4.2' media='all' />
+<link rel='stylesheet' id='tribe-events-v2-single-skeleton-full-css' href='https://workfromgreece.gr/wp-content/plugins/the-events-calendar/src/resources/css/tribe-events-single-full.min.css?ver=6.6.4.2' media='all' />
+<link rel='stylesheet' id='tec-events-elementor-widgets-base-styles-css' href='https://workfromgreece.gr/wp-content/plugins/the-events-calendar/src/resources/css/integrations/plugins/elementor/widgets/widget-base.min.css?ver=6.6.4.2' media='all' />
+<link rel='stylesheet' id='hfe-style-css' href='https://workfromgreece.gr/wp-content/plugins/header-footer-elementor/assets/css/header-footer-elementor.css?ver=2.8.7' media='all' />
+<link rel='stylesheet' id='pafe-2602-css' href='https://workfromgreece.gr/wp-content/uploads/premium-addons-elementor/pafe-2602.css?ver=1780895407' media='all' />
+<link rel='stylesheet' id='elementor-icons-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/eicons/css/elementor-icons.min.css?ver=5.48.0' media='all' />
+<link rel='stylesheet' id='elementor-frontend-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/css/frontend.min.css?ver=4.0.9' media='all' />
+<style id="elementor-frontend-inline-css">
+.elementor-kit-19{--e-global-color-primary:#4CC5CC;--e-global-color-secondary:#54595F;--e-global-color-text:#7A7A7A;--e-global-color-accent:#F3EA22;--e-global-color-2f9b81c2:#4BC6CC;--e-global-color-667ee008:#23A455;--e-global-color-499a20e2:#000;--e-global-color-50ae6595:#FFF;--e-global-color-8e1baeb:#6EC1E4;--e-global-color-455f277:#F3EA22;--e-global-typography-primary-font-family:"Fira Sans";--e-global-typography-primary-font-size:30px;--e-global-typography-primary-font-weight:600;--e-global-typography-secondary-font-family:"Roboto Slab";--e-global-typography-secondary-font-weight:400;--e-global-typography-text-font-family:"Fira Sans";--e-global-typography-text-font-size:20px;--e-global-typography-text-font-weight:300;--e-global-typography-accent-font-family:"Roboto";--e-global-typography-accent-font-weight:500;--e-global-typography-a0780f3-font-family:"Fira Sans";--e-global-typography-a0780f3-font-size:20px;--e-global-typography-a0780f3-font-weight:300;--e-global-typography-a3eb3c8-font-family:"Fira Sans";--e-global-typography-a3eb3c8-font-size:16px;--e-global-typography-a3eb3c8-font-weight:200;--e-global-typography-a3eb3c8-font-style:italic;--e-global-typography-a3eb3c8-line-height:1em;--e-global-typography-17e347d-font-family:"Burford Rustic";--e-global-typography-17e347d-font-size:68px;--e-global-typography-17e347d-font-weight:100;--e-global-typography-17e347d-line-height:1em;--e-global-typography-17e347d-letter-spacing:-5px;--e-global-typography-cb029b3-font-family:"Burford Rustic";--e-global-typography-cb029b3-font-size:200px;--e-global-typography-cb029b3-line-height:0.6em;--e-global-typography-cb029b3-letter-spacing:-5px;--e-global-typography-145f6eb-font-family:"Burford Rustic";--e-global-typography-145f6eb-font-size:24px;--e-global-typography-145f6eb-font-weight:100;--e-global-typography-145f6eb-text-transform:uppercase;--e-global-typography-145f6eb-line-height:1em;--e-global-typography-0973104-font-family:"Burford Rustic";--e-global-typography-0973104-font-size:90px;--e-global-typography-0973104-font-weight:100;--e-global-typography-0973104-line-height:0.5em;--e-global-typography-0973104-letter-spacing:-5px;}.elementor-kit-19 e-page-transition{background-color:#FFBC7D;}.elementor-section.elementor-section-boxed > .elementor-container{max-width:1140px;}.e-con{--container-max-width:1140px;}{}h1.entry-title{display:var(--page-title-display);}@media(max-width:1024px){.elementor-section.elementor-section-boxed > .elementor-container{max-width:1024px;}.e-con{--container-max-width:1024px;}}@media(max-width:767px){.elementor-kit-19{--e-global-typography-0973104-font-size:65px;--e-global-typography-0973104-line-height:1em;}.elementor-section.elementor-section-boxed > .elementor-container{max-width:767px;}.e-con{--container-max-width:767px;}}/* Start Custom Fonts CSS */@font-face {
+	font-family: 'Burford Rustic';
+	font-style: normal;
+	font-weight: normal;
+	font-display: auto;
+	src: url('https://workfromgreece.gr/wp-content/uploads/2023/10/burford.ttf') format('truetype');
+}
+/* End Custom Fonts CSS */
+.elementor-widget-table-of-contents{--header-color:var( --e-global-color-secondary );--item-text-color:var( --e-global-color-text );--item-text-hover-color:var( --e-global-color-accent );--marker-color:var( --e-global-color-text );}.elementor-widget-table-of-contents .elementor-toc__header, .elementor-widget-table-of-contents .elementor-toc__header-title{font-family:var( --e-global-typography-primary-font-family );font-size:var( --e-global-typography-primary-font-size );font-weight:var( --e-global-typography-primary-font-weight );}.elementor-widget-table-of-contents .elementor-toc__list-item{font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );}.elementor-2602 .elementor-element.elementor-element-332fc2d .elementor-toc__header-title{text-align:start;}.elementor-2602 .elementor-element.elementor-element-332fc2d .elementor-toc__header{flex-direction:row;}.elementor-2602 .elementor-element.elementor-element-332fc2d{--item-text-hover-decoration:underline;}.elementor-widget-text-editor{font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );color:var( --e-global-color-text );}.elementor-widget-text-editor.elementor-drop-cap-view-stacked .elementor-drop-cap{background-color:var( --e-global-color-primary );}.elementor-widget-text-editor.elementor-drop-cap-view-framed .elementor-drop-cap, .elementor-widget-text-editor.elementor-drop-cap-view-default .elementor-drop-cap{color:var( --e-global-color-primary );border-color:var( --e-global-color-primary );}.elementor-2602 .elementor-element.elementor-element-1b89bf0{font-family:var( --e-global-typography-a0780f3-font-family );font-size:var( --e-global-typography-a0780f3-font-size );font-weight:var( --e-global-typography-a0780f3-font-weight );}.elementor-widget-divider{--divider-color:var( --e-global-color-secondary );}.elementor-widget-divider .elementor-divider__text{color:var( --e-global-color-secondary );font-family:var( --e-global-typography-secondary-font-family );font-weight:var( --e-global-typography-secondary-font-weight );}.elementor-widget-divider.elementor-view-stacked .elementor-icon{background-color:var( --e-global-color-secondary );}.elementor-widget-divider.elementor-view-framed .elementor-icon, .elementor-widget-divider.elementor-view-default .elementor-icon{color:var( --e-global-color-secondary );border-color:var( --e-global-color-secondary );}.elementor-widget-divider.elementor-view-framed .elementor-icon, .elementor-widget-divider.elementor-view-default .elementor-icon svg{fill:var( --e-global-color-secondary );}.elementor-2602 .elementor-element.elementor-element-3db6e0e{--divider-border-style:solid;--divider-color:#000;--divider-border-width:1px;}.elementor-2602 .elementor-element.elementor-element-3db6e0e .elementor-divider-separator{width:70%;margin:0 auto;margin-center:0;}.elementor-2602 .elementor-element.elementor-element-3db6e0e .elementor-divider{text-align:center;padding-block-start:15px;padding-block-end:15px;}.elementor-widget-heading .elementor-heading-title{font-family:var( --e-global-typography-primary-font-family );font-size:var( --e-global-typography-primary-font-size );font-weight:var( --e-global-typography-primary-font-weight );color:var( --e-global-color-primary );}.elementor-2602 .elementor-element.elementor-element-c1d7d24 > .elementor-widget-container{padding:10px 10px 10px 10px;}.elementor-2602 .elementor-element.elementor-element-c1d7d24{text-align:start;}.elementor-2602 .elementor-element.elementor-element-c1d7d24 .elementor-heading-title{color:#4BC6CC;}.elementor-2602 .elementor-element.elementor-element-e6fe299{text-align:start;}.elementor-2602 .elementor-element.elementor-element-d302a44{text-align:start;}.elementor-widget-image .widget-image-caption{color:var( --e-global-color-text );font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );}.elementor-2602 .elementor-element.elementor-element-192cb30{--divider-border-style:solid;--divider-color:#000;--divider-border-width:1px;}.elementor-2602 .elementor-element.elementor-element-192cb30 .elementor-divider-separator{width:70%;margin:0 auto;margin-center:0;}.elementor-2602 .elementor-element.elementor-element-192cb30 .elementor-divider{text-align:center;padding-block-start:15px;padding-block-end:15px;}.elementor-2602 .elementor-element.elementor-element-23da220 > .elementor-widget-container{margin:0px 0px 0px 0px;padding:10px 10px 10px 10px;}.elementor-2602 .elementor-element.elementor-element-23da220{text-align:start;}.elementor-2602 .elementor-element.elementor-element-23da220 .elementor-heading-title{color:#4BC6CC;}.elementor-2602 .elementor-element.elementor-element-f0f686a{--divider-border-style:solid;--divider-color:#000;--divider-border-width:1px;}.elementor-2602 .elementor-element.elementor-element-f0f686a .elementor-divider-separator{width:70%;margin:0 auto;margin-center:0;}.elementor-2602 .elementor-element.elementor-element-f0f686a .elementor-divider{text-align:center;padding-block-start:15px;padding-block-end:15px;}.elementor-2602 .elementor-element.elementor-element-6824dd7 > .elementor-widget-container{padding:10px 10px 10px 10px;}.elementor-2602 .elementor-element.elementor-element-6824dd7{text-align:start;}.elementor-2602 .elementor-element.elementor-element-6824dd7 .elementor-heading-title{color:#4BC6CC;}.elementor-widget-premium-icon-list .premium-bullet-list-wrapper i, .elementor-widget-premium-icon-list .premium-bullet-list-icon-text p{color:var( --e-global-color-primary );}.elementor-widget-premium-icon-list .premium-drawable-icon *, .elementor-widget-premium-icon-list svg:not([class*="premium-"]){fill:var( --e-global-color-primary );stroke:var( --e-global-color-primary );}.elementor-widget-premium-icon-list .premium-bullet-list-blur:hover .premium-bullet-list-wrapper i, .elementor-widget-premium-icon-list .premium-bullet-list-blur:hover .premium-bullet-list-wrapper svg, .elementor-widget-premium-icon-list .premium-bullet-list-blur:hover .premium-bullet-list-wrapper .premium-bullet-list-icon-text p{text-shadow:var( --e-global-color-primary );}.elementor-widget-premium-icon-list .premium-bullet-list-content:hover .premium-bullet-list-wrapper i, .elementor-widget-premium-icon-list .premium-bullet-list-content:hover .premium-bullet-list-icon-text p{color:var( --e-global-color-primary );}.elementor-widget-premium-icon-list .premium-bullet-list-blur .premium-bullet-list-content:hover .premium-bullet-list-wrapper i, .elementor-widget-premium-icon-list .premium-bullet-list-blur .premium-bullet-list-content:hover  .premium-bullet-list-icon-text p{text-shadow:var( --e-global-color-primary );color:var( --e-global-color-primary );}.elementor-widget-premium-icon-list .premium-bullet-list-content:hover .premium-drawable-icon *, .elementor-widget-premium-icon-list .premium-bullet-list-content:hover svg:not([class*="premium-"]){fill:var( --e-global-color-primary );stroke:var( --e-global-color-primary );} .elementor-widget-premium-icon-list .premium-bullet-list-icon-text p{font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );}.elementor-widget-premium-icon-list .premium-bullet-text{font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );} .elementor-widget-premium-icon-list .premium-bullet-text{color:var( --e-global-color-primary );} .elementor-widget-premium-icon-list .premium-bullet-list-blur:hover .premium-bullet-text{text-shadow:var( --e-global-color-primary );}.elementor-widget-premium-icon-list .premium-bullet-list-content:hover .premium-bullet-text{color:var( --e-global-color-primary );}.elementor-widget-premium-icon-list .premium-bullet-list-blur .premium-bullet-list-content:hover .premium-bullet-text{text-shadow:var( --e-global-color-primary );color:var( --e-global-color-primary );}.elementor-widget-premium-icon-list .premium-bullet-list-desc{font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );color:var( --e-global-color-text );}.elementor-widget-premium-icon-list .premium-bullet-list-blur:hover .premium-bullet-list-desc{text-shadow:var( --e-global-color-text );} .elementor-widget-premium-icon-list .premium-bullet-list-badge span{font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );}.elementor-widget-premium-icon-list .premium-bullet-list-badge span{color:var( --e-global-color-primary );background-color:var( --e-global-color-primary );}.elementor-widget-premium-icon-list .premium-bullet-list-divider:not(:last-child):after {border-top-color:var( --e-global-color-secondary );}.elementor-widget-premium-icon-list .premium-bullet-list-divider-inline:not(:last-child):after {border-left-color:var( --e-global-color-secondary );}.elementor-widget-premium-icon-list li.premium-bullet-list-content:not(:last-of-type) .premium-bullet-list-connector .premium-icon-connector-content:after{border-color:var( --e-global-color-secondary );}.elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-a808872 .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-a808872 svg:not([class*="premium-"]){stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-a808872.premium-bullet-list-content:hover .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-a808872.premium-bullet-list-content:hover svg:not([class*="premium-"]){stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-b038387 .premium-bullet-list-wrapper i{color:#000;}.elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-b038387 .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-b038387 svg:not([class*="premium-"]){fill:#000;stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-blur:hover .elementor-repeater-item-b038387 .premium-bullet-list-wrapper i, .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-blur:hover .elementor-repeater-item-b038387 .premium-bullet-list-wrapper svg{text-shadow:0 0 3px #000;}.elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-b038387.premium-bullet-list-content:hover .premium-bullet-list-wrapper i{color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-b038387.premium-bullet-list-content:hover .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-b038387.premium-bullet-list-content:hover svg:not([class*="premium-"]){fill:var( --e-global-color-2f9b81c2 );stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-blur .elementor-repeater-item-b038387.premium-bullet-list-content:hover .premium-bullet-list-wrapper i, .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-blur .elementor-repeater-item-b038387.premium-bullet-list-content:hover .premium-bullet-list-wrapper svg{text-shadow:var( --e-global-color-2f9b81c2 );color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-b038387.premium-bullet-list-content:hover .premium-bullet-text{color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-blur:hover .elementor-repeater-item-b038387.premium-bullet-list-content:hover .premium-bullet-text{text-shadow:var( --e-global-color-2f9b81c2 );color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-7f5faf8 .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-7f5faf8 svg:not([class*="premium-"]){stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-7f5faf8.premium-bullet-list-content:hover .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-7f5faf8.premium-bullet-list-content:hover svg:not([class*="premium-"]){stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-d3fdf6e .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-d3fdf6e svg:not([class*="premium-"]){stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-d3fdf6e.premium-bullet-list-content:hover .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-3733afd .elementor-repeater-item-d3fdf6e.premium-bullet-list-content:hover svg:not([class*="premium-"]){stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-content{overflow:hidden;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-box {flex-direction:column;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-content, .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-box{justify-content:flex-start;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-divider, .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-wrapper-top{align-self:flex-start;}.elementor-2602 .elementor-element.elementor-element-3733afd{--pa-bullet-align:flex-start;--pa-bullet-hv-size:35px;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-text{display:flex;flex-direction:row;order:5;}.elementor-2602 .elementor-element.elementor-element-3733afd > .elementor-widget-container{margin:0px 0px 0px 0px;padding:5px 5px 5px 5px;}.elementor-2602 .elementor-element.elementor-element-3733afd.bdt-cursor-effects-yes{--cursor-ball-color:#3C49366E;}.elementor-2602 .elementor-element.elementor-element-3733afd.bdt-cursor-effects-yes .bdt-cursor-icons{font-size:32px;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-content .premium-bullet-list-text-wrapper > span{align-self:start;text-align:start;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-wrapper{align-self:center;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-badge{order:8;} .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-content{background-color:#F3EA22;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-content:hover{box-shadow:2px 2px 10px 1px rgba(0,0,0,0.5) inset;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-content {border-radius:10px 10px 10px 10px;margin:0% 0% 0% 0%;padding:1% 0% 0% 0%;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-wrapper i, .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-text p, .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-text{font-size:35px;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-wrapper svg, .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-wrapper img{width:35px !important;height:35px !important;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-wrapper i, .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-icon-text p{color:#4BC6CC;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-3733afd svg:not([class*="premium-"]){fill:#4BC6CC;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-blur:hover .premium-bullet-list-wrapper i, .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-blur:hover .premium-bullet-list-wrapper svg, .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-blur:hover .premium-bullet-list-wrapper .premium-bullet-list-icon-text p{text-shadow:0 0 3px #4BC6CC;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-content:hover .premium-bullet-list-wrapper i, .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-content:hover .premium-bullet-list-icon-text p{color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-blur .premium-bullet-list-content:hover .premium-bullet-list-wrapper i, .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-blur .premium-bullet-list-content:hover  .premium-bullet-list-icon-text p{text-shadow:var( --e-global-color-2f9b81c2 );color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-content:hover .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-content:hover svg:not([class*="premium-"]){fill:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-wrapper {margin:5px 5px 5px 5px;} .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-text{color:#7A7A7A;} .elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-blur:hover .premium-bullet-text{text-shadow:0 0 3px #7A7A7A;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-content:hover .premium-bullet-text{color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-blur .premium-bullet-list-content:hover .premium-bullet-text{text-shadow:var( --e-global-color-2f9b81c2 );color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-text {margin:10px 10px 10px 10px;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-badge span{color:#fff;background-color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-badge span {border-radius:2px 2px 2px 2px;padding:10px 10px 10px 10px;}.elementor-2602 .elementor-element.elementor-element-3733afd .premium-bullet-list-badge {margin:0px 0px 0px 5px;}.elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-a808872 .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-a808872 svg:not([class*="premium-"]){stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-a808872.premium-bullet-list-content:hover .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-a808872.premium-bullet-list-content:hover svg:not([class*="premium-"]){stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-b038387 .premium-bullet-list-wrapper i{color:#000000;}.elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-b038387 .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-b038387 svg:not([class*="premium-"]){fill:#000000;stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-blur:hover .elementor-repeater-item-b038387 .premium-bullet-list-wrapper i, .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-blur:hover .elementor-repeater-item-b038387 .premium-bullet-list-wrapper svg{text-shadow:0 0 3px #000000;}.elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-b038387.premium-bullet-list-content:hover .premium-bullet-list-wrapper i{color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-b038387.premium-bullet-list-content:hover .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-b038387.premium-bullet-list-content:hover svg:not([class*="premium-"]){fill:var( --e-global-color-2f9b81c2 );stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-blur .elementor-repeater-item-b038387.premium-bullet-list-content:hover .premium-bullet-list-wrapper i, .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-blur .elementor-repeater-item-b038387.premium-bullet-list-content:hover .premium-bullet-list-wrapper svg{text-shadow:var( --e-global-color-2f9b81c2 );color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-b038387.premium-bullet-list-content:hover .premium-bullet-text{color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-blur:hover .elementor-repeater-item-b038387.premium-bullet-list-content:hover .premium-bullet-text{text-shadow:var( --e-global-color-2f9b81c2 );color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-7f5faf8 .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-7f5faf8 svg:not([class*="premium-"]){stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-7f5faf8.premium-bullet-list-content:hover .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-7f5faf8.premium-bullet-list-content:hover svg:not([class*="premium-"]){stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-d3fdf6e .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-d3fdf6e svg:not([class*="premium-"]){stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-d3fdf6e.premium-bullet-list-content:hover .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-e39f12b .elementor-repeater-item-d3fdf6e.premium-bullet-list-content:hover svg:not([class*="premium-"]){stroke:#61CE70;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-content{overflow:hidden;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-box {flex-direction:column;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-content, .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-box{justify-content:flex-start;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-divider, .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-wrapper-top{align-self:flex-start;}.elementor-2602 .elementor-element.elementor-element-e39f12b{--pa-bullet-align:flex-start;--pa-bullet-hv-size:35px;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-text{display:flex;flex-direction:row;order:5;}.elementor-2602 .elementor-element.elementor-element-e39f12b > .elementor-widget-container{margin:0px 0px 0px 0px;padding:5px 5px 5px 5px;}.elementor-2602 .elementor-element.elementor-element-e39f12b.bdt-cursor-effects-yes{--cursor-ball-color:#3C49366E;}.elementor-2602 .elementor-element.elementor-element-e39f12b.bdt-cursor-effects-yes .bdt-cursor-icons{font-size:32px;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-content .premium-bullet-list-text-wrapper > span{align-self:start;text-align:start;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-wrapper{align-self:center;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-badge{order:8;} .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-content{background-color:#F3EA22;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-content:hover{box-shadow:2px 2px 10px 1px rgba(0,0,0,0.5) inset;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-content {border-radius:10px 10px 10px 10px;margin:0% 0% 0% 0%;padding:1% 0% 0% 0%;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-wrapper i, .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-text p, .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-text{font-size:35px;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-wrapper svg, .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-wrapper img{width:35px !important;height:35px !important;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-wrapper i, .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-icon-text p{color:#4BC6CC;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-e39f12b svg:not([class*="premium-"]){fill:#4BC6CC;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-blur:hover .premium-bullet-list-wrapper i, .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-blur:hover .premium-bullet-list-wrapper svg, .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-blur:hover .premium-bullet-list-wrapper .premium-bullet-list-icon-text p{text-shadow:0 0 3px #4BC6CC;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-content:hover .premium-bullet-list-wrapper i, .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-content:hover .premium-bullet-list-icon-text p{color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-blur .premium-bullet-list-content:hover .premium-bullet-list-wrapper i, .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-blur .premium-bullet-list-content:hover  .premium-bullet-list-icon-text p{text-shadow:var( --e-global-color-2f9b81c2 );color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-content:hover .premium-drawable-icon *, .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-content:hover svg:not([class*="premium-"]){fill:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-wrapper {margin:5px 5px 5px 5px;} .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-text{color:#7A7A7A;} .elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-blur:hover .premium-bullet-text{text-shadow:0 0 3px #7A7A7A;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-content:hover .premium-bullet-text{color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-blur .premium-bullet-list-content:hover .premium-bullet-text{text-shadow:var( --e-global-color-2f9b81c2 );color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-text {margin:10px 10px 10px 10px;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-badge span{color:#fff;background-color:var( --e-global-color-2f9b81c2 );}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-badge span {border-radius:2px 2px 2px 2px;padding:10px 10px 10px 10px;}.elementor-2602 .elementor-element.elementor-element-e39f12b .premium-bullet-list-badge {margin:0px 0px 0px 5px;}.elementor-widget-button .elementor-button{background-color:var( --e-global-color-accent );font-family:var( --e-global-typography-accent-font-family );font-weight:var( --e-global-typography-accent-font-weight );}.elementor-2602 .elementor-element.elementor-element-98147a6 .elementor-button{background-color:#F3EA22;fill:#000000;color:#000000;}.elementor-2602 .elementor-element.elementor-element-98147a6 .elementor-button-content-wrapper{flex-direction:row;}.elementor-2602 .elementor-element.elementor-element-98147a6 .elementor-button:hover, .elementor-2602 .elementor-element.elementor-element-98147a6 .elementor-button:focus{color:var( --e-global-color-primary );}.elementor-2602 .elementor-element.elementor-element-98147a6 .elementor-button:hover svg, .elementor-2602 .elementor-element.elementor-element-98147a6 .elementor-button:focus svg{fill:var( --e-global-color-primary );}.elementor-2602 .elementor-element.elementor-element-2f625f5{--divider-border-style:solid;--divider-color:#000;--divider-border-width:1px;}.elementor-2602 .elementor-element.elementor-element-2f625f5 .elementor-divider-separator{width:70%;margin:0 auto;margin-center:0;}.elementor-2602 .elementor-element.elementor-element-2f625f5 .elementor-divider{text-align:center;padding-block-start:15px;padding-block-end:15px;}.elementor-2602 .elementor-element.elementor-element-f242c5e{--spacer-size:21px;}.elementor-2602 .elementor-element.elementor-element-bea2697{--divider-border-style:solid;--divider-color:#000;--divider-border-width:1px;}.elementor-2602 .elementor-element.elementor-element-bea2697 .elementor-divider-separator{width:70%;margin:0 auto;margin-center:0;}.elementor-2602 .elementor-element.elementor-element-bea2697 .elementor-divider{text-align:center;padding-block-start:15px;padding-block-end:15px;}.elementor-2602 .elementor-element.elementor-element-d68610a{width:var( --container-widget-width, 99.861% );max-width:99.861%;--container-widget-width:99.861%;--container-widget-flex-grow:0;text-align:start;}.elementor-2602 .elementor-element.elementor-element-d68610a > .elementor-widget-container{padding:10px 10px 10px 10px;}.elementor-2602 .elementor-element.elementor-element-d68610a .elementor-heading-title{color:#4BC6CC;}.elementor-2602 .elementor-element.elementor-element-5b7cad0 .elementor-button{background-color:#F3EA22;fill:#000000;color:#000000;}.elementor-2602 .elementor-element.elementor-element-5b7cad0 .elementor-button-content-wrapper{flex-direction:row;}.elementor-2602 .elementor-element.elementor-element-5b7cad0 .elementor-button:hover, .elementor-2602 .elementor-element.elementor-element-5b7cad0 .elementor-button:focus{color:var( --e-global-color-primary );}.elementor-2602 .elementor-element.elementor-element-5b7cad0 .elementor-button:hover svg, .elementor-2602 .elementor-element.elementor-element-5b7cad0 .elementor-button:focus svg{fill:var( --e-global-color-primary );}.elementor-2602 .elementor-element.elementor-element-8357004{--divider-border-style:solid;--divider-color:#000;--divider-border-width:1px;}.elementor-2602 .elementor-element.elementor-element-8357004 .elementor-divider-separator{width:70%;margin:0 auto;margin-center:0;}.elementor-2602 .elementor-element.elementor-element-8357004 .elementor-divider{text-align:center;padding-block-start:15px;padding-block-end:15px;}.elementor-2602 .elementor-element.elementor-element-a5e43f5 > .elementor-widget-container{padding:10px 10px 10px 10px;}.elementor-2602 .elementor-element.elementor-element-a5e43f5{text-align:start;}.elementor-2602 .elementor-element.elementor-element-a5e43f5 .elementor-heading-title{color:#4BC6CC;}.elementor-widget .tippy-tooltip .tippy-content{text-align:center;}@media(max-width:1024px){.elementor-widget-table-of-contents .elementor-toc__header, .elementor-widget-table-of-contents .elementor-toc__header-title{font-size:var( --e-global-typography-primary-font-size );}.elementor-widget-table-of-contents .elementor-toc__list-item{font-size:var( --e-global-typography-text-font-size );}.elementor-widget-text-editor{font-size:var( --e-global-typography-text-font-size );}.elementor-2602 .elementor-element.elementor-element-1b89bf0{font-size:var( --e-global-typography-a0780f3-font-size );}.elementor-widget-heading .elementor-heading-title{font-size:var( --e-global-typography-primary-font-size );}.elementor-widget-image .widget-image-caption{font-size:var( --e-global-typography-text-font-size );} .elementor-widget-premium-icon-list .premium-bullet-list-icon-text p{font-size:var( --e-global-typography-text-font-size );}.elementor-widget-premium-icon-list .premium-bullet-text{font-size:var( --e-global-typography-text-font-size );}.elementor-widget-premium-icon-list .premium-bullet-list-desc{font-size:var( --e-global-typography-text-font-size );} .elementor-widget-premium-icon-list .premium-bullet-list-badge span{font-size:var( --e-global-typography-text-font-size );}}@media(max-width:767px){.elementor-widget-table-of-contents .elementor-toc__header, .elementor-widget-table-of-contents .elementor-toc__header-title{font-size:var( --e-global-typography-primary-font-size );}.elementor-widget-table-of-contents .elementor-toc__list-item{font-size:var( --e-global-typography-text-font-size );}.elementor-widget-text-editor{font-size:var( --e-global-typography-text-font-size );}.elementor-2602 .elementor-element.elementor-element-1b89bf0{font-size:var( --e-global-typography-a0780f3-font-size );}.elementor-widget-heading .elementor-heading-title{font-size:var( --e-global-typography-primary-font-size );}.elementor-widget-image .widget-image-caption{font-size:var( --e-global-typography-text-font-size );} .elementor-widget-premium-icon-list .premium-bullet-list-icon-text p{font-size:var( --e-global-typography-text-font-size );}.elementor-widget-premium-icon-list .premium-bullet-text{font-size:var( --e-global-typography-text-font-size );}.elementor-widget-premium-icon-list .premium-bullet-list-desc{font-size:var( --e-global-typography-text-font-size );} .elementor-widget-premium-icon-list .premium-bullet-list-badge span{font-size:var( --e-global-typography-text-font-size );}}
+.elementor-84 .elementor-element.elementor-element-0bce2f1:not(.elementor-motion-effects-element-type-background), .elementor-84 .elementor-element.elementor-element-0bce2f1 > .elementor-motion-effects-container > .elementor-motion-effects-layer{background-color:#71B3DD;}.elementor-84 .elementor-element.elementor-element-0bce2f1{transition:background 0.3s, border 0.3s, border-radius 0.3s, box-shadow 0.3s;}.elementor-84 .elementor-element.elementor-element-0bce2f1 > .elementor-background-overlay{transition:background 0.3s, border-radius 0.3s, opacity 0.3s;}.elementor-84 .elementor-element.elementor-element-7d2ec91:not(.elementor-motion-effects-element-type-background), .elementor-84 .elementor-element.elementor-element-7d2ec91 > .elementor-motion-effects-container > .elementor-motion-effects-layer{background-color:#FFFFFF;}.elementor-84 .elementor-element.elementor-element-7d2ec91{transition:background 0.3s, border 0.3s, border-radius 0.3s, box-shadow 0.3s;}.elementor-84 .elementor-element.elementor-element-7d2ec91 > .elementor-background-overlay{transition:background 0.3s, border-radius 0.3s, opacity 0.3s;}.elementor-widget-text-editor{font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );color:var( --e-global-color-text );}.elementor-widget-text-editor.elementor-drop-cap-view-stacked .elementor-drop-cap{background-color:var( --e-global-color-primary );}.elementor-widget-text-editor.elementor-drop-cap-view-framed .elementor-drop-cap, .elementor-widget-text-editor.elementor-drop-cap-view-default .elementor-drop-cap{color:var( --e-global-color-primary );border-color:var( --e-global-color-primary );}.elementor-84 .elementor-element.elementor-element-af241bf{text-align:center;}.elementor-84 .elementor-element.elementor-element-56599c9{text-align:end;}.elementor-84 .elementor-element.elementor-element-3c64df2{text-align:center;line-height:1px;}.elementor-84 .elementor-element.elementor-element-1f4a630{line-height:1px;}.elementor-84 .elementor-element.elementor-element-d3b8d5b{--grid-side-margin:10px;--grid-column-gap:10px;--grid-row-gap:10px;--grid-bottom-margin:10px;}.elementor-widget .tippy-tooltip .tippy-content{text-align:center;}@media(max-width:1024px){.elementor-widget-text-editor{font-size:var( --e-global-typography-text-font-size );} .elementor-84 .elementor-element.elementor-element-d3b8d5b{--grid-side-margin:10px;--grid-column-gap:10px;--grid-row-gap:10px;--grid-bottom-margin:10px;}}@media(max-width:767px){.elementor-widget-text-editor{font-size:var( --e-global-typography-text-font-size );} .elementor-84 .elementor-element.elementor-element-d3b8d5b{--grid-side-margin:10px;--grid-column-gap:10px;--grid-row-gap:10px;--grid-bottom-margin:10px;}}/* Start custom CSS for text-editor, class: .elementor-element-b09b630 */.elementor-84 .elementor-element.elementor-element-b09b630{
+    display: none
+}/* End custom CSS */
+.elementor-3066 .elementor-element.elementor-element-4ae43af:not(.elementor-motion-effects-element-type-background), .elementor-3066 .elementor-element.elementor-element-4ae43af > .elementor-motion-effects-container > .elementor-motion-effects-layer{background-color:#FFFFFF;}.elementor-3066 .elementor-element.elementor-element-4ae43af{transition:background 0.3s, border 0.3s, border-radius 0.3s, box-shadow 0.3s;}.elementor-3066 .elementor-element.elementor-element-4ae43af > .elementor-background-overlay{transition:background 0.3s, border-radius 0.3s, opacity 0.3s;}.elementor-bc-flex-widget .elementor-3066 .elementor-element.elementor-element-6aa8cd0.elementor-column .elementor-widget-wrap{align-items:center;}.elementor-3066 .elementor-element.elementor-element-6aa8cd0.elementor-column.elementor-element[data-element_type="column"] > .elementor-widget-wrap.elementor-element-populated{align-content:center;align-items:center;}.elementor-widget-theme-site-logo .widget-image-caption{color:var( --e-global-color-text );font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );}.elementor-widget-nav-menu .elementor-nav-menu .elementor-item{font-family:var( --e-global-typography-primary-font-family );font-size:var( --e-global-typography-primary-font-size );font-weight:var( --e-global-typography-primary-font-weight );}.elementor-widget-nav-menu .elementor-nav-menu--main .elementor-item{color:var( --e-global-color-text );fill:var( --e-global-color-text );}.elementor-widget-nav-menu .elementor-nav-menu--main .elementor-item:hover,
+					.elementor-widget-nav-menu .elementor-nav-menu--main .elementor-item.elementor-item-active,
+					.elementor-widget-nav-menu .elementor-nav-menu--main .elementor-item.highlighted,
+					.elementor-widget-nav-menu .elementor-nav-menu--main .elementor-item:focus{color:var( --e-global-color-accent );fill:var( --e-global-color-accent );}.elementor-widget-nav-menu .elementor-nav-menu--main:not(.e--pointer-framed) .elementor-item:before,
+					.elementor-widget-nav-menu .elementor-nav-menu--main:not(.e--pointer-framed) .elementor-item:after{background-color:var( --e-global-color-accent );}.elementor-widget-nav-menu .e--pointer-framed .elementor-item:before,
+					.elementor-widget-nav-menu .e--pointer-framed .elementor-item:after{border-color:var( --e-global-color-accent );}.elementor-widget-nav-menu{--e-nav-menu-divider-color:var( --e-global-color-text );}.elementor-widget-nav-menu .elementor-nav-menu--dropdown .elementor-item, .elementor-widget-nav-menu .elementor-nav-menu--dropdown  .elementor-sub-item{font-family:var( --e-global-typography-accent-font-family );font-weight:var( --e-global-typography-accent-font-weight );}.elementor-3066 .elementor-element.elementor-element-6f22f64{--ecs-nav-main-display:flex;--ecs-nav-main-dir:row;--ecs-nav-toggle-display:none;}.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-menu-toggle{margin-left:auto;}.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--main,
+					 .elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--main .elementor-nav-menu{justify-content:right;}.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--dropdown .elementor-item,
+					 .elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--dropdown .elementor-sub-item{justify-content:flex-start;}.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu .elementor-item{font-family:var( --e-global-typography-145f6eb-font-family );font-size:var( --e-global-typography-145f6eb-font-size );font-weight:var( --e-global-typography-145f6eb-font-weight );text-transform:var( --e-global-typography-145f6eb-text-transform );line-height:var( --e-global-typography-145f6eb-line-height );}.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--main .elementor-item{color:var( --e-global-color-secondary );fill:var( --e-global-color-secondary );}.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--main .elementor-item:hover,
+					.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--main .elementor-item.elementor-item-active,
+					.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--main .elementor-item.highlighted,
+					.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--main .elementor-item:focus{color:var( --e-global-color-primary );fill:var( --e-global-color-primary );}.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--main:not(.e--pointer-framed) .elementor-item:before,
+					.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--main:not(.e--pointer-framed) .elementor-item:after{background-color:var( --e-global-color-primary );}.elementor-3066 .elementor-element.elementor-element-6f22f64 .e--pointer-framed .elementor-item:before,
+					.elementor-3066 .elementor-element.elementor-element-6f22f64 .e--pointer-framed .elementor-item:after{border-color:var( --e-global-color-primary );}.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--dropdown a:hover,
+					.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--dropdown a:focus,
+					.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--dropdown a.elementor-item-active,
+					.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu--dropdown a.highlighted{background-color:var( --e-global-color-primary );}.elementor-theme-builder-content-area{height:400px;}.elementor-location-header:before, .elementor-location-footer:before{content:"";display:table;clear:both;}.elementor-widget .tippy-tooltip .tippy-content{text-align:center;}@media(max-width:1024px){.elementor-widget-theme-site-logo .widget-image-caption{font-size:var( --e-global-typography-text-font-size );}.elementor-bc-flex-widget .elementor-3066 .elementor-element.elementor-element-d16d5b9.elementor-column .elementor-widget-wrap{align-items:center;}.elementor-3066 .elementor-element.elementor-element-d16d5b9.elementor-column.elementor-element[data-element_type="column"] > .elementor-widget-wrap.elementor-element-populated{align-content:center;align-items:center;}.elementor-widget-nav-menu .elementor-nav-menu .elementor-item{font-size:var( --e-global-typography-primary-font-size );}.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu .elementor-item{font-size:var( --e-global-typography-145f6eb-font-size );line-height:var( --e-global-typography-145f6eb-line-height );}}@media(min-width:768px){.elementor-3066 .elementor-element.elementor-element-6aa8cd0{width:20%;}.elementor-3066 .elementor-element.elementor-element-d16d5b9{width:80%;}}@media(max-width:1024px) and (min-width:768px){.elementor-3066 .elementor-element.elementor-element-6aa8cd0{width:70%;}.elementor-3066 .elementor-element.elementor-element-d16d5b9{width:30%;}}@media(max-width:767px){.elementor-3066 .elementor-element.elementor-element-4ae43af{margin-top:0px;margin-bottom:0px;}.elementor-3066 .elementor-element.elementor-element-6aa8cd0{width:70%;}.elementor-widget-theme-site-logo .widget-image-caption{font-size:var( --e-global-typography-text-font-size );}.elementor-3066 .elementor-element.elementor-element-d16d5b9{width:30%;}.elementor-widget-nav-menu .elementor-nav-menu .elementor-item{font-size:var( --e-global-typography-primary-font-size );}.elementor-3066 .elementor-element.elementor-element-6f22f64 .elementor-nav-menu .elementor-item{font-size:var( --e-global-typography-145f6eb-font-size );line-height:var( --e-global-typography-145f6eb-line-height );}}
+.elementor-1652 .elementor-element.elementor-element-4267988 > .elementor-background-overlay{background-color:#000000;opacity:0.5;transition:background 0.3s, border-radius 0.3s, opacity 0.3s;}.elementor-1652 .elementor-element.elementor-element-4267988:not(.elementor-motion-effects-element-type-background), .elementor-1652 .elementor-element.elementor-element-4267988 > .elementor-motion-effects-container > .elementor-motion-effects-layer{background-position:center center;background-repeat:no-repeat;background-size:cover;}.elementor-1652 .elementor-element.elementor-element-4267988{transition:background 0.3s, border 0.3s, border-radius 0.3s, box-shadow 0.3s;}.elementor-1652 .elementor-element.elementor-element-bf6b25d > .elementor-element-populated >  .elementor-background-overlay{opacity:0.4;}.elementor-1652 .elementor-element.elementor-element-bf6b25d > .elementor-element-populated{transition:background 0.3s, border 0.3s, border-radius 0.3s, box-shadow 0.3s;}.elementor-1652 .elementor-element.elementor-element-bf6b25d > .elementor-element-populated > .elementor-background-overlay{transition:background 0.3s, border-radius 0.3s, opacity 0.3s;}.elementor-widget-theme-post-title .elementor-heading-title{font-family:var( --e-global-typography-primary-font-family );font-size:var( --e-global-typography-primary-font-size );font-weight:var( --e-global-typography-primary-font-weight );color:var( --e-global-color-primary );}.elementor-1652 .elementor-element.elementor-element-3bb916a > .elementor-widget-container{padding:200px 0px 200px 0px;}.elementor-1652 .elementor-element.elementor-element-3bb916a .elementor-heading-title{font-family:var( --e-global-typography-0973104-font-family );font-size:var( --e-global-typography-0973104-font-size );font-weight:var( --e-global-typography-0973104-font-weight );line-height:var( --e-global-typography-0973104-line-height );letter-spacing:var( --e-global-typography-0973104-letter-spacing );color:#FFFFFF;}.elementor-1652 .elementor-element.elementor-element-8f24a97{--spacer-size:50px;}.elementor-widget-breadcrumbs{font-family:var( --e-global-typography-secondary-font-family );font-weight:var( --e-global-typography-secondary-font-weight );}.elementor-1652 .elementor-element.elementor-element-1ac0b07 a{color:var( --e-global-color-2f9b81c2 );}.elementor-1652 .elementor-element.elementor-element-1ac0b07 a:hover{color:var( --e-global-color-secondary );}.elementor-widget-theme-post-content{color:var( --e-global-color-text );font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );}.elementor-1652 .elementor-element.elementor-element-1759035{font-family:"Fira Sans";font-size:20px;font-weight:300;}.elementor-widget-heading .elementor-heading-title{font-family:var( --e-global-typography-primary-font-family );font-size:var( --e-global-typography-primary-font-size );font-weight:var( --e-global-typography-primary-font-weight );color:var( --e-global-color-primary );}.elementor-1652 .elementor-element.elementor-element-600dc0a .elementor-heading-title{font-family:"Roboto";font-weight:600;color:var( --e-global-color-2f9b81c2 );}.elementor-1652 .elementor-element.elementor-element-3f60b13{--grid-side-margin:10px;--grid-column-gap:10px;--grid-row-gap:10px;--grid-bottom-margin:10px;--e-share-buttons-primary-color:var( --e-global-color-499a20e2 );}.elementor-1652 .elementor-element.elementor-element-3f60b13 .elementor-share-btn:hover{--e-share-buttons-primary-color:var( --e-global-color-2f9b81c2 );}.elementor-1652 .elementor-element.elementor-element-be9648f{--spacer-size:50px;}.elementor-widget-author-box .elementor-author-box__name{color:var( --e-global-color-secondary );font-family:var( --e-global-typography-primary-font-family );font-size:var( --e-global-typography-primary-font-size );font-weight:var( --e-global-typography-primary-font-weight );}.elementor-widget-author-box .elementor-author-box__bio{color:var( --e-global-color-text );font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );}.elementor-widget-author-box .elementor-author-box__button{color:var( --e-global-color-secondary );border-color:var( --e-global-color-secondary );font-family:var( --e-global-typography-accent-font-family );font-weight:var( --e-global-typography-accent-font-weight );}.elementor-widget-author-box .elementor-author-box__button:hover{border-color:var( --e-global-color-secondary );color:var( --e-global-color-secondary );}.elementor-1652 .elementor-element.elementor-element-cb471a9 .elementor-author-box__name{color:var( --e-global-color-text );font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );}.elementor-1652 .elementor-element.elementor-element-cb471a9 .elementor-author-box__bio{font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );}.elementor-1652 .elementor-element.elementor-element-cb471a9 .elementor-author-box__button{font-family:"Fira Sans";font-size:14px;font-weight:300;}.elementor-1652 .elementor-element.elementor-element-d948218 .elementor-heading-title{font-family:"Roboto";font-weight:600;color:var( --e-global-color-2f9b81c2 );}.elementor-widget-post-info .elementor-icon-list-item:not(:last-child):after{border-color:var( --e-global-color-text );}.elementor-widget-post-info .elementor-icon-list-icon i{color:var( --e-global-color-primary );}.elementor-widget-post-info .elementor-icon-list-icon svg{fill:var( --e-global-color-primary );}.elementor-widget-post-info .elementor-icon-list-text, .elementor-widget-post-info .elementor-icon-list-text a{color:var( --e-global-color-secondary );}.elementor-widget-post-info .elementor-icon-list-item{font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );}.elementor-1652 .elementor-element.elementor-element-5b6b8fa .elementor-icon-list-icon i{color:var( --e-global-color-2f9b81c2 );font-size:14px;}.elementor-1652 .elementor-element.elementor-element-5b6b8fa .elementor-icon-list-icon svg{fill:var( --e-global-color-2f9b81c2 );--e-icon-list-icon-size:14px;}.elementor-1652 .elementor-element.elementor-element-5b6b8fa .elementor-icon-list-icon{width:14px;}.elementor-1652 .elementor-element.elementor-element-d02db7c .elementor-heading-title{color:var( --e-global-color-2f9b81c2 );}.elementor-widget-posts .elementor-button{background-color:var( --e-global-color-accent );font-family:var( --e-global-typography-accent-font-family );font-weight:var( --e-global-typography-accent-font-weight );}.elementor-widget-posts .elementor-post__title, .elementor-widget-posts .elementor-post__title a{color:var( --e-global-color-secondary );font-family:var( --e-global-typography-primary-font-family );font-size:var( --e-global-typography-primary-font-size );font-weight:var( --e-global-typography-primary-font-weight );}.elementor-widget-posts .elementor-post__meta-data{font-family:var( --e-global-typography-secondary-font-family );font-weight:var( --e-global-typography-secondary-font-weight );}.elementor-widget-posts .elementor-post__excerpt p{font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );}.elementor-widget-posts .elementor-post__read-more{color:var( --e-global-color-accent );}.elementor-widget-posts a.elementor-post__read-more{font-family:var( --e-global-typography-accent-font-family );font-weight:var( --e-global-typography-accent-font-weight );}.elementor-widget-posts .elementor-post__card .elementor-post__badge{background-color:var( --e-global-color-accent );font-family:var( --e-global-typography-accent-font-family );font-weight:var( --e-global-typography-accent-font-weight );}.elementor-widget-posts .elementor-pagination{font-family:var( --e-global-typography-secondary-font-family );font-weight:var( --e-global-typography-secondary-font-weight );}.elementor-widget-posts .ecs-load-more-button .elementor-button{font-family:var( --e-global-typography-accent-font-family );font-weight:var( --e-global-typography-accent-font-weight );background-color:var( --e-global-color-accent );}.elementor-widget-posts .e-load-more-message{font-family:var( --e-global-typography-secondary-font-family );font-weight:var( --e-global-typography-secondary-font-weight );}.elementor-1652 .elementor-element.elementor-element-74aa43a{--grid-row-gap:35px;--grid-column-gap:30px;}.elementor-widget-post-navigation span.post-navigation__prev--label{color:var( --e-global-color-text );}.elementor-widget-post-navigation span.post-navigation__next--label{color:var( --e-global-color-text );}.elementor-widget-post-navigation span.post-navigation__prev--label, .elementor-widget-post-navigation span.post-navigation__next--label{font-family:var( --e-global-typography-secondary-font-family );font-weight:var( --e-global-typography-secondary-font-weight );}.elementor-widget-post-navigation span.post-navigation__prev--title, .elementor-widget-post-navigation span.post-navigation__next--title{color:var( --e-global-color-secondary );font-family:var( --e-global-typography-secondary-font-family );font-weight:var( --e-global-typography-secondary-font-weight );}.elementor-1652 .elementor-element.elementor-element-2c55acf span.post-navigation__prev--label, .elementor-1652 .elementor-element.elementor-element-2c55acf span.post-navigation__next--label{font-family:"Fira Sans";font-weight:400;}.elementor-1652 .elementor-element.elementor-element-2c55acf span.post-navigation__prev--title, .elementor-1652 .elementor-element.elementor-element-2c55acf span.post-navigation__next--title{font-family:"Fira Sans";font-weight:400;}.elementor-1652 .elementor-element.elementor-element-2c55acf .post-navigation__arrow-wrapper{font-size:15px;}.elementor-1652 .elementor-element.elementor-element-8b295f5{--spacer-size:50px;}.elementor-widget .tippy-tooltip .tippy-content{text-align:center;}@media(min-width:1025px){.elementor-1652 .elementor-element.elementor-element-4267988:not(.elementor-motion-effects-element-type-background), .elementor-1652 .elementor-element.elementor-element-4267988 > .elementor-motion-effects-container > .elementor-motion-effects-layer{background-attachment:fixed;}}@media(max-width:1024px){.elementor-widget-theme-post-title .elementor-heading-title{font-size:var( --e-global-typography-primary-font-size );}.elementor-1652 .elementor-element.elementor-element-3bb916a .elementor-heading-title{font-size:var( --e-global-typography-0973104-font-size );line-height:var( --e-global-typography-0973104-line-height );letter-spacing:var( --e-global-typography-0973104-letter-spacing );}.elementor-widget-theme-post-content{font-size:var( --e-global-typography-text-font-size );}.elementor-widget-heading .elementor-heading-title{font-size:var( --e-global-typography-primary-font-size );} .elementor-1652 .elementor-element.elementor-element-3f60b13{--grid-side-margin:10px;--grid-column-gap:10px;--grid-row-gap:10px;--grid-bottom-margin:10px;}.elementor-widget-author-box .elementor-author-box__name{font-size:var( --e-global-typography-primary-font-size );}.elementor-widget-author-box .elementor-author-box__bio{font-size:var( --e-global-typography-text-font-size );}.elementor-1652 .elementor-element.elementor-element-cb471a9 .elementor-author-box__name{font-size:var( --e-global-typography-text-font-size );}.elementor-1652 .elementor-element.elementor-element-cb471a9 .elementor-author-box__bio{font-size:var( --e-global-typography-text-font-size );}.elementor-widget-post-info .elementor-icon-list-item{font-size:var( --e-global-typography-text-font-size );}.elementor-widget-posts .elementor-post__title, .elementor-widget-posts .elementor-post__title a{font-size:var( --e-global-typography-primary-font-size );}.elementor-widget-posts .elementor-post__excerpt p{font-size:var( --e-global-typography-text-font-size );}}@media(max-width:767px){.elementor-widget-theme-post-title .elementor-heading-title{font-size:var( --e-global-typography-primary-font-size );}.elementor-1652 .elementor-element.elementor-element-3bb916a .elementor-heading-title{font-size:var( --e-global-typography-0973104-font-size );line-height:var( --e-global-typography-0973104-line-height );letter-spacing:var( --e-global-typography-0973104-letter-spacing );}.elementor-widget-theme-post-content{font-size:var( --e-global-typography-text-font-size );}.elementor-widget-heading .elementor-heading-title{font-size:var( --e-global-typography-primary-font-size );} .elementor-1652 .elementor-element.elementor-element-3f60b13{--grid-side-margin:10px;--grid-column-gap:10px;--grid-row-gap:10px;--grid-bottom-margin:10px;}.elementor-widget-author-box .elementor-author-box__name{font-size:var( --e-global-typography-primary-font-size );}.elementor-widget-author-box .elementor-author-box__bio{font-size:var( --e-global-typography-text-font-size );}.elementor-1652 .elementor-element.elementor-element-cb471a9 .elementor-author-box__name{font-size:var( --e-global-typography-text-font-size );}.elementor-1652 .elementor-element.elementor-element-cb471a9 .elementor-author-box__bio{font-size:var( --e-global-typography-text-font-size );}.elementor-widget-post-info .elementor-icon-list-item{font-size:var( --e-global-typography-text-font-size );}.elementor-widget-posts .elementor-post__title, .elementor-widget-posts .elementor-post__title a{font-size:var( --e-global-typography-primary-font-size );}.elementor-widget-posts .elementor-post__excerpt p{font-size:var( --e-global-typography-text-font-size );}}/* Start custom CSS for author-box, class: .elementor-element-cb471a9 */.elementor-1652 .elementor-element.elementor-element-cb471a9 .elementor-author-box__bio a{
+    font-family: "Fira Sans"!important;
+    color: var(--blue);
+}
+.elementor-1652 .elementor-element.elementor-element-cb471a9 .elementor-author-box__bio a:hover{
+    color: var(--blue);
+    text-decoration: underline;
+}
+.elementor-1652 .elementor-element.elementor-element-cb471a9 h4{
+    font-weight: bold!important;
+}/* End custom CSS */
+/* Start custom CSS for shortcode, class: .elementor-element-e653ddd */.elementor-1652 .elementor-element.elementor-element-e653ddd .elementor-share-btn__icon {
+    background-image: unset !important;
+}/* End custom CSS */
+/* Start custom CSS for posts, class: .elementor-element-74aa43a */.elementor-1652 .elementor-element.elementor-element-74aa43a .elementor-invisible {
+    visibility: unset !important;
+}
+.elementor-1652 .elementor-element.elementor-element-74aa43a .swiper-container:not(.swiper-container-initialized)>.swiper-wrapper, 
+.elementor-1652 .elementor-element.elementor-element-74aa43a .swiper:not(.swiper-initialized)>.swiper-wrapper {
+   overflow: unset !important;
+}
+
+.elementor-1652 .elementor-element.elementor-element-74aa43a {
+   overflow: hidden !important;
+}/* End custom CSS */
+.elementor-1652 .elementor-element.elementor-element-4267988:not(.elementor-motion-effects-element-type-background), .elementor-1652 .elementor-element.elementor-element-4267988 > .elementor-motion-effects-container > .elementor-motion-effects-layer{background-image:url("https://workfromgreece.gr/wp-content/uploads/2023/05/How-to-get-a-Digital-Nomad-Visa-for-Greece.jpg");}
+/*# sourceURL=elementor-frontend-inline-css */
+</style>
+<link rel='stylesheet' id='font-awesome-5-all-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/font-awesome/css/all.min.css?ver=4.11.77' media='all' />
+<link rel='stylesheet' id='font-awesome-4-shim-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/font-awesome/css/v4-shims.min.css?ver=4.0.9' media='all' />
+<link rel='stylesheet' id='widget-table-of-contents-css' href='https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/css/widget-table-of-contents.min.css?ver=4.0.2' media='all' />
+<link rel='stylesheet' id='widget-divider-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/css/widget-divider.min.css?ver=4.0.9' media='all' />
+<link rel='stylesheet' id='widget-heading-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/css/widget-heading.min.css?ver=4.0.9' media='all' />
+<link rel='stylesheet' id='widget-image-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/css/widget-image.min.css?ver=4.0.9' media='all' />
+<link rel='stylesheet' id='pa-glass-css' href='https://workfromgreece.gr/wp-content/plugins/premium-addons-for-elementor/assets/frontend/min-css/liquid-glass.min.css?ver=4.11.77' media='all' />
+<link rel='stylesheet' id='widget-spacer-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/css/widget-spacer.min.css?ver=4.0.9' media='all' />
+<link rel='stylesheet' id='ecs-color-scheme-css' href='https://workfromgreece.gr/wp-content/plugins/ele-custom-skin/modules/color-scheme/assets/css/ecs-color-scheme.css?ver=4.3.1' media='all' />
+<link rel='stylesheet' id='ecs-container-layout-css' href='https://workfromgreece.gr/wp-content/plugins/ele-custom-skin/modules/container-layout/assets/css/ecs-container-layout.css?ver=4.3.1' media='all' />
+<link rel='stylesheet' id='swiper-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/swiper/v8/css/swiper.min.css?ver=8.4.5' media='all' />
+<link rel='stylesheet' id='e-swiper-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/css/conditionals/e-swiper.min.css?ver=4.0.9' media='all' />
+<link rel='stylesheet' id='ecs-mobile-menu-css' href='https://workfromgreece.gr/wp-content/plugins/ele-custom-skin/modules/mobile-menu/assets/css/ecs-mobile-menu.css?ver=4.3.1' media='all' />
+<link rel='stylesheet' id='ecs-editorial-text-css' href='https://workfromgreece.gr/wp-content/plugins/ele-custom-skin/modules/editorial-text/assets/css/ecs-editorial-text.css?ver=4.3.1' media='all' />
+<link rel='stylesheet' id='ecs-scheme-selector-css' href='https://workfromgreece.gr/wp-content/plugins/ele-custom-skin-pro/assets/css/ecs-scheme-selector.css?ver=4.2.1' media='all' />
+<link rel='stylesheet' id='widget-nav-menu-css' href='https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/css/widget-nav-menu.min.css?ver=4.0.2' media='all' />
+<link rel='stylesheet' id='widget-breadcrumbs-css' href='https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/css/widget-breadcrumbs.min.css?ver=4.0.2' media='all' />
+<link rel='stylesheet' id='widget-share-buttons-css' href='https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/css/widget-share-buttons.min.css?ver=4.0.2' media='all' />
+<link rel='stylesheet' id='e-apple-webkit-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/css/conditionals/apple-webkit.min.css?ver=4.0.9' media='all' />
+<link rel='stylesheet' id='elementor-icons-shared-0-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/font-awesome/css/fontawesome.min.css?ver=5.15.3' media='all' />
+<link rel='stylesheet' id='elementor-icons-fa-solid-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/font-awesome/css/solid.min.css?ver=5.15.3' media='all' />
+<link rel='stylesheet' id='elementor-icons-fa-brands-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/font-awesome/css/brands.min.css?ver=5.15.3' media='all' />
+<link rel='stylesheet' id='widget-author-box-css' href='https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/css/widget-author-box.min.css?ver=4.0.2' media='all' />
+<link rel='stylesheet' id='widget-post-info-css' href='https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/css/widget-post-info.min.css?ver=4.0.2' media='all' />
+<link rel='stylesheet' id='widget-icon-list-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/css/widget-icon-list.min.css?ver=4.0.9' media='all' />
+<link rel='stylesheet' id='elementor-icons-fa-regular-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/font-awesome/css/regular.min.css?ver=5.15.3' media='all' />
+<link rel='stylesheet' id='widget-posts-css' href='https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/css/widget-posts.min.css?ver=4.0.2' media='all' />
+<link rel='stylesheet' id='widget-post-navigation-css' href='https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/css/widget-post-navigation.min.css?ver=4.0.2' media='all' />
+<link rel='stylesheet' id='qcld-wp-chatbot-common-style-css' href='https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/css/common-style.css?ver=15.4.1' media='screen' />
+<style id="qcld-wp-chatbot-common-style-inline-css">
+#wp-chatbot-board-container > .wp-chatbot-header{
+                    background: #4bc6cc;
+                }
+            #wp-chatbot-messages-container > li.wp-chatbot-msg > .wp-chatbot-paragraph,
+                #wp-chatbot-messages-container > li.wp-chatbot-msg > span{
+                    font-family: 'Alata';
+                    font-weight: 400;
+                    font-style: normal;
+                }
+                 
+                #wp-chatbot-messages-container > li.wp-chat-user-msg > .wp-chatbot-paragraph{
+                    font-family: 'Alata';
+                    font-weight: 400;
+                    font-style: normal;
+                }
+                
+            #wp-chatbot-messages-container > li.wp-chatbot-msg > .wp-chatbot-paragraph,
+            ul.wp-chatbot-messages-container > li.wp-chat-user-msg .wp-chatbot-paragraph,
+                #wp-chatbot-messages-container > li.wp-chatbot-msg > span{
+                    font-size: 16px;
+                }
+                
+                #wp-chatbot-chat-container, .wp-chatbot-product-description, .wp-chatbot-product-description p,.wp-chatbot-product-quantity label, .wp-chatbot-product-variable label {
+                    color: #000000 !important;
+                }
+                #wp-chatbot-chat-container a {
+                    color: #4bc6cc !important;
+                }
+                #wp-chatbot-chat-container a:hover {
+                    color: #444444 !important;
+                }
+                
+                ul.wp-chatbot-messages-container > li.wp-chatbot-msg .wp-chatbot-paragraph,
+                .wp-chatbot-agent-profile .wp-chatbot-bubble {
+                    color: #000000 !important;
+                    background: #f3ea23 !important;
+                    word-break: break-word;
+                }
+                span.qcld-chatbot-product-category,div.qcld_new_start_button,div.qcld_new_start_button span,div.qcld_new_start_button .qcld-chatbot-site-search, div.qcld_new_start_button .qcld-chatbot-custom-intent, span.qcld-chatbot-support-items, span.qcld-chatbot-wildcard, span.qcld-chatbot-suggest-email, span.qcld-chatbot-reset-btn, #woo-chatbot-loadmore, .wp-chatbot-shortcode-template-container span.qcld-chatbot-product-category, .wp-chatbot-shortcode-template-container span.qcld-chatbot-support-items, .wp-chatbot-shortcode-template-container span.qcld-chatbot-wildcard, .wp-chatbot-shortcode-template-container span.wp-chatbot-card-button, .wp-chatbot-shortcode-template-container span.qcld-chatbot-suggest-email, span.qcld-chatbot-suggest-phone, .wp-chatbot-shortcode-template-container span.qcld-chatbot-reset-btn, .wp-chatbot-shortcode-template-container #wp-chatbot-loadmore, .id="wp-chatbot-chat-container"-cart-items, .wpbd_subscription, .qcld-chatbot-site-search, .qcld_subscribe_confirm, .qcld-chat-common, .qcld-chatbot-custom-intent {
+                    color: #ffffff !important;
+                    background: #4bc6cc !important;
+                    background-image: none !important;
+                    border: solid  #4bc6cc !important;
+                }
+
+                span.qcld-chatbot-product-category:hover, span.qcld-chatbot-support-items:hover, span.qcld-chatbot-wildcard:hover, span.qcld-chatbot-suggest-email:hover, span.qcld-chatbot-reset-btn:hover, #woo-chatbot-loadmore:hover, .wp-chatbot-shortcode-template-container:hover span.qcld-chatbot-product-category:hover, .wp-chatbot-shortcode-template-container:hover span.qcld-chatbot-support-items:hover, .wp-chatbot-shortcode-template-container:hover span.qcld-chatbot-wildcard:hover, .wp-chatbot-shortcode-template-container:hover span.wp-chatbot-card-button:hover, .wp-chatbot-shortcode-template-container:hover span.qcld-chatbot-suggest-email:hover, span.qcld-chatbot-suggest-phone:hover, .wp-chatbot-shortcode-template-container:hover span.qcld-chatbot-reset-btn:hover, .wp-chatbot-shortcode-template-container:hover #wp-chatbot-loadmore:hover, .wp-chatbot-ball-cart-items:hover, .wpbd_subscription:hover, .qcld-chatbot-site-search:hover, .qcld_subscribe_confirm:hover, .qcld-chat-common:hover, .qcld-chatbot-custom-intent:hover {
+                    color: #000000 !important;
+                    background: #f3ea23 !important;
+                background-image: none !important;
+                }
+
+                li.wp-chat-user-msg .wp-chatbot-paragraph {
+                    color: #000000 !important;
+                    background: #b5b5b5 !important;
+                }
+                ul.wp-chatbot-messages-container > li.wp-chatbot-msg > .wp-chatbot-paragraph:before,
+                .wp-chatbot-bubble:before {
+                    border-right: 10px solid #f3ea23 !important;
+
+                }
+                ul.wp-chatbot-messages-container > li.wp-chat-user-msg > .wp-chatbot-paragraph:before {
+                    border-left: 10px solid #b5b5b5 !important;
+                }
+            .wp-chatbot-ball{
+                background: #f3ea23 !important;
+            }
+            .wp-chatbot-ball:hover, .wp-chatbot-ball:focus{
+                background: #f3ea23 !important;
+            }
+            .qc_wpbot_floating_main{
+                background-color: #f3ea23 !important;
+            }
+            .qc_wpbot_floating_main:hover, .qc_wpbot_floating_main:focus{
+                background-color: #f3ea23 !important;
+            }
+             #wp-chatbot-ball-container,#wp-chatbot-board-container,.wp-chatbot-start-screen,.slimScrollDiv,.wp-chatbot-start-container, {
+                max-height: 650px !important;
+            }
+            .wp-chatbot-content {
+                max-height: 600px !important;
+            }
+/*# sourceURL=qcld-wp-chatbot-common-style-inline-css */
+</style>
+<link rel='stylesheet' id='qcld-wp-chatbot-frontend-style-css' href='https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/css/frontend-style.css?ver=15.4.1' media='screen' />
+<link rel='stylesheet' id='qcld-wp-chatbot-datetime-style-css' href='https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/css/jquery.datetimepicker.min.css?ver=15.4.1' media='screen' />
+<link rel='stylesheet' id='jquery-ui-css-css' href='https://code.jquery.com/ui/1.13.2/themes/smoothness/jquery-ui.css?ver=7.0' media='all' />
+<link rel='stylesheet' id='qcld-chatbot-user-google-fonts-css' href='https://fonts.googleapis.com/css2?family=Alata&#038;ver=7.0' media='all' />
+<link rel='stylesheet' id='qcld-chatbot-bot-google-fonts-css' href='https://fonts.googleapis.com/css2?family=Alata&#038;ver=7.0' media='all' />
+<link rel='stylesheet' id='qcld-wp-chatbot-magnifict-qcpopup-css-css' href='https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/css/magnific-popup.css?ver=15.4.1' media='screen' />
+<link rel='stylesheet' id='qlcd-wp-chatbot-font-awe-css' href='https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/css/font-awesome.min.css?ver=15.4.1' media='screen' />
+<link rel='stylesheet' id='qlcd-wp-chatbot-ani-mate-css' href='https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/css/animate.css?ver=15.4.1' media='screen' />
+<link rel='stylesheet' id='nomads-theme-css-core-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/style.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='nomads-theme-css-homepage-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/css/homepage.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='nomads-theme-css-template-parts-header-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/css/template-parts/header.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='nomads-theme-css-template-parts-footer-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/css/template-parts/footer.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='nomads-theme-css-template-parts-banner-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/css/template-parts/banner.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='nomads-theme-css-template-parts-media_cover-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/css/template-parts/media_cover.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='nomads-theme-css-template-parts-testimonials-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/css/template-parts/testimonials.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='nomads-theme-css-homepage-mobile-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/css/homepage.mobile.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='nomads-theme-css-contact-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/css/page-contact.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='nomads-theme-css-contact-mobile-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/css/page-contact.mobile.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='nomads-theme-css-archive-faq-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/css/archive-faq.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='nomads-theme-css-archive-benefit-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/css/archive-benefit.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='nomads-theme-css-archive-location-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/css/archive-location.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='nomads-theme-css-single-location-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/css/single-location.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='animate-css-lib-css-css' href='https://workfromgreece.gr/wp-content/themes/work-from-greece/assets/libs/animate.css/animate.min.css?ver=1.0.9' media='all' />
+<link rel='stylesheet' id='swiper-lib-css-css' href='https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css?ver=1.0.9' media='all' />
+<style id="elementor-pro-custom-fonts-inline-css">
+@font-face {
+	font-family: 'Burford Rustic';
+	font-style: normal;
+	font-weight: normal;
+	font-display: auto;
+	src: url('https://workfromgreece.gr/wp-content/uploads/2023/10/burford.ttf') format('truetype');
+}
+
+/*# sourceURL=elementor-pro-custom-fonts-inline-css */
+</style>
+<link rel='stylesheet' id='hfe-elementor-icons-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/eicons/css/elementor-icons.min.css?ver=5.34.0' media='all' />
+<link rel='stylesheet' id='hfe-icons-list-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/css/widget-icon-list.min.css?ver=3.24.3' media='all' />
+<link rel='stylesheet' id='hfe-social-icons-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/css/widget-social-icons.min.css?ver=3.24.0' media='all' />
+<link rel='stylesheet' id='hfe-social-share-icons-brands-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/font-awesome/css/brands.css?ver=5.15.3' media='all' />
+<link rel='stylesheet' id='hfe-social-share-icons-fontawesome-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/font-awesome/css/fontawesome.css?ver=5.15.3' media='all' />
+<link rel='stylesheet' id='hfe-nav-menu-icons-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/font-awesome/css/solid.css?ver=5.15.3' media='all' />
+<link rel='stylesheet' id='hfe-widget-blockquote-css' href='https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/css/widget-blockquote.min.css?ver=3.25.0' media='all' />
+<link rel='stylesheet' id='hfe-mega-menu-css' href='https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/css/widget-mega-menu.min.css?ver=3.26.2' media='all' />
+<link rel='stylesheet' id='hfe-nav-menu-widget-css' href='https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/css/widget-nav-menu.min.css?ver=3.26.0' media='all' />
+<link rel='stylesheet' id='ecs-styles-css' href='https://workfromgreece.gr/wp-content/plugins/ele-custom-skin/assets/css/ecs-style.css?ver=4.3.1' media='all' />
+<link rel='stylesheet' id='elementor-gf-local-firasans-css' href='https://workfromgreece.gr/wp-content/uploads/elementor/google-fonts/css/firasans.css?ver=1742269163' media='all' />
+<link rel='stylesheet' id='elementor-gf-local-robotoslab-css' href='https://workfromgreece.gr/wp-content/uploads/elementor/google-fonts/css/robotoslab.css?ver=1742269166' media='all' />
+<link rel='stylesheet' id='elementor-gf-local-roboto-css' href='https://workfromgreece.gr/wp-content/uploads/elementor/google-fonts/css/roboto.css?ver=1742269174' media='all' />
+<script id="astra-flexibility-js" src="https://workfromgreece.gr/wp-content/themes/astra/assets/js/minified/flexibility.min.js?ver=4.12.0"></script>
+<script id="astra-flexibility-js-after">
+typeof flexibility !== "undefined" && flexibility(document.documentElement);
+//# sourceURL=astra-flexibility-js-after
+</script>
+<script id="jquery-core-js" src="https://workfromgreece.gr/wp-includes/js/jquery/jquery.min.js?ver=3.7.1"></script>
+<script id="jquery-migrate-js" src="https://workfromgreece.gr/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1"></script>
+<script id="jquery-js-after">
+!function($){"use strict";$(document).ready(function(){$(this).scrollTop()>100&&$(".hfe-scroll-to-top-wrap").removeClass("hfe-scroll-to-top-hide"),$(window).scroll(function(){$(this).scrollTop()<100?$(".hfe-scroll-to-top-wrap").fadeOut(300):$(".hfe-scroll-to-top-wrap").fadeIn(300)}),$(".hfe-scroll-to-top-wrap").on("click",function(){$("html, body").animate({scrollTop:0},300);return!1})})}(jQuery);
+!function($){'use strict';$(document).ready(function(){var bar=$('.hfe-reading-progress-bar');if(!bar.length)return;$(window).on('scroll',function(){var s=$(window).scrollTop(),d=$(document).height()-$(window).height(),p=d? s/d*100:0;bar.css('width',p+'%')});});}(jQuery);
+//# sourceURL=jquery-js-after
+</script>
+<script id="cookie-law-info-js-extra">
+var Cli_Data = {"nn_cookie_ids":["cookielawinfo-checkbox-analytics","cookielawinfo-checkbox-advertisement","cookielawinfo-checkbox-others","elementor","YSC","VISITOR_INFO1_LIVE","CONSENT","dtCookie","cookielawinfo-checkbox-functional","cookielawinfo-checkbox-performance","_ga","_gid","_gat_gtag_UA_*_1"],"cookielist":[],"non_necessary_cookies":{"necessary":["elementor"],"performance":["dtCookie"],"analytics":["CONSENT"],"advertisement":["YSC","VISITOR_INFO1_LIVE"]},"ccpaEnabled":"","ccpaRegionBased":"","ccpaBarEnabled":"","strictlyEnabled":["necessary","obligatoire"],"ccpaType":"gdpr","js_blocking":"1","custom_integration":"","triggerDomRefresh":"","secure_cookies":""};
+var cli_cookiebar_settings = {"animate_speed_hide":"500","animate_speed_show":"500","background":"#FFF","border":"#b1a6a6c2","border_on":"","button_1_button_colour":"#71b3dd","button_1_button_hover":"#5a8fb1","button_1_link_colour":"#fff","button_1_as_button":"1","button_1_new_win":"","button_2_button_colour":"#333","button_2_button_hover":"#292929","button_2_link_colour":"#71b3dd","button_2_as_button":"","button_2_hidebar":"1","button_3_button_colour":"#c1c1c1","button_3_button_hover":"#9a9a9a","button_3_link_colour":"#fff","button_3_as_button":"1","button_3_new_win":"","button_4_button_colour":"#000","button_4_button_hover":"#000000","button_4_link_colour":"#007cc3","button_4_as_button":"","button_7_button_colour":"#71b3dd","button_7_button_hover":"#5a8fb1","button_7_link_colour":"#fff","button_7_as_button":"1","button_7_new_win":"","font_family":"inherit","header_fix":"","notify_animate_hide":"1","notify_animate_show":"","notify_div_id":"#cookie-law-info-bar","notify_position_horizontal":"right","notify_position_vertical":"bottom","scroll_close":"","scroll_close_reload":"","accept_close_reload":"","reject_close_reload":"","showagain_tab":"","showagain_background":"#fff","showagain_border":"#000","showagain_div_id":"#cookie-law-info-again","showagain_x_position":"100px","text":"#000","show_once_yn":"","show_once":"10000","logging_on":"","as_popup":"","popup_overlay":"1","bar_heading_text":"","cookie_bar_as":"banner","popup_showagain_position":"bottom-right","widget_position":"left"};
+var log_object = {"ajax_url":"https://workfromgreece.gr/wp-admin/admin-ajax.php"};
+//# sourceURL=cookie-law-info-js-extra
+</script>
+<script id="cookie-law-info-js" src="https://workfromgreece.gr/wp-content/plugins/cookie-law-info/legacy/public/js/cookie-law-info-public.js?ver=3.5.0"></script>
+<script id="font-awesome-4-shim-js" src="https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/font-awesome/js/v4-shims.min.js?ver=4.0.9"></script>
+<script id="ecs_ajax_load-js-extra">
+var ecs_ajax_params = {"ajaxurl":"https://workfromgreece.gr/wp-admin/admin-ajax.php","posts":"{\"page\":0,\"category_name\":\"setting-up-in-greece\",\"error\":\"\",\"m\":\"\",\"p\":2602,\"post_parent\":\"\",\"subpost\":\"\",\"subpost_id\":\"\",\"attachment\":\"\",\"attachment_id\":0,\"pagename\":\"\",\"page_id\":\"\",\"second\":\"\",\"minute\":\"\",\"hour\":\"\",\"day\":0,\"monthnum\":0,\"year\":0,\"w\":0,\"tag\":\"\",\"cat\":\"\",\"tag_id\":\"\",\"author\":\"\",\"author_name\":\"\",\"feed\":\"\",\"tb\":\"\",\"paged\":0,\"meta_key\":\"\",\"meta_value\":\"\",\"preview\":\"\",\"s\":\"\",\"sentence\":\"\",\"title\":\"\",\"fields\":\"all\",\"menu_order\":\"\",\"embed\":\"\",\"category__in\":[],\"category__not_in\":[],\"category__and\":[],\"post__in\":[],\"post__not_in\":[],\"post_name__in\":[],\"tag__in\":[],\"tag__not_in\":[],\"tag__and\":[],\"tag_slug__in\":[],\"tag_slug__and\":[],\"post_parent__in\":[],\"post_parent__not_in\":[],\"author__in\":[],\"author__not_in\":[],\"search_columns\":[],\"name\":\"the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one\",\"ignore_sticky_posts\":false,\"suppress_filters\":false,\"cache_results\":true,\"update_post_term_cache\":true,\"update_menu_item_cache\":false,\"lazy_load_term_meta\":true,\"update_post_meta_cache\":true,\"post_type\":\"\",\"posts_per_page\":20,\"nopaging\":false,\"comments_per_page\":\"50\",\"no_found_rows\":false,\"order\":\"DESC\"}"};
+//# sourceURL=ecs_ajax_load-js-extra
+</script>
+<script id="ecs_ajax_load-js" src="https://workfromgreece.gr/wp-content/plugins/ele-custom-skin/assets/js/ecs_ajax_pagination.js?ver=4.3.1"></script>
+<script id="ecs-script-js" src="https://workfromgreece.gr/wp-content/plugins/ele-custom-skin/assets/js/ecs.js?ver=4.3.1"></script>
+<link rel="https://api.w.org/" href="https://workfromgreece.gr/wp-json/" /><link rel="alternate" title="JSON" type="application/json" href="https://workfromgreece.gr/wp-json/wp/v2/posts/2602" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://workfromgreece.gr/xmlrpc.php?rsd" />
+<meta name="generator" content="WordPress 7.0" />
+<link rel='shortlink' href='https://workfromgreece.gr/?p=2602' />
+<meta name="generator" content="WPML ver:4.9.4 stt:1;" />
+<!-- Google Tag Manager -->
+<script type="text/plain" data-cli-class="cli-blocker-script"  data-cli-script-type="non-necessary" data-cli-block="true"  data-cli-element-position="head">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-PVJD4J5');</script>
+<!-- End Google Tag Manager --><meta name="tec-api-version" content="v1"><meta name="tec-api-origin" content="https://workfromgreece.gr"><link rel="alternate" href="https://workfromgreece.gr/wp-json/tribe/events/v1/" /><header class="page_header">
+    
+    <div class="centered">
+        <a href='/'><img class="logo"></a>
+        <label for="is_main_menu_shown">
+            <div class="menu_toggle_wrapper" role="button" tabindex="0" aria-label="Menu Toggle" aria-expanded="false">
+                <i aria-hidden="true" role="presentation" class="eicon-menu-bar"></i>			
+                <span class="elementor-screen-only">Menu</span>
+            </div>
+        </label>
+    </div>
+    <input type="checkbox" style="display: none;" id="is_main_menu_shown">
+    <div class="main_menu">
+        <label class="menu_close" for="is_main_menu_shown">
+            X
+        </label>
+        <div class="menu_wrapper">
+        <div class="menu-main-menu-container"><ul id="menu-main-menu" class="menu"><li id="menu-item-616" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-616"><a href="https://workfromgreece.gr/about/" class="menu-link">Digital Nomad in Greece</a></li>
+<li id="menu-item-1210" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1210"><a href="/remote-work-locations" class="menu-link">Locations</a></li>
+<li id="menu-item-802" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-802"><a href="/benefit" class="menu-link">Benefits</a></li>
+<li id="menu-item-2753" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-2753"><a href="/blog" class="menu-link">Blog</a></li>
+<li id="menu-item-617" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-617"><a href="https://workfromgreece.gr/faq/" class="menu-link">FAQ</a></li>
+<li id="menu-item-3697" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-3697"><a href="/events" class="menu-link">Events</a></li>
+<li id="menu-item-615" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-615"><a href="https://workfromgreece.gr/contact/" class="menu-link">Contact Us</a></li>
+</ul></div>        </div>
+    </div>
+</header>
+<style>
+    #is_main_menu_shown:not(:checked) + .main_menu {
+        display: none;
+    }
+</style><meta name="generator" content="Elementor 4.0.9; features: additional_custom_breakpoints; settings: css_print_method-internal, google_font-enabled, font_display-auto">
+<style>.recentcomments a{display:inline !important;padding:0 !important;margin:0 !important;}</style>			<style>
+				.e-con.e-parent:nth-of-type(n+4):not(.e-lazyloaded):not(.e-no-lazyload),
+				.e-con.e-parent:nth-of-type(n+4):not(.e-lazyloaded):not(.e-no-lazyload) * {
+					background-image: none !important;
+				}
+				@media screen and (max-height: 1024px) {
+					.e-con.e-parent:nth-of-type(n+3):not(.e-lazyloaded):not(.e-no-lazyload),
+					.e-con.e-parent:nth-of-type(n+3):not(.e-lazyloaded):not(.e-no-lazyload) * {
+						background-image: none !important;
+					}
+				}
+				@media screen and (max-height: 640px) {
+					.e-con.e-parent:nth-of-type(n+2):not(.e-lazyloaded):not(.e-no-lazyload),
+					.e-con.e-parent:nth-of-type(n+2):not(.e-lazyloaded):not(.e-no-lazyload) * {
+						background-image: none !important;
+					}
+				}
+			</style>
+			<link rel="icon" href="https://workfromgreece.gr/wp-content/uploads/2021/11/WORKFROMGREECE_SoMe_Logos-01-150x150.jpg" sizes="32x32" />
+<link rel="icon" href="https://workfromgreece.gr/wp-content/uploads/2021/11/WORKFROMGREECE_SoMe_Logos-01-300x300.jpg" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://workfromgreece.gr/wp-content/uploads/2021/11/WORKFROMGREECE_SoMe_Logos-01-300x300.jpg" />
+<meta name="msapplication-TileImage" content="https://workfromgreece.gr/wp-content/uploads/2021/11/WORKFROMGREECE_SoMe_Logos-01-300x300.jpg" />
+</head>
+
+<body itemtype='https://schema.org/Blog' itemscope='itemscope' class="wp-singular post-template-default single single-post postid-2602 single-format-standard wp-custom-logo wp-embed-responsive wp-theme-astra wp-child-theme-work-from-greece tribe-no-js ehf-footer ehf-template-astra ehf-stylesheet-work-from-greece ast-desktop ast-page-builder-template ast-no-sidebar astra-4.12.0 ast-header-custom-item-inside ast-full-width-primary-header group-blog ast-blog-single-style-1 ast-single-post ast-inherit-site-logo-transparent ast-theme-transparent-header elementor-page-1652 ast-normal-title-enabled elementor-default elementor-kit-19 elementor-page elementor-page-2602">
+
+<a
+	class="skip-link screen-reader-text"
+	href="#content">
+		Skip to content</a>
+
+<div
+class="hfeed site" id="page">
+			<header data-elementor-type="header" data-elementor-id="3066" class="elementor elementor-3066 elementor-location-header" data-elementor-post-type="elementor_library">
+					<section class="elementor-section elementor-top-section elementor-element elementor-element-4ae43af elementor-section-full_width elementor-section-height-default elementor-section-height-default" data-id="4ae43af" data-element_type="section" data-e-type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-50 elementor-top-column elementor-element elementor-element-6aa8cd0" data-id="6aa8cd0" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-ab8a686 elementor-widget elementor-widget-theme-site-logo elementor-widget-image" data-id="ab8a686" data-element_type="widget" data-e-type="widget" data-widget_type="theme-site-logo.default">
+				<div class="elementor-widget-container">
+											<a href="https://workfromgreece.gr">
+			<img width="857" height="119" src="https://workfromgreece.gr/wp-content/uploads/2021/10/Logo.png" class="attachment-full size-full wp-image-445" alt="Logo" srcset="https://workfromgreece.gr/wp-content/uploads/2021/10/Logo.png 857w, https://workfromgreece.gr/wp-content/uploads/2021/10/Logo-300x42.png 300w, https://workfromgreece.gr/wp-content/uploads/2021/10/Logo-768x107.png 768w" sizes="(max-width: 857px) 100vw, 857px" />				</a>
+											</div>
+				</div>
+					</div>
+		</div>
+				<div class="elementor-column elementor-col-50 elementor-top-column elementor-element elementor-element-d16d5b9" data-id="d16d5b9" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-6f22f64 elementor-nav-menu--stretch ecs-toggle-align-right ecs-nav-layout-horizontal elementor-nav-menu--dropdown-tablet e--pointer-underline e--animation-fade elementor-nav-menu--toggle elementor-nav-menu--burger elementor-widget elementor-widget-nav-menu" data-id="6f22f64" data-element_type="widget" data-e-type="widget" data-settings="{&quot;full_width&quot;:&quot;stretch&quot;,&quot;layout&quot;:&quot;horizontal&quot;,&quot;submenu_icon&quot;:{&quot;value&quot;:&quot;&lt;i class=\&quot;fas fa-caret-down\&quot; aria-hidden=\&quot;true\&quot;&gt;&lt;\/i&gt;&quot;,&quot;library&quot;:&quot;fa-solid&quot;},&quot;toggle&quot;:&quot;burger&quot;}" data-widget_type="nav-menu.default">
+				<div class="elementor-widget-container">
+								<nav aria-label="Menu" class="elementor-nav-menu--main elementor-nav-menu__container elementor-nav-menu--layout-horizontal e--pointer-underline e--animation-fade">
+				<ul id="menu-1-6f22f64" class="elementor-nav-menu"><li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-616"><a href="https://workfromgreece.gr/about/" class="elementor-item menu-link">Digital Nomad in Greece</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1210"><a href="/remote-work-locations" class="elementor-item menu-link">Locations</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-802"><a href="/benefit" class="elementor-item menu-link">Benefits</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-2753"><a href="/blog" class="elementor-item menu-link">Blog</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-617"><a href="https://workfromgreece.gr/faq/" class="elementor-item menu-link">FAQ</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-3697"><a href="/events" class="elementor-item menu-link">Events</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-615"><a href="https://workfromgreece.gr/contact/" class="elementor-item menu-link">Contact Us</a></li>
+</ul>			</nav>
+					<div class="elementor-menu-toggle" role="button" tabindex="0" aria-label="Menu Toggle" aria-expanded="false">
+			<i aria-hidden="true" role="presentation" class="elementor-menu-toggle__icon--open eicon-menu-bar"></i><i aria-hidden="true" role="presentation" class="elementor-menu-toggle__icon--close eicon-close"></i>		</div>
+					<nav class="elementor-nav-menu--dropdown elementor-nav-menu__container" aria-hidden="true">
+				<ul id="menu-2-6f22f64" class="elementor-nav-menu"><li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-616"><a href="https://workfromgreece.gr/about/" class="elementor-item menu-link" tabindex="-1">Digital Nomad in Greece</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-1210"><a href="/remote-work-locations" class="elementor-item menu-link" tabindex="-1">Locations</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-802"><a href="/benefit" class="elementor-item menu-link" tabindex="-1">Benefits</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-2753"><a href="/blog" class="elementor-item menu-link" tabindex="-1">Blog</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-617"><a href="https://workfromgreece.gr/faq/" class="elementor-item menu-link" tabindex="-1">FAQ</a></li>
+<li class="menu-item menu-item-type-custom menu-item-object-custom menu-item-3697"><a href="/events" class="elementor-item menu-link" tabindex="-1">Events</a></li>
+<li class="menu-item menu-item-type-post_type menu-item-object-page menu-item-615"><a href="https://workfromgreece.gr/contact/" class="elementor-item menu-link" tabindex="-1">Contact Us</a></li>
+</ul>			</nav>
+						</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				</header>
+			<div id="content" class="site-content">
+		<div class="ast-container">
+		
+
+	<div id="primary" class="content-area primary">
+
+		
+					<main id="main" class="site-main">
+						<div data-elementor-type="single-post" data-elementor-id="1652" class="elementor elementor-1652 elementor-location-single post-2602 post type-post status-publish format-standard has-post-thumbnail hentry category-setting-up-in-greece tag-travel-tips tag-visa ast-article-single" data-elementor-post-type="elementor_library">
+					<section class="elementor-section elementor-top-section elementor-element elementor-element-4267988 elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="4267988" data-element_type="section" data-e-type="section" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+							<div class="elementor-background-overlay"></div>
+							<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-bf6b25d" data-id="bf6b25d" data-element_type="column" data-e-type="column" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+			<div class="elementor-widget-wrap elementor-element-populated">
+					<div class="elementor-background-overlay"></div>
+						<div class="elementor-element elementor-element-3bb916a post-title elementor-widget elementor-widget-theme-post-title elementor-page-title elementor-widget-heading" data-id="3bb916a" data-element_type="widget" data-e-type="widget" data-widget_type="theme-post-title.default">
+				<div class="elementor-widget-container">
+					<h1 class="elementor-heading-title elementor-size-default">The Digital Nomad Visa for Greece: Who is eligible and how to get one</h1>				</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				<section class="elementor-section elementor-top-section elementor-element elementor-element-4f9fb2a elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="4f9fb2a" data-element_type="section" data-e-type="section">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-1afd692" data-id="1afd692" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-8f24a97 elementor-widget elementor-widget-spacer" data-id="8f24a97" data-element_type="widget" data-e-type="widget" data-widget_type="spacer.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-spacer">
+			<div class="elementor-spacer-inner"></div>
+		</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-1ac0b07 post-breadcrumbs elementor-widget elementor-widget-breadcrumbs" data-id="1ac0b07" data-element_type="widget" data-e-type="widget" data-widget_type="breadcrumbs.default">
+				<div class="elementor-widget-container">
+					<div id="breadcrumbs"><span><span><a href="https://workfromgreece.gr/">Home</a></span> » <span><a href="https://workfromgreece.gr/blog/">Blog</a></span> » <span><a href="https://workfromgreece.gr/./setting-up-in-greece/">Setting Up in Greece</a></span> » <span class="breadcrumb_last" aria-current="page"><strong>The Digital Nomad Visa for Greece: Who is eligible and how to get one</strong></span></span></div>				</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				<section class="elementor-section elementor-top-section elementor-element elementor-element-6156dff elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="6156dff" data-element_type="section" data-e-type="section">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-66 elementor-top-column elementor-element elementor-element-8fc61ad" data-id="8fc61ad" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-1759035 elementor-widget elementor-widget-theme-post-content" data-id="1759035" data-element_type="widget" data-e-type="widget" data-widget_type="theme-post-content.default">
+				<div class="elementor-widget-container">
+							<div data-elementor-type="wp-post" data-elementor-id="2602" class="elementor elementor-2602" data-elementor-post-type="post">
+						<section class="elementor-section elementor-top-section elementor-element elementor-element-3aeba0d elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="3aeba0d" data-element_type="section" data-e-type="section">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-ad1d0b1" data-id="ad1d0b1" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-332fc2d elementor-toc--minimized-on-tablet elementor-widget elementor-widget-table-of-contents" data-id="332fc2d" data-element_type="widget" data-e-type="widget" data-settings="{&quot;headings_by_tags&quot;:[&quot;h3&quot;],&quot;exclude_headings_by_selector&quot;:[],&quot;no_headings_message&quot;:&quot;No headings were found on this page.&quot;,&quot;marker_view&quot;:&quot;numbers&quot;,&quot;minimize_box&quot;:&quot;yes&quot;,&quot;minimized_on&quot;:&quot;tablet&quot;,&quot;hierarchical_view&quot;:&quot;yes&quot;,&quot;min_height&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:&quot;&quot;,&quot;sizes&quot;:[]},&quot;min_height_tablet&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:&quot;&quot;,&quot;sizes&quot;:[]},&quot;min_height_mobile&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:&quot;&quot;,&quot;sizes&quot;:[]}}" data-widget_type="table-of-contents.default">
+				<div class="elementor-widget-container">
+									<div class="elementor-toc__header">
+						<h4 class="elementor-toc__header-title">
+				Table of Contents			</h4>
+										<div class="elementor-toc__toggle-button elementor-toc__toggle-button--expand" role="button" tabindex="0" aria-controls="elementor-toc__332fc2d" aria-expanded="true" aria-label="Open table of contents"><i aria-hidden="true" class="fas fa-chevron-down"></i></div>
+				<div class="elementor-toc__toggle-button elementor-toc__toggle-button--collapse" role="button" tabindex="0" aria-controls="elementor-toc__332fc2d" aria-expanded="true" aria-label="Close table of contents"><i aria-hidden="true" class="fas fa-chevron-up"></i></div>
+					</div>
+				<div id="elementor-toc__332fc2d" class="elementor-toc__body">
+			<div class="elementor-toc__spinner-container">
+				<i class="elementor-toc__spinner eicon-animation-spin eicon-loading" aria-hidden="true"></i>			</div>
+		</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-1b89bf0 elementor-widget elementor-widget-text-editor" data-id="1b89bf0" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<p>Introduced in 2021, the <strong>Digital Nomad Visa for Greece</strong> allows people who are not citizens of the European Union or European Economic Area and who work remotely to legally live and work in Greece for up to one year. It also allows you to bring your immediate family members with you, as long as you meet all the requirements. So if you’ve been toying with the idea of becoming a digital nomad in Greece, let’s have a look at the steps you need to follow to make that dream come true.</p>								</div>
+				</div>
+				<div class="elementor-element elementor-element-3db6e0e elementor-widget-divider--view-line_icon elementor-view-default elementor-widget-divider--element-align-center elementor-widget elementor-widget-divider" data-id="3db6e0e" data-element_type="widget" data-e-type="widget" data-widget_type="divider.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-divider">
+			<span class="elementor-divider-separator">
+							<div class="elementor-icon elementor-divider__element">
+					<i aria-hidden="true" class="fas fa-tasks"></i></div>
+						</span>
+		</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-c1d7d24 elementor-widget elementor-widget-heading" data-id="c1d7d24" data-element_type="widget" data-e-type="widget" data-widget_type="heading.default">
+				<div class="elementor-widget-container">
+					<h3 class="elementor-heading-title elementor-size-large">Who can become a digital nomad in Greece?</h3>				</div>
+				</div>
+				<div class="elementor-element elementor-element-e6fe299 elementor-widget elementor-widget-text-editor" data-id="e6fe299" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<p>If you are an EU or EEA citizen, you have the right to enter and move freely within Greece, according to EU law. For third-party nationals (ie non-EU or EEA), you can apply for a Digital Nomad Visa letting you live and work in Greece hassle-free, according to the following: </p>								</div>
+				</div>
+				<div class="elementor-element elementor-element-d302a44 elementor-widget elementor-widget-text-editor" data-id="d302a44" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<ul><li>You must not be employed or engaged in any business activity in Greece.<br /><br /></li><li>You must have clients or be employed by a company located outside of Greece.<br /><br /></li><li>You have to be able to provide your services and fulfil your work responsibilities using a stable internet connection and a laptop, which includes information and communication technology.<br /><br /></li><li>If you are self-employed, you need to provide evidence of your business activity, corporate purpose and business address, while also noting that your business cannot be registered in Greece.<br /><br /></li><li>You must prove that you earn at least €3,500 (after taxes) as the main applicant for the Digital Nomad Visa for Greece or have sufficient resources for the length of your stay. If you plan on extending your residency permit to your partner/spouse or child, you need to account for additional finances. For instance, for a spouse or partner, the minimum financial requirement will go up to €4,200. Additionally, for each child the requirement will increase by €525. In other words, for you, your spouse and one child, you will need to be earning €4,725 (after taxes) a month and so on.</li></ul>								</div>
+				</div>
+				<div class="elementor-element elementor-element-403333a elementor-widget elementor-widget-image" data-id="403333a" data-element_type="widget" data-e-type="widget" data-widget_type="image.default">
+				<div class="elementor-widget-container">
+															<img fetchpriority="high" fetchpriority="high" decoding="async" width="768" height="959" src="https://workfromgreece.gr/wp-content/uploads/2023/05/digital-nomad-in-greece-768x959.jpg" class="attachment-medium_large size-medium_large wp-image-2621" alt="" srcset="https://workfromgreece.gr/wp-content/uploads/2023/05/digital-nomad-in-greece-768x959.jpg 768w, https://workfromgreece.gr/wp-content/uploads/2023/05/digital-nomad-in-greece-240x300.jpg 240w, https://workfromgreece.gr/wp-content/uploads/2023/05/digital-nomad-in-greece-820x1024.jpg 820w, https://workfromgreece.gr/wp-content/uploads/2023/05/digital-nomad-in-greece.jpg 1080w" sizes="(max-width: 768px) 100vw, 768px" />															</div>
+				</div>
+				<div class="elementor-element elementor-element-192cb30 elementor-widget-divider--view-line_icon elementor-view-default elementor-widget-divider--element-align-center elementor-widget elementor-widget-divider" data-id="192cb30" data-element_type="widget" data-e-type="widget" data-widget_type="divider.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-divider">
+			<span class="elementor-divider-separator">
+							<div class="elementor-icon elementor-divider__element">
+					<i aria-hidden="true" class="fas fa-pencil-alt"></i></div>
+						</span>
+		</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-23da220 elementor-widget elementor-widget-heading" data-id="23da220" data-element_type="widget" data-e-type="widget" data-widget_type="heading.default">
+				<div class="elementor-widget-container">
+					<h3 class="elementor-heading-title elementor-size-large">How do you apply for a Digital Nomad Visa for Greece?</h3>				</div>
+				</div>
+				<div class="elementor-element elementor-element-1e86ec5 elementor-widget elementor-widget-text-editor" data-id="1e86ec5" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<p>Applications for a Greek Digital Nomad Visa are made through your nearest Greek consular authority. You can submit your request via email or registered letter. The consulate is obliged to confirm receipt and the status of your application within 10 days. If your application is successful, the Greek Ministry of Migration and Asylum will issue your visa.</p><p>Your Digital Nomad Visa for Greece will be valid for one year. When this period is over, you may apply for a Digital Nomad Residence Permit to extend your stay for another two years, as long as you still satisfy the visa requirements of your original application.</p><p>You can find a list with the contact information of the Greek Consular Offices around the world <a style="font-size: 20px; font-family: var( --e-global-typography-text-font-family ); background-color: white;" href="https://www.mfa.gr/missionsabroad/en/" target="_blank" rel="noopener">here</a></p>								</div>
+				</div>
+				<div class="elementor-element elementor-element-f0f686a elementor-widget-divider--view-line_icon elementor-view-default elementor-widget-divider--element-align-center elementor-widget elementor-widget-divider" data-id="f0f686a" data-element_type="widget" data-e-type="widget" data-widget_type="divider.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-divider">
+			<span class="elementor-divider-separator">
+							<div class="elementor-icon elementor-divider__element">
+					<i aria-hidden="true" class="fas fa-passport"></i></div>
+						</span>
+		</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-6824dd7 elementor-widget elementor-widget-heading" data-id="6824dd7" data-element_type="widget" data-e-type="widget" data-widget_type="heading.default">
+				<div class="elementor-widget-container">
+					<h3 class="elementor-heading-title elementor-size-large">What documents do you need to apply for a Digital Nomad Visa in Greece?</h3>				</div>
+				</div>
+				<div class="elementor-element elementor-element-6e76650 elementor-widget elementor-widget-text-editor" data-id="6e76650" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<p>As a Type-D Visa, the Greek Digital Nomad Visa requires the following supporting documents to be included in your application:</p>								</div>
+				</div>
+				<div class="elementor-element elementor-element-3733afd premium-type-column elementor-widget elementor-widget-premium-icon-list" data-id="3733afd" data-element_type="widget" data-e-type="widget" data-settings="{&quot;element_pack_cursor_effects_icons&quot;:{&quot;value&quot;:&quot;fas fa-laptop-house&quot;,&quot;library&quot;:&quot;fa-solid&quot;},&quot;_animation&quot;:&quot;none&quot;,&quot;rbadges_repeater&quot;:[]}" data-widget_type="premium-icon-list.default">
+				<div class="elementor-widget-container">
+								<ul class="premium-bullet-list-box">
+				
+							<li class="premium-bullet-list-content elementor-repeater-item-a808872">
+								<div class="premium-bullet-list-text">
+																			<div class="premium-bullet-list-wrapper">
+											<div class="premium-drawable-icon"><i class="premium-svg-nodraw far fa-check-circle" aria-hidden="true"></i></div>											</div>
+									
+									<div class="premium-bullet-list-text-wrapper premium-bullet-list-gradient-effect">
+										<span class="premium-bullet-text" data-text="Declaration Letter"> Declaration Letter </span>																			</div>
+								</div>
+
+								
+								
+							</li>
+
+							
+							<li class="premium-bullet-list-content elementor-repeater-item-b038387">
+								<div class="premium-bullet-list-text">
+																			<div class="premium-bullet-list-wrapper">
+											<div class="premium-drawable-icon"><i class="premium-svg-nodraw far fa-check-circle" aria-hidden="true"></i></div>											</div>
+									
+									<div class="premium-bullet-list-text-wrapper premium-bullet-list-gradient-effect premium-bullet-list-gradient-effect">
+										<span class="premium-bullet-text" data-text="Proof of Employment"> Proof of Employment </span>																			</div>
+								</div>
+
+								
+								
+							</li>
+
+							
+							<li class="premium-bullet-list-content elementor-repeater-item-7f5faf8">
+								<div class="premium-bullet-list-text">
+																			<div class="premium-bullet-list-wrapper">
+											<div class="premium-drawable-icon"><i class="premium-svg-nodraw far fa-check-circle" aria-hidden="true"></i></div>											</div>
+									
+									<div class="premium-bullet-list-text-wrapper premium-bullet-list-gradient-effect premium-bullet-list-gradient-effect premium-bullet-list-gradient-effect">
+										<span class="premium-bullet-text" data-text="Proof of Sufficient Funds"> Proof of Sufficient Funds </span>																			</div>
+								</div>
+
+								
+								
+							</li>
+
+							
+							<li class="premium-bullet-list-content elementor-repeater-item-d3fdf6e">
+								<div class="premium-bullet-list-text">
+																			<div class="premium-bullet-list-wrapper">
+											<div class="premium-drawable-icon"><i class="premium-svg-nodraw far fa-check-circle" aria-hidden="true"></i></div>											</div>
+									
+									<div class="premium-bullet-list-text-wrapper premium-bullet-list-gradient-effect premium-bullet-list-gradient-effect premium-bullet-list-gradient-effect premium-bullet-list-gradient-effect">
+										<span class="premium-bullet-text" data-text="Greek Digital Nomad Fee"> Greek Digital Nomad Fee </span>																			</div>
+								</div>
+
+								
+								
+							</li>
+
+										</ul>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-1283898 elementor-widget elementor-widget-text-editor" data-id="1283898" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<ul><li><strong>Declaration Letter: </strong>A formal statement declaring that the applicant intends to use their national entry visa for remote work and will not engage in any employment or freelance services for a Greek-based employer.</li><li><strong>Proof of Employment</strong>, which could be proven by:<ul><li>an open-ended contract of employment or independent services or proof of employment with an employer, natural or legal person, who is established outside the Greek Territory, or in case of a fixed-term contract, with a remaining duration covering the period of the granted national visa.<p><strong>or<u></u></strong></p></li><li>an open-ended contract of employment or independent services or, in the case of a fixed-term employment contract, with a remaining duration covering the period of validity of the granted visa, in case the third-country national is self-employed with more than one employer established outside Greece.<p><strong>or</strong></p></li><li>information on your status in the company, as well as information on the trade name, registered office, field of activity, and corporate purpose of the company in case you are self-employed in your own company, which is outside the Greek Territory.</li></ul></li><li><strong>Proof of Sufficient Funds: </strong>Evidence that you have sufficient resources at a stable income level to cover your living expenses during your stay in the country, without burdening the national social welfare system. Sufficient Funds can be proved by the contract of employment or independent services or employment certificate or by a bank account.</li><li><strong>Greek Digital Nomad Fee: </strong>The application fee you’ll need to pay will be a total of €75 plus an administrative fee of €150 for each family member applying with you.</li></ul>								</div>
+				</div>
+				<div class="elementor-element elementor-element-9796ca2 elementor-widget elementor-widget-text-editor" data-id="9796ca2" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<p><span style="font-size: 20px; font-style: normal; font-weight: 300;">In addition to your </span><span style="font-size: 20px; font-style: normal; font-weight: bold;">fully completed and signed <a style="font-size: 20px;" href="https://www.mfa.gr/missionsabroad/images/visas/national/application_for_a_visa_for_a_long_stay_in_greece.pdf" target="_blank" rel="noopener">application form</a></span><span style="font-size: 20px; font-style: normal; font-weight: 300;">, you will need to include the following for your application to be valid:</span></p>								</div>
+				</div>
+				<div class="elementor-element elementor-element-e39f12b premium-type-column elementor-widget elementor-widget-premium-icon-list" data-id="e39f12b" data-element_type="widget" data-e-type="widget" data-settings="{&quot;element_pack_cursor_effects_icons&quot;:{&quot;value&quot;:&quot;fas fa-laptop-house&quot;,&quot;library&quot;:&quot;fa-solid&quot;},&quot;_animation&quot;:&quot;none&quot;,&quot;rbadges_repeater&quot;:[]}" data-widget_type="premium-icon-list.default">
+				<div class="elementor-widget-container">
+								<ul class="premium-bullet-list-box">
+				
+							<li class="premium-bullet-list-content elementor-repeater-item-a808872">
+								<div class="premium-bullet-list-text">
+																			<div class="premium-bullet-list-wrapper">
+											<div class="premium-drawable-icon"><i class="premium-svg-nodraw fas fa-passport" aria-hidden="true"></i></div>											</div>
+									
+									<div class="premium-bullet-list-text-wrapper premium-bullet-list-gradient-effect">
+										<span class="premium-bullet-text" data-text="Your passport or other travel document recognized by the competent Greek authorities"> Your passport or other travel document recognized by the competent Greek authorities </span>																			</div>
+								</div>
+
+								
+								
+							</li>
+
+							
+							<li class="premium-bullet-list-content elementor-repeater-item-b038387">
+								<div class="premium-bullet-list-text">
+																			<div class="premium-bullet-list-wrapper">
+											<div class="premium-drawable-icon"><i class="premium-svg-nodraw fas fa-balance-scale" aria-hidden="true"></i></div>											</div>
+									
+									<div class="premium-bullet-list-text-wrapper premium-bullet-list-gradient-effect premium-bullet-list-gradient-effect">
+										<span class="premium-bullet-text" data-text="A certificate of criminal record from the foreign authorities"> A certificate of criminal record from the foreign authorities </span>																			</div>
+								</div>
+
+								
+								
+							</li>
+
+							
+							<li class="premium-bullet-list-content elementor-repeater-item-7f5faf8">
+								<div class="premium-bullet-list-text">
+																			<div class="premium-bullet-list-wrapper">
+											<div class="premium-drawable-icon"><i class="premium-svg-nodraw fas fa-file-medical" aria-hidden="true"></i></div>											</div>
+									
+									<div class="premium-bullet-list-text-wrapper premium-bullet-list-gradient-effect premium-bullet-list-gradient-effect premium-bullet-list-gradient-effect">
+										<span class="premium-bullet-text" data-text="A medical certificate from a recognized state or private body"> A medical certificate from a recognized state or private body </span>																			</div>
+								</div>
+
+								
+								
+							</li>
+
+							
+							<li class="premium-bullet-list-content elementor-repeater-item-d3fdf6e">
+								<div class="premium-bullet-list-text">
+																			<div class="premium-bullet-list-wrapper">
+											<div class="premium-drawable-icon"><i class="premium-svg-nodraw fas fa-crutch" aria-hidden="true"></i></div>											</div>
+									
+									<div class="premium-bullet-list-text-wrapper premium-bullet-list-gradient-effect premium-bullet-list-gradient-effect premium-bullet-list-gradient-effect premium-bullet-list-gradient-effect">
+										<span class="premium-bullet-text" data-text="Your travel insurance"> Your travel insurance </span>																			</div>
+								</div>
+
+								
+								
+							</li>
+
+										</ul>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-24d7115 elementor-widget elementor-widget-text-editor" data-id="24d7115" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<p>A full Greek Digital Nomad Visa<strong> document checklist</strong> is available in the link below.</p>								</div>
+				</div>
+				<div class="elementor-element elementor-element-98147a6 elementor-align-center elementor-widget elementor-widget-button" data-id="98147a6" data-element_type="widget" data-e-type="widget" data-widget_type="button.default">
+				<div class="elementor-widget-container">
+									<div class="elementor-button-wrapper">
+					<a class="elementor-button elementor-button-link elementor-size-sm" href="https://workfromgreece.gr/wp-content/uploads/2023/05/WFG_VisaChecklistGreece.pdf" target="_blank">
+						<span class="elementor-button-content-wrapper">
+						<span class="elementor-button-icon">
+				<i aria-hidden="true" class="far fa-check-circle"></i>			</span>
+									<span class="elementor-button-text">Greek Digital Nomad Visa document checklist</span>
+					</span>
+					</a>
+				</div>
+								</div>
+				</div>
+				<div class="elementor-element elementor-element-2f625f5 elementor-widget-divider--view-line_icon elementor-view-default elementor-widget-divider--element-align-center elementor-widget elementor-widget-divider" data-id="2f625f5" data-element_type="widget" data-e-type="widget" data-widget_type="divider.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-divider">
+			<span class="elementor-divider-separator">
+							<div class="elementor-icon elementor-divider__element">
+					<i aria-hidden="true" class="fas fa-hourglass-half"></i></div>
+						</span>
+		</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-92fed83 elementor-widget elementor-widget-text-editor" data-id="92fed83" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<p><span style="font-size: 20px; font-style: normal; font-weight: 300;">Once you’ve submitted your application for your Digital Nomad Visa for Greece, you’ll receive feedback within 10 days to let you know the status of your application. You can typically expect to receive your approved visa from the Greek Ministry of Migration and Asylum within a month, although the Greek government does not provide a specific timeline. Take into account that the timeframe for issuing your visa depends on the processing times of the Ministry.</span><br></p>								</div>
+				</div>
+				<div class="elementor-element elementor-element-f242c5e elementor-widget elementor-widget-spacer" data-id="f242c5e" data-element_type="widget" data-e-type="widget" data-widget_type="spacer.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-spacer">
+			<div class="elementor-spacer-inner"></div>
+		</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-115cb88 elementor-widget elementor-widget-image" data-id="115cb88" data-element_type="widget" data-e-type="widget" data-widget_type="image.default">
+				<div class="elementor-widget-container">
+															<img decoding="async" width="768" height="1024" src="https://workfromgreece.gr/wp-content/uploads/2023/01/Travelbuddyanna-Pelion-3-768x1024.jpg" class="attachment-medium_large size-medium_large wp-image-2498" alt="" srcset="https://workfromgreece.gr/wp-content/uploads/2023/01/Travelbuddyanna-Pelion-3-768x1024.jpg 768w, https://workfromgreece.gr/wp-content/uploads/2023/01/Travelbuddyanna-Pelion-3-225x300.jpg 225w, https://workfromgreece.gr/wp-content/uploads/2023/01/Travelbuddyanna-Pelion-3-1152x1536.jpg 1152w, https://workfromgreece.gr/wp-content/uploads/2023/01/Travelbuddyanna-Pelion-3-1536x2048.jpg 1536w, https://workfromgreece.gr/wp-content/uploads/2023/01/Travelbuddyanna-Pelion-3-scaled.jpg 1920w" sizes="(max-width: 768px) 100vw, 768px" />															</div>
+				</div>
+				<div class="elementor-element elementor-element-bea2697 elementor-widget-divider--view-line_icon elementor-view-default elementor-widget-divider--element-align-center elementor-widget elementor-widget-divider" data-id="bea2697" data-element_type="widget" data-e-type="widget" data-widget_type="divider.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-divider">
+			<span class="elementor-divider-separator">
+							<div class="elementor-icon elementor-divider__element">
+					<i aria-hidden="true" class="fas fa-hand-point-down"></i></div>
+						</span>
+		</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-d68610a elementor-widget__width-initial elementor-widget elementor-widget-heading" data-id="d68610a" data-element_type="widget" data-e-type="widget" data-widget_type="heading.default">
+				<div class="elementor-widget-container">
+					<h3 class="elementor-heading-title elementor-size-large">Can you apply for a Greek Digital Nomad Visa if you are currently in Greece?</h3>				</div>
+				</div>
+				<div class="elementor-element elementor-element-82a06a1 elementor-widget elementor-widget-text-editor" data-id="82a06a1" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<p>If you are already in Greece, you cannot apply for the Digital Nomad Visa from within the country. The visa must be issued by a Greek consulate in your country of residence before you travel.</p><p>As of 5 February 2026 (<a id="menur7gr" class="fui-Link ___1q1shib f2hkw1w f3rmtva f1ewtqcl fyind8e f1k6fduh f1w7gpdv fk6fouc fjoy568 figsok6 f1s184ao f1mk8lai fnbmjn9 f1o700av f13mvf36 f1cmlufx f9n3di6 f1ids18y f1tx3yz7 f1deo86v f1eh06m1 f1iescvh fhgqx19 f1olyrje f1p93eir f1nev41a f1h8hb77 f1lqvz6u f10aw75t fsle3fq f17ae5zn" title="https://migration.gov.gr/wp-content/uploads/2026/02/%ce%a6%ce%95%ce%9a%ce%9117_6.2.2025.pdf" href="https://migration.gov.gr/wp-content/uploads/2026/02/%CE%A6%CE%95%CE%9A%CE%9117_6.2.2025.pdf" target="_blank" rel="noreferrer noopener" aria-label="Link N5275/2026">N5275/2026</a>), it is no longer possible to apply for a Digital Nomad Residence Permit while in Greece on a tourist visa or visa waiver. However, if you have entered Greece with a valid Digital Nomad Visa, you can apply locally to extend your stay by obtaining a Digital Nomad Residence Permit (valid for up to two years). Applications are submitted through the Directorate of Residence Permits of the Ministry of Migration and Asylum. For further information and to apply online, you can check out the Ministry’s web page <strong><a id="menur7gt" class="fui-Link ___1q1shib f2hkw1w f3rmtva f1ewtqcl fyind8e f1k6fduh f1w7gpdv fk6fouc fjoy568 figsok6 f1s184ao f1mk8lai fnbmjn9 f1o700av f13mvf36 f1cmlufx f9n3di6 f1ids18y f1tx3yz7 f1deo86v f1eh06m1 f1iescvh fhgqx19 f1olyrje f1p93eir f1nev41a f1h8hb77 f1lqvz6u f10aw75t fsle3fq f17ae5zn" title="https://migration.gov.gr/en/migration-policy/dioikisi/" href="https://migration.gov.gr/en/migration-policy/dioikisi/" target="_blank" rel="noreferrer noopener" aria-label="Link here">here</a></strong>.</p><p>You will need to provide the same supporting documents required for the visa, along with proof of accommodation in Greece (such as a rental agreement or property ownership). The residence permit is valid for two years and comes with a €1,000 application fee, plus €150 for each additional family member. </p>								</div>
+				</div>
+				<div class="elementor-element elementor-element-5b7cad0 elementor-align-center elementor-widget elementor-widget-button" data-id="5b7cad0" data-element_type="widget" data-e-type="widget" data-widget_type="button.default">
+				<div class="elementor-widget-container">
+									<div class="elementor-button-wrapper">
+					<a class="elementor-button elementor-button-link elementor-size-sm" href="https://portal.immigration.gov.gr/electronic-applications/index?lang=en" target="_blank">
+						<span class="elementor-button-content-wrapper">
+						<span class="elementor-button-icon">
+				<i aria-hidden="true" class="far fa-arrow-alt-circle-right"></i>			</span>
+									<span class="elementor-button-text">Apply for a Digital Nomad Residence Permit </span>
+					</span>
+					</a>
+				</div>
+								</div>
+				</div>
+				<div class="elementor-element elementor-element-8357004 elementor-widget-divider--view-line_icon elementor-view-default elementor-widget-divider--element-align-center elementor-widget elementor-widget-divider" data-id="8357004" data-element_type="widget" data-e-type="widget" data-widget_type="divider.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-divider">
+			<span class="elementor-divider-separator">
+							<div class="elementor-icon elementor-divider__element">
+					<i aria-hidden="true" class="far fa-smile"></i></div>
+						</span>
+		</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-a5e43f5 elementor-widget elementor-widget-heading" data-id="a5e43f5" data-element_type="widget" data-e-type="widget" data-widget_type="heading.default">
+				<div class="elementor-widget-container">
+					<h3 class="elementor-heading-title elementor-size-large">Why work from Greece as a digital nomad in the first place?</h3>				</div>
+				</div>
+				<div class="elementor-element elementor-element-6c8b280 elementor-widget elementor-widget-text-editor" data-id="6c8b280" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<p>It doesn’t matter if you’re a mountain or an island person, Greece offers both and plenty more! The views, the friendly locals, the rich culture, not to mention the delicious food, are only a few of the things that will make you feel at home.</p><p>So, why not make Greece your new office and experience the joy of living and working in a country that will leave you feeling energized and inspired every day?</p><p><strong><br /></strong>Not yet convinced? You can check out more of the benefits Greece has to offer you <a href="https://workfromgreece.gr/benefit/">here</a>.</p>								</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				<section class="elementor-section elementor-top-section elementor-element elementor-element-c5decb6 elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="c5decb6" data-element_type="section" data-e-type="section">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-c43f267" data-id="c43f267" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap">
+							</div>
+		</div>
+					</div>
+		</section>
+				</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-600dc0a sidebar-title elementor-widget elementor-widget-heading" data-id="600dc0a" data-element_type="widget" data-e-type="widget" data-widget_type="heading.default">
+				<div class="elementor-widget-container">
+					<h5 class="elementor-heading-title elementor-size-default">Share on Social Media</h5>				</div>
+				</div>
+				<div class="elementor-element elementor-element-3f60b13 elementor-grid-6 elementor-share-buttons--view-icon elementor-share-buttons--shape-rounded elementor-share-buttons--color-custom elementor-share-buttons--skin-gradient elementor-widget elementor-widget-share-buttons" data-id="3f60b13" data-element_type="widget" data-e-type="widget" data-widget_type="share-buttons.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-grid" role="list">
+								<div class="elementor-grid-item" role="listitem">
+						<div class="elementor-share-btn elementor-share-btn_facebook" role="button" tabindex="0" aria-label="Share on facebook">
+															<span class="elementor-share-btn__icon">
+								<i class="fab fa-facebook" aria-hidden="true"></i>							</span>
+																				</div>
+					</div>
+									<div class="elementor-grid-item" role="listitem">
+						<div class="elementor-share-btn elementor-share-btn_twitter" role="button" tabindex="0" aria-label="Share on twitter">
+															<span class="elementor-share-btn__icon">
+								<i class="fab fa-twitter" aria-hidden="true"></i>							</span>
+																				</div>
+					</div>
+									<div class="elementor-grid-item" role="listitem">
+						<div class="elementor-share-btn elementor-share-btn_linkedin" role="button" tabindex="0" aria-label="Share on linkedin">
+															<span class="elementor-share-btn__icon">
+								<i class="fab fa-linkedin" aria-hidden="true"></i>							</span>
+																				</div>
+					</div>
+						</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-be9648f elementor-widget elementor-widget-spacer" data-id="be9648f" data-element_type="widget" data-e-type="widget" data-widget_type="spacer.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-spacer">
+			<div class="elementor-spacer-inner"></div>
+		</div>
+						</div>
+				</div>
+					</div>
+		</div>
+				<div class="elementor-column elementor-col-33 elementor-top-column elementor-element elementor-element-9f45af4 sidebar-post" data-id="9f45af4" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-cb471a9 animated-slow elementor-author-box--avatar-yes elementor-author-box--name-yes elementor-author-box--biography-yes elementor-widget elementor-widget-author-box" data-id="cb471a9" data-element_type="widget" data-e-type="widget" data-settings="{&quot;_animation&quot;:&quot;none&quot;}" data-widget_type="author-box.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-author-box">
+							<div  class="elementor-author-box__avatar">
+					<img src="https://workfromgreece.gr/wp-content/uploads/2025/06/WFG-logo.jpg" alt="Picture of Work From Greece Team" loading="lazy">
+				</div>
+			
+			<div class="elementor-author-box__text">
+									<div >
+						<h4 class="elementor-author-box__name">
+							Work From Greece Team						</h4>
+					</div>
+				
+									<div class="elementor-author-box__bio">
+						Your one-stop-shop for Digital Nomads looking to live and work in Greece					</div>
+				
+							</div>
+		</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-d948218 sidebar-title elementor-widget elementor-widget-heading" data-id="d948218" data-element_type="widget" data-e-type="widget" data-widget_type="heading.default">
+				<div class="elementor-widget-container">
+					<h5 class="elementor-heading-title elementor-size-default">Author's Social Media &amp; Website</h5>				</div>
+				</div>
+				<div class="elementor-element elementor-element-e653ddd elementor-widget elementor-widget-shortcode" data-id="e653ddd" data-element_type="widget" data-e-type="widget" data-widget_type="shortcode.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-element elementor-element-3f60b13 elementor-grid-6 elementor-share-buttons--view-icon elementor-share-buttons--shape-rounded elementor-share-buttons--color-custom elementor-share-buttons--skin-gradient elementor-widget elementor-widget-share-buttons" data-author_id="12">
+			<div class="elementor-widget-container">
+				<div class="elementor-grid">
+
+										<div class="elementor-grid-item">
+						<div class="elementor-share-btn elementor-share-btn_facebook" tabindex="0" aria-label="Facebook">
+							<a href="https://www.facebook.com/WorkFromGR/" target="_blank">
+								<span class="elementor-share-btn__icon">
+									<i class="fab fa-facebook" aria-hidden="true"></i>
+								</span>
+							</a>
+						</div>
+					</div>
+										<div class="elementor-grid-item">
+						<div class="elementor-share-btn elementor-share-btn_instagram" tabindex="0" aria-label="Instagram">
+							<a href="https://www.instagram.com/workfromgreece_/?hl=en" target="_blank">
+								<span class="elementor-share-btn__icon">
+									<i class="fab fa-instagram" aria-hidden="true"></i>
+								</span>
+							</a>
+						</div>
+					</div>
+					
+				</div>
+			</div>
+		</div>
+					<div class="elementor-shortcode"></div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-5b6b8fa elementor-widget elementor-widget-post-info" data-id="5b6b8fa" data-element_type="widget" data-e-type="widget" data-widget_type="post-info.default">
+				<div class="elementor-widget-container">
+							<ul class="elementor-icon-list-items elementor-post-info">
+								<li class="elementor-icon-list-item elementor-repeater-item-4a1f184" itemprop="datePublished">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="fas fa-calendar"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-date">
+										<time>May 25, 2023</time>					</span>
+								</li>
+				<li class="elementor-icon-list-item elementor-repeater-item-a03371b" itemprop="about">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="fas fa-tags"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-terms">
+										<span class="elementor-post-info__terms-list">
+				<a href="https://workfromgreece.gr/tag/travel-tips/" class="elementor-post-info__terms-list-item">Travel Tips</a>, <a href="https://workfromgreece.gr/tag/visa/" class="elementor-post-info__terms-list-item">visa</a>				</span>
+					</span>
+								</li>
+				</ul>
+						</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				<section class="elementor-section elementor-top-section elementor-element elementor-element-dc02feb elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="dc02feb" data-element_type="section" data-e-type="section">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-23b1efe" data-id="23b1efe" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-d02db7c category-title elementor-widget elementor-widget-heading" data-id="d02db7c" data-element_type="widget" data-e-type="widget" data-widget_type="heading.default">
+				<div class="elementor-widget-container">
+					<h2 class="elementor-heading-title elementor-size-default">Related Posts</h2>				</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				<section class="elementor-section elementor-top-section elementor-element elementor-element-64e8836 elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="64e8836" data-element_type="section" data-e-type="section">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-b51ad70" data-id="b51ad70" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-74aa43a elementor-grid-2 elementor-posts--thumbnail-top elementor-grid-tablet-2 elementor-grid-mobile-1 elementor-widget elementor-widget-posts" data-id="74aa43a" data-element_type="widget" data-e-type="widget" data-settings="{&quot;custom_columns&quot;:&quot;2&quot;,&quot;custom_columns_tablet&quot;:&quot;2&quot;,&quot;custom_columns_mobile&quot;:&quot;1&quot;,&quot;custom_row_gap&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:35,&quot;sizes&quot;:[]},&quot;custom_row_gap_tablet&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:&quot;&quot;,&quot;sizes&quot;:[]},&quot;custom_row_gap_mobile&quot;:{&quot;unit&quot;:&quot;px&quot;,&quot;size&quot;:&quot;&quot;,&quot;sizes&quot;:[]}}" data-widget_type="posts.custom">
+				<div class="elementor-widget-container">
+					<div class="elementor-main-swiper swiper-container swiper">      <div class="ecs-posts elementor-posts-container elementor-posts swiper-wrapper   elementor-posts--skin-custom" data-settings="{&quot;current_page&quot;:1,&quot;max_num_pages&quot;:4,&quot;load_method&quot;:&quot;&quot;,&quot;widget_id&quot;:&quot;74aa43a&quot;,&quot;post_id&quot;:2602,&quot;theme_id&quot;:1652,&quot;change_url&quot;:false,&quot;reinit_js&quot;:false}">
+      		<article id="post-3906" class="elementor-post elementor-grid-item ecs-post-loop swiper-slide post-3906 post type-post status-publish format-standard has-post-thumbnail hentry category-digital-nomads-around-greece tag-digital-nomad-lifestyle tag-remote-work-in-greece ast-article-single">
+		<style id="elementor-post-1677">.elementor-1677 .elementor-element.elementor-element-7d3ddf7 > .elementor-widget-wrap > .elementor-widget:not(.elementor-widget__width-auto):not(.elementor-widget__width-initial):not(:last-child):not(.elementor-absolute){margin-block-end:10px;}.elementor-widget-theme-post-featured-image .widget-image-caption{color:var( --e-global-color-text );font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );}.elementor-1677 .elementor-element.elementor-element-6ba0961 img{height:300px;object-fit:cover;object-position:center center;}.elementor-widget-theme-post-title .elementor-heading-title{font-family:var( --e-global-typography-primary-font-family );font-size:var( --e-global-typography-primary-font-size );font-weight:var( --e-global-typography-primary-font-weight );color:var( --e-global-color-primary );}.elementor-1677 .elementor-element.elementor-element-82ccd54 .elementor-heading-title{font-size:28px;font-weight:600;line-height:1em;letter-spacing:-1.2px;color:var( --e-global-color-text );}.elementor-widget-post-info .elementor-icon-list-item:not(:last-child):after{border-color:var( --e-global-color-text );}.elementor-widget-post-info .elementor-icon-list-icon i{color:var( --e-global-color-primary );}.elementor-widget-post-info .elementor-icon-list-icon svg{fill:var( --e-global-color-primary );}.elementor-widget-post-info .elementor-icon-list-text, .elementor-widget-post-info .elementor-icon-list-text a{color:var( --e-global-color-secondary );}.elementor-widget-post-info .elementor-icon-list-item{font-family:var( --e-global-typography-text-font-family );font-size:var( --e-global-typography-text-font-size );font-weight:var( --e-global-typography-text-font-weight );}.elementor-1677 .elementor-element.elementor-element-190b5f8 .elementor-icon-list-icon i{color:var( --e-global-color-2f9b81c2 );font-size:14px;}.elementor-1677 .elementor-element.elementor-element-190b5f8 .elementor-icon-list-icon svg{fill:var( --e-global-color-2f9b81c2 );--e-icon-list-icon-size:14px;}.elementor-1677 .elementor-element.elementor-element-190b5f8 .elementor-icon-list-icon{width:14px;}.elementor-widget .tippy-tooltip .tippy-content{text-align:center;}@media(max-width:1024px){.elementor-widget-theme-post-featured-image .widget-image-caption{font-size:var( --e-global-typography-text-font-size );}.elementor-widget-theme-post-title .elementor-heading-title{font-size:var( --e-global-typography-primary-font-size );}.elementor-widget-post-info .elementor-icon-list-item{font-size:var( --e-global-typography-text-font-size );}}@media(max-width:767px){.elementor-widget-theme-post-featured-image .widget-image-caption{font-size:var( --e-global-typography-text-font-size );}.elementor-widget-theme-post-title .elementor-heading-title{font-size:var( --e-global-typography-primary-font-size );}.elementor-widget-post-info .elementor-icon-list-item{font-size:var( --e-global-typography-text-font-size );}}/* Start custom CSS for theme-post-title, class: .elementor-element-82ccd54 */.elementor-1677 .elementor-element.elementor-element-82ccd54 h1{
+    text-align: left;
+}/* End custom CSS */
+/* Start custom CSS for post-info, class: .elementor-element-190b5f8 */.elementor-1677 .elementor-element.elementor-element-190b5f8 .elementor-post-info__item--type-author,
+.elementor-1677 .elementor-element.elementor-element-190b5f8 .elementor-post-info__item--type-date,
+.elementor-1677 .elementor-element.elementor-element-190b5f8 .elementor-icon-list-item
+{
+    font-family: 'Burford Rustic'!important;
+}/* End custom CSS */</style>		<div data-elementor-type="loop" data-elementor-id="1677" class="elementor elementor-1677 elementor-location-single post-3906 post type-post status-publish format-standard has-post-thumbnail hentry category-digital-nomads-around-greece tag-digital-nomad-lifestyle tag-remote-work-in-greece ast-article-single" data-elementor-post-type="elementor_library">
+					<section class="elementor-section elementor-top-section elementor-element elementor-element-c9a124d elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-invisible" data-id="c9a124d" data-element_type="section" data-e-type="section" data-settings="{&quot;animation&quot;:&quot;fadeIn&quot;}">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-7d3ddf7" data-id="7d3ddf7" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div data-ep-wrapper-link="{&quot;url&quot;:&quot;https:\/\/workfromgreece.gr\/digital-nomads-around-greece\/remote-in-the-peloponnese\/&quot;,&quot;is_external&quot;:&quot;&quot;,&quot;nofollow&quot;:&quot;&quot;,&quot;custom_attributes&quot;:&quot;&quot;}" style="cursor: pointer" class="bdt-element-link elementor-element elementor-element-6ba0961 elementor-invisible elementor-widget elementor-widget-theme-post-featured-image elementor-widget-image" data-id="6ba0961" data-element_type="widget" data-e-type="widget" data-settings="{&quot;_animation&quot;:&quot;zoomIn&quot;}" data-widget_type="theme-post-featured-image.default">
+				<div class="elementor-widget-container">
+																<a href="https://workfromgreece.gr/digital-nomads-around-greece/remote-in-the-peloponnese/">
+							<img loading="lazy" width="1024" height="683" src="https://workfromgreece.gr/wp-content/uploads/2025/11/Remote-in-the-Peloponnese-2-1024x683.jpeg" class="attachment-large size-large wp-image-3907" alt="Remote in the Peloponnese" srcset="https://workfromgreece.gr/wp-content/uploads/2025/11/Remote-in-the-Peloponnese-2-1024x683.jpeg 1024w, https://workfromgreece.gr/wp-content/uploads/2025/11/Remote-in-the-Peloponnese-2-300x200.jpeg 300w, https://workfromgreece.gr/wp-content/uploads/2025/11/Remote-in-the-Peloponnese-2-768x512.jpeg 768w, https://workfromgreece.gr/wp-content/uploads/2025/11/Remote-in-the-Peloponnese-2-1536x1024.jpeg 1536w, https://workfromgreece.gr/wp-content/uploads/2025/11/Remote-in-the-Peloponnese-2.jpeg 1920w" sizes="(max-width: 1024px) 100vw, 1024px" />								</a>
+															</div>
+				</div>
+				<div class="elementor-element elementor-element-82ccd54 elementor-widget elementor-widget-theme-post-title elementor-page-title elementor-widget-heading" data-id="82ccd54" data-element_type="widget" data-e-type="widget" data-widget_type="theme-post-title.default">
+				<div class="elementor-widget-container">
+					<h1 class="elementor-heading-title elementor-size-default"><a href="https://workfromgreece.gr/digital-nomads-around-greece/remote-in-the-peloponnese/">Remote in the Peloponnese</a></h1>				</div>
+				</div>
+				<div class="elementor-element elementor-element-190b5f8 elementor-widget elementor-widget-post-info" data-id="190b5f8" data-element_type="widget" data-e-type="widget" data-widget_type="post-info.default">
+				<div class="elementor-widget-container">
+							<ul class="elementor-inline-items elementor-icon-list-items elementor-post-info">
+								<li class="elementor-icon-list-item elementor-repeater-item-f89b59e elementor-inline-item" itemprop="datePublished">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="fas fa-calendar"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-date">
+										<time>November 10, 2025</time>					</span>
+								</li>
+				<li class="elementor-icon-list-item elementor-repeater-item-6f7e1b5 elementor-inline-item" itemprop="about">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="fas fa-tags"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-terms">
+										<span class="elementor-post-info__terms-list">
+				<span class="elementor-post-info__terms-list-item">Digital Nomad Lifestyle</span>, <span class="elementor-post-info__terms-list-item">Remote Work in Greece</span>				</span>
+					</span>
+								</li>
+				<li class="elementor-icon-list-item elementor-repeater-item-9e44518 elementor-inline-item" itemprop="author">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="far fa-user-circle"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-author">
+										Tursi Digital Nomads					</span>
+								</li>
+				</ul>
+						</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				</div>
+				</article>
+				<article id="post-3795" class="elementor-post elementor-grid-item ecs-post-loop swiper-slide post-3795 post type-post status-publish format-standard has-post-thumbnail hentry category-setting-up-in-greece tag-global-nomad-pass tag-remote-work-in-greece ast-article-single">
+				<div data-elementor-type="loop" data-elementor-id="1677" class="elementor elementor-1677 elementor-location-single post-3795 post type-post status-publish format-standard has-post-thumbnail hentry category-setting-up-in-greece tag-global-nomad-pass tag-remote-work-in-greece ast-article-single" data-elementor-post-type="elementor_library">
+					<section class="elementor-section elementor-top-section elementor-element elementor-element-c9a124d elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-invisible" data-id="c9a124d" data-element_type="section" data-e-type="section" data-settings="{&quot;animation&quot;:&quot;fadeIn&quot;}">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-7d3ddf7" data-id="7d3ddf7" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div data-ep-wrapper-link="{&quot;url&quot;:&quot;https:\/\/workfromgreece.gr\/setting-up-in-greece\/work-from-greece-like-a-local-get-your-freeglobal-nomad-pass\/&quot;,&quot;is_external&quot;:&quot;&quot;,&quot;nofollow&quot;:&quot;&quot;,&quot;custom_attributes&quot;:&quot;&quot;}" style="cursor: pointer" class="bdt-element-link elementor-element elementor-element-6ba0961 elementor-invisible elementor-widget elementor-widget-theme-post-featured-image elementor-widget-image" data-id="6ba0961" data-element_type="widget" data-e-type="widget" data-settings="{&quot;_animation&quot;:&quot;zoomIn&quot;}" data-widget_type="theme-post-featured-image.default">
+				<div class="elementor-widget-container">
+																<a href="https://workfromgreece.gr/setting-up-in-greece/work-from-greece-like-a-local-get-your-freeglobal-nomad-pass/">
+							<img loading="lazy" width="1024" height="704" src="https://workfromgreece.gr/wp-content/uploads/2025/06/Global-Nomad-Pass-Header-1024x704.png" class="attachment-large size-large wp-image-3832" alt="Global Nomad Pass Header" srcset="https://workfromgreece.gr/wp-content/uploads/2025/06/Global-Nomad-Pass-Header-1024x704.png 1024w, https://workfromgreece.gr/wp-content/uploads/2025/06/Global-Nomad-Pass-Header-300x206.png 300w, https://workfromgreece.gr/wp-content/uploads/2025/06/Global-Nomad-Pass-Header-768x528.png 768w, https://workfromgreece.gr/wp-content/uploads/2025/06/Global-Nomad-Pass-Header.png 1080w" sizes="(max-width: 1024px) 100vw, 1024px" />								</a>
+															</div>
+				</div>
+				<div class="elementor-element elementor-element-82ccd54 elementor-widget elementor-widget-theme-post-title elementor-page-title elementor-widget-heading" data-id="82ccd54" data-element_type="widget" data-e-type="widget" data-widget_type="theme-post-title.default">
+				<div class="elementor-widget-container">
+					<h1 class="elementor-heading-title elementor-size-default"><a href="https://workfromgreece.gr/setting-up-in-greece/work-from-greece-like-a-local-get-your-freeglobal-nomad-pass/">Work from Greece Like a Local: Get Your Free Global Nomad Pass</a></h1>				</div>
+				</div>
+				<div class="elementor-element elementor-element-190b5f8 elementor-widget elementor-widget-post-info" data-id="190b5f8" data-element_type="widget" data-e-type="widget" data-widget_type="post-info.default">
+				<div class="elementor-widget-container">
+							<ul class="elementor-inline-items elementor-icon-list-items elementor-post-info">
+								<li class="elementor-icon-list-item elementor-repeater-item-f89b59e elementor-inline-item" itemprop="datePublished">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="fas fa-calendar"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-date">
+										<time>June 13, 2025</time>					</span>
+								</li>
+				<li class="elementor-icon-list-item elementor-repeater-item-6f7e1b5 elementor-inline-item" itemprop="about">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="fas fa-tags"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-terms">
+										<span class="elementor-post-info__terms-list">
+				<span class="elementor-post-info__terms-list-item">Global Nomad Pass</span>, <span class="elementor-post-info__terms-list-item">Remote Work in Greece</span>				</span>
+					</span>
+								</li>
+				<li class="elementor-icon-list-item elementor-repeater-item-9e44518 elementor-inline-item" itemprop="author">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="far fa-user-circle"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-author">
+										Work From Greece Team					</span>
+								</li>
+				</ul>
+						</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				</div>
+				</article>
+				<article id="post-3411" class="elementor-post elementor-grid-item ecs-post-loop swiper-slide post-3411 post type-post status-publish format-standard has-post-thumbnail hentry category-digital-nomads-around-greece category-islands tag-co-working-and-co-living-spaces tag-digital-nomad-lifestyle tag-remote-work-in-greece ast-article-single">
+				<div data-elementor-type="loop" data-elementor-id="1677" class="elementor elementor-1677 elementor-location-single post-3411 post type-post status-publish format-standard has-post-thumbnail hentry category-digital-nomads-around-greece category-islands tag-co-working-and-co-living-spaces tag-digital-nomad-lifestyle tag-remote-work-in-greece ast-article-single" data-elementor-post-type="elementor_library">
+					<section class="elementor-section elementor-top-section elementor-element elementor-element-c9a124d elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-invisible" data-id="c9a124d" data-element_type="section" data-e-type="section" data-settings="{&quot;animation&quot;:&quot;fadeIn&quot;}">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-7d3ddf7" data-id="7d3ddf7" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div data-ep-wrapper-link="{&quot;url&quot;:&quot;https:\/\/workfromgreece.gr\/digital-nomads-around-greece\/wintering-in-greece-syros-a-hidden-paradise-for-digital-nomads\/&quot;,&quot;is_external&quot;:&quot;&quot;,&quot;nofollow&quot;:&quot;&quot;,&quot;custom_attributes&quot;:&quot;&quot;}" style="cursor: pointer" class="bdt-element-link elementor-element elementor-element-6ba0961 elementor-invisible elementor-widget elementor-widget-theme-post-featured-image elementor-widget-image" data-id="6ba0961" data-element_type="widget" data-e-type="widget" data-settings="{&quot;_animation&quot;:&quot;zoomIn&quot;}" data-widget_type="theme-post-featured-image.default">
+				<div class="elementor-widget-container">
+																<a href="https://workfromgreece.gr/digital-nomads-around-greece/wintering-in-greece-syros-a-hidden-paradise-for-digital-nomads/">
+							<img loading="lazy" width="1024" height="683" src="https://workfromgreece.gr/wp-content/uploads/2024/02/Ermoupoli_19-1024x683.jpg" class="attachment-large size-large wp-image-3414" alt="Ermoupoli 19" srcset="https://workfromgreece.gr/wp-content/uploads/2024/02/Ermoupoli_19-1024x683.jpg 1024w, https://workfromgreece.gr/wp-content/uploads/2024/02/Ermoupoli_19-300x200.jpg 300w, https://workfromgreece.gr/wp-content/uploads/2024/02/Ermoupoli_19-768x512.jpg 768w, https://workfromgreece.gr/wp-content/uploads/2024/02/Ermoupoli_19-1536x1024.jpg 1536w, https://workfromgreece.gr/wp-content/uploads/2024/02/Ermoupoli_19.jpg 1920w" sizes="(max-width: 1024px) 100vw, 1024px" />								</a>
+															</div>
+				</div>
+				<div class="elementor-element elementor-element-82ccd54 elementor-widget elementor-widget-theme-post-title elementor-page-title elementor-widget-heading" data-id="82ccd54" data-element_type="widget" data-e-type="widget" data-widget_type="theme-post-title.default">
+				<div class="elementor-widget-container">
+					<h1 class="elementor-heading-title elementor-size-default"><a href="https://workfromgreece.gr/digital-nomads-around-greece/wintering-in-greece-syros-a-hidden-paradise-for-digital-nomads/">Wintering in Greece: Syros – A Hidden Paradise for Digital Nomads</a></h1>				</div>
+				</div>
+				<div class="elementor-element elementor-element-190b5f8 elementor-widget elementor-widget-post-info" data-id="190b5f8" data-element_type="widget" data-e-type="widget" data-widget_type="post-info.default">
+				<div class="elementor-widget-container">
+							<ul class="elementor-inline-items elementor-icon-list-items elementor-post-info">
+								<li class="elementor-icon-list-item elementor-repeater-item-f89b59e elementor-inline-item" itemprop="datePublished">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="fas fa-calendar"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-date">
+										<time>February 23, 2024</time>					</span>
+								</li>
+				<li class="elementor-icon-list-item elementor-repeater-item-6f7e1b5 elementor-inline-item" itemprop="about">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="fas fa-tags"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-terms">
+										<span class="elementor-post-info__terms-list">
+				<span class="elementor-post-info__terms-list-item">Co-working and Co-living Spaces</span>, <span class="elementor-post-info__terms-list-item">Digital Nomad Lifestyle</span>, <span class="elementor-post-info__terms-list-item">Remote Work in Greece</span>				</span>
+					</span>
+								</li>
+				<li class="elementor-icon-list-item elementor-repeater-item-9e44518 elementor-inline-item" itemprop="author">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="far fa-user-circle"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-author">
+										Anni and Thommy					</span>
+								</li>
+				</ul>
+						</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				</div>
+				</article>
+				<article id="post-3320" class="elementor-post elementor-grid-item ecs-post-loop swiper-slide post-3320 post type-post status-publish format-standard has-post-thumbnail hentry category-digital-nomads-around-greece tag-co-working-and-co-living-spaces tag-cultural-experiences-in-peloponnese tag-digital-nomad-lifestyle tag-peloponnese tag-remote-work-in-greece ast-article-single">
+				<div data-elementor-type="loop" data-elementor-id="1677" class="elementor elementor-1677 elementor-location-single post-3320 post type-post status-publish format-standard has-post-thumbnail hentry category-digital-nomads-around-greece tag-co-working-and-co-living-spaces tag-cultural-experiences-in-peloponnese tag-digital-nomad-lifestyle tag-peloponnese tag-remote-work-in-greece ast-article-single" data-elementor-post-type="elementor_library">
+					<section class="elementor-section elementor-top-section elementor-element elementor-element-c9a124d elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-invisible" data-id="c9a124d" data-element_type="section" data-e-type="section" data-settings="{&quot;animation&quot;:&quot;fadeIn&quot;}">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-7d3ddf7" data-id="7d3ddf7" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div data-ep-wrapper-link="{&quot;url&quot;:&quot;https:\/\/workfromgreece.gr\/digital-nomads-around-greece\/why-the-peloponnese-could-be-the-next-digital-nomad-hotspot\/&quot;,&quot;is_external&quot;:&quot;&quot;,&quot;nofollow&quot;:&quot;&quot;,&quot;custom_attributes&quot;:&quot;&quot;}" style="cursor: pointer" class="bdt-element-link elementor-element elementor-element-6ba0961 elementor-invisible elementor-widget elementor-widget-theme-post-featured-image elementor-widget-image" data-id="6ba0961" data-element_type="widget" data-e-type="widget" data-settings="{&quot;_animation&quot;:&quot;zoomIn&quot;}" data-widget_type="theme-post-featured-image.default">
+				<div class="elementor-widget-container">
+																<a href="https://workfromgreece.gr/digital-nomads-around-greece/why-the-peloponnese-could-be-the-next-digital-nomad-hotspot/">
+							<img loading="lazy" width="1024" height="334" src="https://workfromgreece.gr/wp-content/uploads/2024/01/Limeni-2-1024x334.jpg" class="attachment-large size-large wp-image-3324" alt="Limeni 2" srcset="https://workfromgreece.gr/wp-content/uploads/2024/01/Limeni-2-1024x334.jpg 1024w, https://workfromgreece.gr/wp-content/uploads/2024/01/Limeni-2-300x98.jpg 300w, https://workfromgreece.gr/wp-content/uploads/2024/01/Limeni-2-768x251.jpg 768w, https://workfromgreece.gr/wp-content/uploads/2024/01/Limeni-2-1536x502.jpg 1536w, https://workfromgreece.gr/wp-content/uploads/2024/01/Limeni-2.jpg 1920w" sizes="(max-width: 1024px) 100vw, 1024px" />								</a>
+															</div>
+				</div>
+				<div class="elementor-element elementor-element-82ccd54 elementor-widget elementor-widget-theme-post-title elementor-page-title elementor-widget-heading" data-id="82ccd54" data-element_type="widget" data-e-type="widget" data-widget_type="theme-post-title.default">
+				<div class="elementor-widget-container">
+					<h1 class="elementor-heading-title elementor-size-default"><a href="https://workfromgreece.gr/digital-nomads-around-greece/why-the-peloponnese-could-be-the-next-digital-nomad-hotspot/">Why the Peloponnese Could Be the Next Digital Nomad Hotspot</a></h1>				</div>
+				</div>
+				<div class="elementor-element elementor-element-190b5f8 elementor-widget elementor-widget-post-info" data-id="190b5f8" data-element_type="widget" data-e-type="widget" data-widget_type="post-info.default">
+				<div class="elementor-widget-container">
+							<ul class="elementor-inline-items elementor-icon-list-items elementor-post-info">
+								<li class="elementor-icon-list-item elementor-repeater-item-f89b59e elementor-inline-item" itemprop="datePublished">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="fas fa-calendar"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-date">
+										<time>January 17, 2024</time>					</span>
+								</li>
+				<li class="elementor-icon-list-item elementor-repeater-item-6f7e1b5 elementor-inline-item" itemprop="about">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="fas fa-tags"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-terms">
+										<span class="elementor-post-info__terms-list">
+				<span class="elementor-post-info__terms-list-item">Co-working and Co-living Spaces</span>, <span class="elementor-post-info__terms-list-item">Cultural Experiences in Peloponnese</span>, <span class="elementor-post-info__terms-list-item">Digital Nomad Lifestyle</span>, <span class="elementor-post-info__terms-list-item">Peloponnese</span>, <span class="elementor-post-info__terms-list-item">Remote Work in Greece</span>				</span>
+					</span>
+								</li>
+				<li class="elementor-icon-list-item elementor-repeater-item-9e44518 elementor-inline-item" itemprop="author">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="far fa-user-circle"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-author">
+										Dominik and Josefine					</span>
+								</li>
+				</ul>
+						</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				</div>
+				</article>
+				<article id="post-3189" class="elementor-post elementor-grid-item ecs-post-loop swiper-slide post-3189 post type-post status-publish format-standard has-post-thumbnail hentry category-digital-nomads-around-greece category-islands ast-article-single">
+				<div data-elementor-type="loop" data-elementor-id="1677" class="elementor elementor-1677 elementor-location-single post-3189 post type-post status-publish format-standard has-post-thumbnail hentry category-digital-nomads-around-greece category-islands ast-article-single" data-elementor-post-type="elementor_library">
+					<section class="elementor-section elementor-top-section elementor-element elementor-element-c9a124d elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-invisible" data-id="c9a124d" data-element_type="section" data-e-type="section" data-settings="{&quot;animation&quot;:&quot;fadeIn&quot;}">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-7d3ddf7" data-id="7d3ddf7" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div data-ep-wrapper-link="{&quot;url&quot;:&quot;https:\/\/workfromgreece.gr\/digital-nomads-around-greece\/a-digital-nomad-guide-to-crete\/&quot;,&quot;is_external&quot;:&quot;&quot;,&quot;nofollow&quot;:&quot;&quot;,&quot;custom_attributes&quot;:&quot;&quot;}" style="cursor: pointer" class="bdt-element-link elementor-element elementor-element-6ba0961 elementor-invisible elementor-widget elementor-widget-theme-post-featured-image elementor-widget-image" data-id="6ba0961" data-element_type="widget" data-e-type="widget" data-settings="{&quot;_animation&quot;:&quot;zoomIn&quot;}" data-widget_type="theme-post-featured-image.default">
+				<div class="elementor-widget-container">
+																<a href="https://workfromgreece.gr/digital-nomads-around-greece/a-digital-nomad-guide-to-crete/">
+							<img loading="lazy" width="1024" height="682" src="https://workfromgreece.gr/wp-content/uploads/2024/01/DJI_0830-1024x682.jpg" class="attachment-large size-large wp-image-3191" alt="DJI 0830" srcset="https://workfromgreece.gr/wp-content/uploads/2024/01/DJI_0830-1024x682.jpg 1024w, https://workfromgreece.gr/wp-content/uploads/2024/01/DJI_0830-300x200.jpg 300w, https://workfromgreece.gr/wp-content/uploads/2024/01/DJI_0830-768x512.jpg 768w, https://workfromgreece.gr/wp-content/uploads/2024/01/DJI_0830-1536x1023.jpg 1536w, https://workfromgreece.gr/wp-content/uploads/2024/01/DJI_0830.jpg 1920w" sizes="(max-width: 1024px) 100vw, 1024px" />								</a>
+															</div>
+				</div>
+				<div class="elementor-element elementor-element-82ccd54 elementor-widget elementor-widget-theme-post-title elementor-page-title elementor-widget-heading" data-id="82ccd54" data-element_type="widget" data-e-type="widget" data-widget_type="theme-post-title.default">
+				<div class="elementor-widget-container">
+					<h1 class="elementor-heading-title elementor-size-default"><a href="https://workfromgreece.gr/digital-nomads-around-greece/a-digital-nomad-guide-to-crete/">A digital nomad guide to Crete</a></h1>				</div>
+				</div>
+				<div class="elementor-element elementor-element-190b5f8 elementor-widget elementor-widget-post-info" data-id="190b5f8" data-element_type="widget" data-e-type="widget" data-widget_type="post-info.default">
+				<div class="elementor-widget-container">
+							<ul class="elementor-inline-items elementor-icon-list-items elementor-post-info">
+								<li class="elementor-icon-list-item elementor-repeater-item-f89b59e elementor-inline-item" itemprop="datePublished">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="fas fa-calendar"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-date">
+										<time>January 4, 2024</time>					</span>
+								</li>
+				<li class="elementor-icon-list-item elementor-repeater-item-9e44518 elementor-inline-item" itemprop="author">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="far fa-user-circle"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-author">
+										Julia Persson					</span>
+								</li>
+				</ul>
+						</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				</div>
+				</article>
+				<article id="post-3110" class="elementor-post elementor-grid-item ecs-post-loop swiper-slide post-3110 post type-post status-publish format-standard has-post-thumbnail hentry category-digital-nomads-around-greece tag-co-working-spaces tag-paros tag-travel-tips tag-visa ast-article-single">
+				<div data-elementor-type="loop" data-elementor-id="1677" class="elementor elementor-1677 elementor-location-single post-3110 post type-post status-publish format-standard has-post-thumbnail hentry category-digital-nomads-around-greece tag-co-working-spaces tag-paros tag-travel-tips tag-visa ast-article-single" data-elementor-post-type="elementor_library">
+					<section class="elementor-section elementor-top-section elementor-element elementor-element-c9a124d elementor-section-boxed elementor-section-height-default elementor-section-height-default elementor-invisible" data-id="c9a124d" data-element_type="section" data-e-type="section" data-settings="{&quot;animation&quot;:&quot;fadeIn&quot;}">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-7d3ddf7" data-id="7d3ddf7" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div data-ep-wrapper-link="{&quot;url&quot;:&quot;https:\/\/workfromgreece.gr\/digital-nomads-around-greece\/remote-work-on-paros-a-nomads-blueprint-for-island-life\/&quot;,&quot;is_external&quot;:&quot;&quot;,&quot;nofollow&quot;:&quot;&quot;,&quot;custom_attributes&quot;:&quot;&quot;}" style="cursor: pointer" class="bdt-element-link elementor-element elementor-element-6ba0961 elementor-invisible elementor-widget elementor-widget-theme-post-featured-image elementor-widget-image" data-id="6ba0961" data-element_type="widget" data-e-type="widget" data-settings="{&quot;_animation&quot;:&quot;zoomIn&quot;}" data-widget_type="theme-post-featured-image.default">
+				<div class="elementor-widget-container">
+																<a href="https://workfromgreece.gr/digital-nomads-around-greece/remote-work-on-paros-a-nomads-blueprint-for-island-life/">
+							<img loading="lazy" width="900" height="600" src="https://workfromgreece.gr/wp-content/uploads/2023/11/Naousa.jpeg" class="attachment-large size-large wp-image-3020" alt="" srcset="https://workfromgreece.gr/wp-content/uploads/2023/11/Naousa.jpeg 900w, https://workfromgreece.gr/wp-content/uploads/2023/11/Naousa-300x200.jpeg 300w, https://workfromgreece.gr/wp-content/uploads/2023/11/Naousa-768x512.jpeg 768w" sizes="(max-width: 900px) 100vw, 900px" />								</a>
+															</div>
+				</div>
+				<div class="elementor-element elementor-element-82ccd54 elementor-widget elementor-widget-theme-post-title elementor-page-title elementor-widget-heading" data-id="82ccd54" data-element_type="widget" data-e-type="widget" data-widget_type="theme-post-title.default">
+				<div class="elementor-widget-container">
+					<h1 class="elementor-heading-title elementor-size-default"><a href="https://workfromgreece.gr/digital-nomads-around-greece/remote-work-on-paros-a-nomads-blueprint-for-island-life/">Remote Work on Paros: A Nomad&#8217;s Blueprint for Island Life</a></h1>				</div>
+				</div>
+				<div class="elementor-element elementor-element-190b5f8 elementor-widget elementor-widget-post-info" data-id="190b5f8" data-element_type="widget" data-e-type="widget" data-widget_type="post-info.default">
+				<div class="elementor-widget-container">
+							<ul class="elementor-inline-items elementor-icon-list-items elementor-post-info">
+								<li class="elementor-icon-list-item elementor-repeater-item-f89b59e elementor-inline-item" itemprop="datePublished">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="fas fa-calendar"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-date">
+										<time>November 3, 2023</time>					</span>
+								</li>
+				<li class="elementor-icon-list-item elementor-repeater-item-6f7e1b5 elementor-inline-item" itemprop="about">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="fas fa-tags"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-terms">
+										<span class="elementor-post-info__terms-list">
+				<span class="elementor-post-info__terms-list-item">Co-working spaces</span>, <span class="elementor-post-info__terms-list-item">Paros</span>, <span class="elementor-post-info__terms-list-item">Travel Tips</span>, <span class="elementor-post-info__terms-list-item">visa</span>				</span>
+					</span>
+								</li>
+				<li class="elementor-icon-list-item elementor-repeater-item-9e44518 elementor-inline-item" itemprop="author">
+										<span class="elementor-icon-list-icon">
+								<i aria-hidden="true" class="far fa-user-circle"></i>							</span>
+									<span class="elementor-icon-list-text elementor-post-info__item elementor-post-info__item--type-author">
+										NomadsTwoGo					</span>
+								</li>
+				</ul>
+						</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				</div>
+				</article>
+				</div>
+		</div>				</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				<section class="elementor-section elementor-top-section elementor-element elementor-element-1d64c3a elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="1d64c3a" data-element_type="section" data-e-type="section">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-84eb30f" data-id="84eb30f" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-2c55acf elementor-post-navigation-borders-yes elementor-widget elementor-widget-post-navigation" data-id="2c55acf" data-element_type="widget" data-e-type="widget" data-widget_type="post-navigation.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-post-navigation" role="navigation" aria-label="Post Navigation">
+			<div class="elementor-post-navigation__prev elementor-post-navigation__link">
+				<a href="https://workfromgreece.gr/digital-nomads-around-greece/a-guide-for-working-and-living-in-pelion/" rel="prev"><span class="post-navigation__arrow-wrapper post-navigation__arrow-prev"><i aria-hidden="true" class="fas fa-angle-left"></i><span class="elementor-screen-only">Prev</span></span><span class="elementor-post-navigation__link__prev"><span class="post-navigation__prev--label">Previous</span><span class="post-navigation__prev--title">Pelion: A first-person guide for digital nomads</span></span></a>			</div>
+							<div class="elementor-post-navigation__separator-wrapper">
+					<div class="elementor-post-navigation__separator"></div>
+				</div>
+						<div class="elementor-post-navigation__next elementor-post-navigation__link">
+				<a href="https://workfromgreece.gr/mainland/nomad-fest-work-from-greece/" rel="next"><span class="elementor-post-navigation__link__next"><span class="post-navigation__next--label">Next</span><span class="post-navigation__next--title">Bansko Nomad Fest <> Work From Greece</span></span><span class="post-navigation__arrow-wrapper post-navigation__arrow-next"><i aria-hidden="true" class="fas fa-angle-right"></i><span class="elementor-screen-only">Next</span></span></a>			</div>
+		</div>
+						</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				<section class="elementor-section elementor-top-section elementor-element elementor-element-ee5e817 elementor-section-full_width elementor-section-height-default elementor-section-height-default" data-id="ee5e817" data-element_type="section" data-e-type="section">
+						<div class="elementor-container elementor-column-gap-no">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-79896d7" data-id="79896d7" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-8b295f5 elementor-widget elementor-widget-spacer" data-id="8b295f5" data-element_type="widget" data-e-type="widget" data-widget_type="spacer.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-spacer">
+			<div class="elementor-spacer-inner"></div>
+		</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-3ff1916 elementor-widget elementor-widget-shortcode" data-id="3ff1916" data-element_type="widget" data-e-type="widget" data-widget_type="shortcode.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-shortcode"><style>
+	section.footer img.main_logo {
+		filter: brightness(255);
+	}
+</style>
+<section class="block footer column">
+	<div class="row">
+		<div class="col-50">
+			<div class="logo">
+				<a href='/'><img class="margin-left"></a>
+			</div>
+			<div class="row margin-left">
+				<div class="socials_and_sponsor row">
+					<div class="social_media_wrapper  row">
+																					<a  name="Facebook" 
+									class="icon facebook" 
+									target="_blank" 
+									href="https://www.facebook.com/WorkFromGR">
+									Facebook								</a>
+															<a  name="Instagram" 
+									class="icon instagram" 
+									target="_blank" 
+									href="https://www.instagram.com/workfromgreece_/">
+									Instagram								</a>
+															<a  name="Twitter" 
+									class="icon twitter" 
+									target="_blank" 
+									href="https://twitter.com/workfrom_Greece">
+									Twitter								</a>
+															<a  name="LinkedIn" 
+									class="icon linkedin" 
+									target="_blank" 
+									href="https://www.linkedin.com/company/workfromgreece/">
+									LinkedIn								</a>
+															<a  name="TikTok" 
+									class="icon tiktok" 
+									target="_blank" 
+									href="https://www.tiktok.com/@workfromgreece">
+									TikTok								</a>
+																		</div>
+					<div class="sponsor">
+						<span>POWERED BY</span>
+						<img>
+					</div>
+				</div>
+			</div>
+			<div class="row margin-left auspices_of_title">
+				<span>Under the auspices of</span>
+			</div>
+			<div class="row margin-left auspices_of">
+				<img class="footer_ministry1_logo">
+				<img class="footer_ministry2_logo">
+			</div>
+		</div>
+
+
+		<div class="col-50">
+			<div class="form margin-right">
+				<script>(function() {
+	window.mc4wp = window.mc4wp || {
+		listeners: [],
+		forms: {
+			on: function(evt, cb) {
+				window.mc4wp.listeners.push(
+					{
+						event   : evt,
+						callback: cb
+					}
+				);
+			}
+		}
+	}
+})();
+</script><!-- Mailchimp for WordPress v4.12.5 - https://wordpress.org/plugins/mailchimp-for-wp/ --><form id="mc4wp-form-1" class="mc4wp-form mc4wp-form-187" method="post" data-id="187" data-name="Newsletter" ><div class="mc4wp-form-fields"><span>Join our Newsletter</span>
+<input type="email" name="EMAIL" placeholder="e-mail" required />
+<label>
+    <input name="AGREE_TO_TERMS" type="checkbox" value="1" required=""> <a href="/terms" target="_blank">I have read and agree to the terms &amp; conditions</a>
+</label>
+<input class="button-default" type="submit" value="SUBSCRIBE" />
+</div><label style="display: none !important;">Leave this field empty if you're human: <input type="text" name="_mc4wp_honeypot" value="" tabindex="-1" autocomplete="off" /></label><input type="hidden" name="_mc4wp_timestamp" value="1780895408" /><input type="hidden" name="_mc4wp_form_id" value="187" /><input type="hidden" name="_mc4wp_form_element_id" value="mc4wp-form-1" /><div class="mc4wp-response"></div></form><!-- / Mailchimp for WordPress Plugin -->			</div>
+		</div>
+	</div>
+
+	<div class="container">
+		<div class="row">
+			<div class="footer-menu-wrapper">
+								<ul>
+										<li><a href="https://workfromgreece.gr/cookie-policy/">Cookie Policy</a></li>
+										<li><a href="https://workfromgreece.gr/terms-conditions/">Terms &#038; Conditions</a></li>
+										<li><a href="https://workfromgreece.gr/contact/">Contact</a></li>
+										<li><a href="https://workfromgreece.gr/about/">About</a></li>
+										<li><a href="https://www.discovergreece.com/">Discovergreece.com</a></li>
+									</ul>
+							</div>
+			<div class="creator">
+				<img>
+			</div>
+		</div>
+	</div>
+</section></div>
+						</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				</div>
+					</main><!-- #main -->
+			
+		
+	</div><!-- #primary -->
+
+
+<!--WPFC_FOOTER_START-->	</div> <!-- ast-container -->
+	</div><!-- #content -->
+		<footer itemtype="https://schema.org/WPFooter" itemscope="itemscope" id="colophon" role="contentinfo">
+			<div class='footer-width-fixer'>		<div data-elementor-type="wp-post" data-elementor-id="84" class="elementor elementor-84" data-elementor-post-type="elementor-hf">
+						<section class="elementor-section elementor-top-section elementor-element elementor-element-0bce2f1 upper-footer elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="0bce2f1" data-element_type="section" data-e-type="section" id="upper-footer" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-33 elementor-top-column elementor-element elementor-element-180e91b" data-id="180e91b" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap">
+							</div>
+		</div>
+				<div class="elementor-column elementor-col-33 elementor-top-column elementor-element elementor-element-862c04c" data-id="862c04c" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap">
+							</div>
+		</div>
+				<div class="elementor-column elementor-col-33 elementor-top-column elementor-element elementor-element-ee0ba8c" data-id="ee0ba8c" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap">
+							</div>
+		</div>
+					</div>
+		</section>
+				<section class="elementor-section elementor-top-section elementor-element elementor-element-7d2ec91 bottom-footer mobile-hide elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="7d2ec91" data-element_type="section" data-e-type="section" id="bottom-footer" data-settings="{&quot;background_background&quot;:&quot;classic&quot;}">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-25 elementor-top-column elementor-element elementor-element-e6b2def" data-id="e6b2def" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-b09b630 elementor-widget elementor-widget-text-editor" data-id="b09b630" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<p>©2020 Marketing Greece</p>								</div>
+				</div>
+					</div>
+		</div>
+				<div class="elementor-column elementor-col-50 elementor-top-column elementor-element elementor-element-d14141c" data-id="d14141c" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-af241bf elementor-widget elementor-widget-text-editor" data-id="af241bf" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<p><a href="/terms-conditions">Terms &amp; Conditions</a> | <a href="/cookie-policy">Cookie Policy</a></p>								</div>
+				</div>
+					</div>
+		</div>
+				<div class="elementor-column elementor-col-25 elementor-top-column elementor-element elementor-element-4cb2277" data-id="4cb2277" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-56599c9 elementor-widget elementor-widget-text-editor" data-id="56599c9" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<p>Made by Giraffes in The Kitchen</p>								</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				<section class="elementor-section elementor-top-section elementor-element elementor-element-5f1dd2e bottom-footer mobile-show elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="5f1dd2e" data-element_type="section" data-e-type="section">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-f799526" data-id="f799526" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-3c64df2 elementor-widget elementor-widget-text-editor" data-id="3c64df2" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<p><a href="/terms-conditions">Terms &amp; Conditions</a></p><p><a href="/cookie-policy">Cookie Policy</a></p>								</div>
+				</div>
+				<div class="elementor-element elementor-element-1f4a630 elementor-widget elementor-widget-text-editor" data-id="1f4a630" data-element_type="widget" data-e-type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+									<p>Made by Giraffes in The Kitchen</p>								</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				<section class="elementor-section elementor-top-section elementor-element elementor-element-b7c8bfd share-buttons elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="b7c8bfd" data-element_type="section" data-e-type="section">
+						<div class="elementor-container elementor-column-gap-default">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-2a741e3" data-id="2a741e3" data-element_type="column" data-e-type="column">
+			<div class="elementor-widget-wrap elementor-element-populated">
+						<div class="elementor-element elementor-element-d3b8d5b elementor-share-buttons--view-icon elementor-grid-3 elementor-share-buttons--skin-gradient elementor-share-buttons--shape-square elementor-share-buttons--color-official elementor-widget elementor-widget-share-buttons" data-id="d3b8d5b" data-element_type="widget" data-e-type="widget" data-settings="{&quot;share_url&quot;:{&quot;url&quot;:&quot;https:\/\/www.endlessgreeksummer.gr&quot;,&quot;is_external&quot;:&quot;&quot;,&quot;nofollow&quot;:&quot;&quot;,&quot;custom_attributes&quot;:&quot;&quot;}}" data-widget_type="share-buttons.default">
+				<div class="elementor-widget-container">
+							<div class="elementor-grid" role="list">
+								<div class="elementor-grid-item" role="listitem">
+						<div class="elementor-share-btn elementor-share-btn_facebook" role="button" tabindex="0" aria-label="Share on facebook">
+															<span class="elementor-share-btn__icon">
+								<i class="fab fa-facebook" aria-hidden="true"></i>							</span>
+																				</div>
+					</div>
+									<div class="elementor-grid-item" role="listitem">
+						<div class="elementor-share-btn elementor-share-btn_twitter" role="button" tabindex="0" aria-label="Share on twitter">
+															<span class="elementor-share-btn__icon">
+								<i class="fab fa-twitter" aria-hidden="true"></i>							</span>
+																				</div>
+					</div>
+									<div class="elementor-grid-item" role="listitem">
+						<div class="elementor-share-btn elementor-share-btn_email" role="button" tabindex="0" aria-label="Share on email">
+															<span class="elementor-share-btn__icon">
+								<i class="fas fa-envelope" aria-hidden="true"></i>							</span>
+																				</div>
+					</div>
+						</div>
+						</div>
+				</div>
+					</div>
+		</div>
+					</div>
+		</section>
+				</div>
+		</div>		</footer>
+		</div><!-- #page -->
+<script type="speculationrules">
+{"prefetch":[{"source":"document","where":{"and":[{"href_matches":"/*"},{"not":{"href_matches":["/wp-*.php","/wp-admin/*","/wp-content/uploads/*","/wp-content/*","/wp-content/plugins/*","/wp-content/themes/work-from-greece/*","/wp-content/themes/astra/*","/*\\?(.+)"]}},{"not":{"selector_matches":"a[rel~=\"nofollow\"]"}},{"not":{"selector_matches":".no-prefetch, .no-prefetch a"}}]},"eagerness":"conservative"}]}
+</script>
+<!--googleoff: all--><div id="cookie-law-info-bar" data-nosnippet="true"><span>This website uses cookies to improve your experience. We'll assume you're ok with this, but you can opt-out if you wish. <a role="button" class="cli_settings_button" style="margin:5px 20px 5px 20px">Cookie settings</a><a id="wt-cli-accept-all-btn" role="button" data-cli_action="accept_all" class="wt-cli-element medium cli-plugin-button wt-cli-accept-all-btn cookie_action_close_header cli_action_button">Accept All</a><a role="button" id="cookie_action_close_header_reject" class="medium cli-plugin-button cli-plugin-main-button cookie_action_close_header_reject cli_action_button wt-cli-reject-btn" data-cli_action="reject" style="margin:5px">REJECT</a><a href="https://workfromgreece.gr/cookie-policy" id="CONSTANT_OPEN_URL" target="_blank" class="cli-plugin-main-link" style="display:inline-block;margin:5px">Read More</a></span></div><div id="cookie-law-info-again" style="display:none" data-nosnippet="true"><span id="cookie_hdr_showagain">Privacy &amp; Cookies Policy</span></div><div class="cli-modal" data-nosnippet="true" id="cliSettingsPopup" tabindex="-1" role="dialog" aria-labelledby="cliSettingsPopup" aria-hidden="true">
+  <div class="cli-modal-dialog" role="document">
+	<div class="cli-modal-content cli-bar-popup">
+		  <button type="button" class="cli-modal-close" id="cliModalClose">
+			<svg class="" viewBox="0 0 24 24"><path d="M19 6.41l-1.41-1.41-5.59 5.59-5.59-5.59-1.41 1.41 5.59 5.59-5.59 5.59 1.41 1.41 5.59-5.59 5.59 5.59 1.41-1.41-5.59-5.59z"></path><path d="M0 0h24v24h-24z" fill="none"></path></svg>
+			<span class="wt-cli-sr-only">Close</span>
+		  </button>
+		  <div class="cli-modal-body">
+			<div class="cli-container-fluid cli-tab-container">
+	<div class="cli-row">
+		<div class="cli-col-12 cli-align-items-stretch cli-px-0">
+			<div class="cli-privacy-overview">
+				<h4>Privacy Overview</h4>				<div class="cli-privacy-content">
+					<div class="cli-privacy-content-text">This website uses cookies to improve your experience while you navigate through the website. Out of these cookies, the cookies that are categorized as necessary are stored on your browser as they are essential for the working of basic functionalities of the website. We also use third-party cookies that help us analyze and understand how you use this website. These cookies will be stored in your browser only with your consent. You also have the option to opt-out of these cookies. But opting out of some of these cookies may have an effect on your browsing experience.</div>
+				</div>
+				<a class="cli-privacy-readmore" aria-label="Show more" role="button" data-readmore-text="Show more" data-readless-text="Show less"></a>			</div>
+		</div>
+		<div class="cli-col-12 cli-align-items-stretch cli-px-0 cli-tab-section-container">
+												<div class="cli-tab-section">
+						<div class="cli-tab-header">
+							<a role="button" tabindex="0" class="cli-nav-link cli-settings-mobile" data-target="necessary" data-toggle="cli-toggle-tab">
+								Necessary							</a>
+																						<div class="wt-cli-necessary-checkbox">
+									<input type="checkbox" class="cli-user-preference-checkbox" id="wt-cli-checkbox-necessary" data-id="checkbox-necessary" checked="checked" />
+									<label class="form-check-label" for="wt-cli-checkbox-necessary">Necessary</label>
+								</div>
+								<span class="cli-necessary-caption">Always Enabled</span>
+													</div>
+						<div class="cli-tab-content">
+							<div class="cli-tab-pane cli-fade" data-id="necessary">
+								<div class="wt-cli-cookie-description">
+									Necessary cookies are absolutely essential for the website to function properly. This category only includes cookies that ensures basic functionalities and security features of the website. These cookies do not store any personal information.								</div>
+							</div>
+						</div>
+					</div>
+																	<div class="cli-tab-section">
+						<div class="cli-tab-header">
+							<a role="button" tabindex="0" class="cli-nav-link cli-settings-mobile" data-target="non-necessary" data-toggle="cli-toggle-tab">
+								Non-necessary							</a>
+																						<div class="cli-switch">
+									<input type="checkbox" id="wt-cli-checkbox-non-necessary" class="cli-user-preference-checkbox" data-id="checkbox-non-necessary" checked='checked' />
+									<label for="wt-cli-checkbox-non-necessary" class="cli-slider" data-cli-enable="Enabled" data-cli-disable="Disabled"><span class="wt-cli-sr-only">Non-necessary</span></label>
+								</div>
+													</div>
+						<div class="cli-tab-content">
+							<div class="cli-tab-pane cli-fade" data-id="non-necessary">
+								<div class="wt-cli-cookie-description">
+									Any cookies that may not be particularly necessary for the website to function and is used specifically to collect user personal data via analytics, ads, other embedded contents are termed as non-necessary cookies. It is mandatory to procure user consent prior to running these cookies on your website.								</div>
+							</div>
+						</div>
+					</div>
+																	<div class="cli-tab-section">
+						<div class="cli-tab-header">
+							<a role="button" tabindex="0" class="cli-nav-link cli-settings-mobile" data-target="functional" data-toggle="cli-toggle-tab">
+								Functional							</a>
+																						<div class="cli-switch">
+									<input type="checkbox" id="wt-cli-checkbox-functional" class="cli-user-preference-checkbox" data-id="checkbox-functional" />
+									<label for="wt-cli-checkbox-functional" class="cli-slider" data-cli-enable="Enabled" data-cli-disable="Disabled"><span class="wt-cli-sr-only">Functional</span></label>
+								</div>
+													</div>
+						<div class="cli-tab-content">
+							<div class="cli-tab-pane cli-fade" data-id="functional">
+								<div class="wt-cli-cookie-description">
+									Functional cookies help to perform certain functionalities like sharing the content of the website on social media platforms, collect feedbacks, and other third-party features.
+								</div>
+							</div>
+						</div>
+					</div>
+																	<div class="cli-tab-section">
+						<div class="cli-tab-header">
+							<a role="button" tabindex="0" class="cli-nav-link cli-settings-mobile" data-target="performance" data-toggle="cli-toggle-tab">
+								Performance							</a>
+																						<div class="cli-switch">
+									<input type="checkbox" id="wt-cli-checkbox-performance" class="cli-user-preference-checkbox" data-id="checkbox-performance" />
+									<label for="wt-cli-checkbox-performance" class="cli-slider" data-cli-enable="Enabled" data-cli-disable="Disabled"><span class="wt-cli-sr-only">Performance</span></label>
+								</div>
+													</div>
+						<div class="cli-tab-content">
+							<div class="cli-tab-pane cli-fade" data-id="performance">
+								<div class="wt-cli-cookie-description">
+									Performance cookies are used to understand and analyze the key performance indexes of the website which helps in delivering a better user experience for the visitors.
+<table class="cookielawinfo-row-cat-table cookielawinfo-winter"><thead><tr><th class="cookielawinfo-column-1">Cookie</th><th class="cookielawinfo-column-3">Duration</th><th class="cookielawinfo-column-4">Description</th></tr></thead><tbody><tr class="cookielawinfo-row"><td class="cookielawinfo-column-1">dtCookie</td><td class="cookielawinfo-column-3">session</td><td class="cookielawinfo-column-4">This cookie is set by the provider Dynatrace. This is a session cookie used to collect information for Dynatrace. Its a system to track application performance and user errors.</td></tr></tbody></table>								</div>
+							</div>
+						</div>
+					</div>
+																	<div class="cli-tab-section">
+						<div class="cli-tab-header">
+							<a role="button" tabindex="0" class="cli-nav-link cli-settings-mobile" data-target="analytics" data-toggle="cli-toggle-tab">
+								Analytics							</a>
+																						<div class="cli-switch">
+									<input type="checkbox" id="wt-cli-checkbox-analytics" class="cli-user-preference-checkbox" data-id="checkbox-analytics" />
+									<label for="wt-cli-checkbox-analytics" class="cli-slider" data-cli-enable="Enabled" data-cli-disable="Disabled"><span class="wt-cli-sr-only">Analytics</span></label>
+								</div>
+													</div>
+						<div class="cli-tab-content">
+							<div class="cli-tab-pane cli-fade" data-id="analytics">
+								<div class="wt-cli-cookie-description">
+									Analytical cookies are used to understand how visitors interact with the website. These cookies help provide information on metrics the number of visitors, bounce rate, traffic source, etc.
+<table class="cookielawinfo-row-cat-table cookielawinfo-winter"><thead><tr><th class="cookielawinfo-column-1">Cookie</th><th class="cookielawinfo-column-3">Duration</th><th class="cookielawinfo-column-4">Description</th></tr></thead><tbody><tr class="cookielawinfo-row"><td class="cookielawinfo-column-1">CONSENT</td><td class="cookielawinfo-column-3">2 years</td><td class="cookielawinfo-column-4">YouTube sets this cookie via embedded youtube-videos and registers anonymous statistical data.</td></tr></tbody></table>								</div>
+							</div>
+						</div>
+					</div>
+																	<div class="cli-tab-section">
+						<div class="cli-tab-header">
+							<a role="button" tabindex="0" class="cli-nav-link cli-settings-mobile" data-target="advertisement" data-toggle="cli-toggle-tab">
+								Advertisement							</a>
+																						<div class="cli-switch">
+									<input type="checkbox" id="wt-cli-checkbox-advertisement" class="cli-user-preference-checkbox" data-id="checkbox-advertisement" />
+									<label for="wt-cli-checkbox-advertisement" class="cli-slider" data-cli-enable="Enabled" data-cli-disable="Disabled"><span class="wt-cli-sr-only">Advertisement</span></label>
+								</div>
+													</div>
+						<div class="cli-tab-content">
+							<div class="cli-tab-pane cli-fade" data-id="advertisement">
+								<div class="wt-cli-cookie-description">
+									Advertisement cookies are used to provide visitors with relevant ads and marketing campaigns. These cookies track visitors across websites and collect information to provide customized ads.
+<table class="cookielawinfo-row-cat-table cookielawinfo-winter"><thead><tr><th class="cookielawinfo-column-1">Cookie</th><th class="cookielawinfo-column-3">Duration</th><th class="cookielawinfo-column-4">Description</th></tr></thead><tbody><tr class="cookielawinfo-row"><td class="cookielawinfo-column-1">VISITOR_INFO1_LIVE</td><td class="cookielawinfo-column-3">5 months 27 days</td><td class="cookielawinfo-column-4">A cookie set by YouTube to measure bandwidth that determines whether the user gets the new or old player interface.</td></tr><tr class="cookielawinfo-row"><td class="cookielawinfo-column-1">YSC</td><td class="cookielawinfo-column-3">session</td><td class="cookielawinfo-column-4">YSC cookie is set by Youtube and is used to track the views of embedded videos on Youtube pages.</td></tr></tbody></table>								</div>
+							</div>
+						</div>
+					</div>
+																	<div class="cli-tab-section">
+						<div class="cli-tab-header">
+							<a role="button" tabindex="0" class="cli-nav-link cli-settings-mobile" data-target="others" data-toggle="cli-toggle-tab">
+								Others							</a>
+																						<div class="cli-switch">
+									<input type="checkbox" id="wt-cli-checkbox-others" class="cli-user-preference-checkbox" data-id="checkbox-others" />
+									<label for="wt-cli-checkbox-others" class="cli-slider" data-cli-enable="Enabled" data-cli-disable="Disabled"><span class="wt-cli-sr-only">Others</span></label>
+								</div>
+													</div>
+						<div class="cli-tab-content">
+							<div class="cli-tab-pane cli-fade" data-id="others">
+								<div class="wt-cli-cookie-description">
+									Other uncategorized cookies are those that are being analyzed and have not been classified into a category as yet.
+								</div>
+							</div>
+						</div>
+					</div>
+										</div>
+	</div>
+</div>
+		  </div>
+		  <div class="cli-modal-footer">
+			<div class="wt-cli-element cli-container-fluid cli-tab-container">
+				<div class="cli-row">
+					<div class="cli-col-12 cli-align-items-stretch cli-px-0">
+						<div class="cli-tab-footer wt-cli-privacy-overview-actions">
+						
+															<a id="wt-cli-privacy-save-btn" role="button" tabindex="0" data-cli-action="accept" class="wt-cli-privacy-btn cli_setting_save_button wt-cli-privacy-accept-btn cli-btn">SAVE &amp; ACCEPT</a>
+													</div>
+												<div class="wt-cli-ckyes-footer-section">
+							<div class="wt-cli-ckyes-brand-logo">Powered by <a href="https://www.cookieyes.com/"><img src="https://workfromgreece.gr/wp-content/plugins/cookie-law-info/legacy/public/images/logo-cookieyes.svg" alt="CookieYes Logo"></a></div>
+						</div>
+						
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+  </div>
+</div>
+<div class="cli-modal-backdrop cli-fade cli-settings-overlay"></div>
+<div class="cli-modal-backdrop cli-fade cli-popupbar-overlay"></div>
+<!--googleon: all--><!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PVJD4J5"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->			
+			<style type="text/css">.wp-chatbot-container {
+					background-image: url(https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/images/background/bg-03.jpg);
+					
+				}</style>			<div id="wp-chatbot-chat-container" class="floatingbot_delay  wp-chatbot-mobile-full-screen  qcchatbot-template-08">
+	
+				<div id="wp-chatbot-integration-container">
+	
+					<div class="wp-chatbot-integration-button-container">
+																								
+						
+												
+												
+						
+							
+																				
+					</div>
+				</div>
+				
+	<style>
+	.wp-bot-header {
+		background: #f3ea23 !important;
+	}
+	.wp-bot-header path {
+		fill: #f3ea23 !important;
+	}
+	</style>
+
+
+
+	<style>
+	button.wp-chatbot-button {
+		background-color: #4bc6cc !important;
+	}
+	</style>
+
+
+<div id="wp-chatbot-ball-container" class="wp-chatbot-template-01">
+		<div class="wpbot-saas-live-chat"> </div>
+	<div class="wp-chatbot-container">
+
+	
+	<div id="wp-chatbot-board-container" class="wp-chatbot-board-container">
+		<div class="wp-bot-header">
+		<div class="wp-bot-header-title">
+			<span>
+			<img src="https://workfromgreece.gr/wp-content/uploads/2025/01/wfg-bot.png"/>
+			</span>
+			<span class="wp-bot-header-title-text">
+			Chat with us!			</span>
+		</div>
+
+		
+		<div class="wp-bot-header-close-icon">
+		  
+			<div class="wp-chatbot-header">
+			
+							<div id="wp-chatbot-email-transcript" title="Send Me the Transcript Via Email."><i class="fa fa-envelope" aria-hidden="true"></i></div>
+						
+			<div id="wp-chatbot-desktop-close" title="reset">
+				<i class="fa fa-times" aria-hidden="true"></i>
+			</div>
+
+			<div id="wp-chatbot-desktop-reload" title="reset">
+				<i class="fa fa-refresh" aria-hidden="true"></i>
+			</div>
+
+			
+			</div>
+		  
+		</div>
+		
+		<div class="SVGBg" style="height: 55px;overflow: hidden;background: #fff;" >
+			<svg viewBox="0 0 500 150" preserveAspectRatio="none" style="height: 100%; width: 100%;">
+			<path d="M0.00,49.98 C144.19,123.84 281.88,-28.13 500.00,49.98 L500.00,0.00 L0.00,0.00 Z" style="stroke: none; fill: #1f51e3;"></path>
+			</svg>
+		</div>
+
+		</div>
+
+		<div class="wp-chatbot-ball-inner wp-chatbot-content"> 
+		<!-- only show on Mobile app -->
+				<div class="wp-chatbot-messages-wrapper">
+			<ul id="wp-chatbot-messages-container" class="wp-chatbot-messages-container">
+			</ul>
+		</div>
+		</div>
+		<div class="wp-chatbot-footer">
+				<div id="wp-chatbot-editor-container" class="wp-chatbot-editor-container">
+			<input id="wp-chatbot-editor" class="wp-chatbot-editor" required placeholder="Send a message.">
+						<button type="button" id="wp-chatbot-send-message" class="wp-chatbot-button">send</button>
+		</div>
+
+		<!--wp-chatbot-editor-container-->
+				
+		<!--wp-chatbot-tab-nav--> 
+		</div>
+		<!--wp-chatbot-footer--> 
+	</div>
+	<!--wp-chatbot-board-container--> 
+	</div>
+</div>
+
+<script>
+
+jQuery(document).ready(function($){
+	$("#wp-chatbot-ball").on('click', function(){
+	$(".wp-chatbot-container").animate({left: '-340px'});
+	
+	});
+  
+	jQuery(document).on('click', 'body', function(e){
+		if(e.target.id!='menuTrigger'){
+			jQuery('#menuTrigger').removeClass('active');
+			jQuery('#menuItems').removeClass('active');
+		}
+	})
+  
+});
+
+
+const menuTrigger = document.getElementById("menuTrigger");
+const menuItems = document.getElementById("menuItems");
+
+menuTrigger.addEventListener('click', () => {
+	menuTrigger.classList.toggle('active');
+	menuItems.classList.toggle('active');
+})
+
+</script>															
+					<div id="wp-chatbot-notification-container" class="wp-chatbot-notification-container " >
+						<div class="wp-chatbot-notification-controller"> <span class="wp-chatbot-notification-close">
+						X			</span></div>
+												
+						<div class="wp-chatbot-notification-agent-profile">
+														<div class="wp-chatbot-notification-widget-avatar" ><img
+										src="https://workfromgreece.gr/wp-content/uploads/2025/01/wfg-bot.png" alt=""></div>
+							<div class="wp-chatbot-notification-welcome">
+															</div>
+							
+						</div>
+												
+						<div class="wp-chatbot-notification-message">Welcome to Work From Greece!</div>
+																							</div>
+										<!--wp-chatbot-board-container-->
+				<div id="wp-chatbot-ball" class="">
+					<button alt="Click to Open or Close the chat window" class="wp-chatbot-ball" title="Chat with us!" aria-label="Click to open or close the chatbot">
+						<div class="wp-chatbot-ball-animator wp-chatbot-ball-animation-switch"></div>
+												<img src="https://workfromgreece.gr/wp-content/uploads/2025/01/wfg-bot.png"
+							alt="wpChatIcon" qcld_agent="https://workfromgreece.gr/wp-content/uploads/2025/01/wfg-bot.png">
+							
+					</button>
+				</div>
+	
+					
+								<!--container-->
+				<!--wp-chatbot-ball-wrapper-->
+			</div>
+						<script type="text/javascript">var clickintent = {"en_US":"FAQ"}</script>	
+	<!-- The Modal -->
+	<div id="qcwpbotModal" class="qcwpbotmodal" style="display:none">
+		<!-- The Close Button -->
+		<span class="qcwpbotclose">&times;</span>
+		<!-- Modal Content (The Image) -->
+		<img class="qcwpbotmodal-content" id="qcwpbotimg01" alt="qcwpbotmodal-content">
+	</div>
+	<div id="bottooltip">
+		<span></span>
+		<div></div>
+	</div>
+	<style type="text/css">
+	#wpfooter {
+		display: none;
+	}
+	#bottooltip{
+		border-radius: 2px;
+		color: black;
+		display: none;
+		padding: 5px 10px;
+		position: fixed;
+	  
+		background-color: white;
+		-ms-filter    : "progid:DXImageTransform.Microsoft.Dropshadow(OffX=0, OffY=2, Color='#444')";
+		filter        : "progid:DXImageTransform.Microsoft.Dropshadow(OffX=0, OffY=2, Color='#444')";
+		-webkit-filter: drop-shadow(0px 2px 5px rgba(130,130,130,1));
+		filter        : drop-shadow(0px 2px 5px rgba(130,130,130,1));
+		z-index: 99;
+		max-width: 150px;
+	}
+	
+	#bottooltip > span{
+		background-color: white;
+		display: inline-block;
+		height: 8px;
+		position: absolute;
+		transform: rotate(45deg);
+		width: 8px;
+	}
+	
+	#bottooltip > div{
+		font-size: 12px;
+	}
+	</style>
+				<script>
+		( function ( body ) {
+			'use strict';
+			body.className = body.className.replace( /\btribe-no-js\b/, 'tribe-js' );
+		} )( document.body );
+		</script>
+		<script>(function() {function maybePrefixUrlField () {
+  const value = this.value.trim()
+  if (value !== '' && value.indexOf('http') !== 0) {
+    this.value = 'http://' + value
+  }
+}
+
+const urlFields = document.querySelectorAll('.mc4wp-form input[type="url"]')
+for (let j = 0; j < urlFields.length; j++) {
+  urlFields[j].addEventListener('blur', maybePrefixUrlField)
+}
+})();</script>	<script>
+		! function() {
+			var t;
+			if (t = window.botsify = window.botsify = window.botsify || [], !t.init) return t.invoked ? void(window.console && console.error && console.error("Botsify snippet included twice.")) : (t.load = function(e) {
+				var o, n;
+				o = document.createElement("script");
+				e.type = "text/javscript";
+				o.async = !0;
+				o.crossorigin = "anonymous";
+				o.src = "https://app.botsify.com/web-bot/script/frame/" + e + "/botsify.js";
+				n = document.getElementsByTagName("script")[0];
+				n.parentNode.insertBefore(o, n);
+			});
+		}();
+		botsify.load('gAORzxg0UCWcBn2PF2wAca08ejW4JQL0mp78Nau1');
+	</script>
+<script> /* <![CDATA[ */var tribe_l10n_datatables = {"aria":{"sort_ascending":": activate to sort column ascending","sort_descending":": activate to sort column descending"},"length_menu":"Show _MENU_ entries","empty_table":"No data available in table","info":"Showing _START_ to _END_ of _TOTAL_ entries","info_empty":"Showing 0 to 0 of 0 entries","info_filtered":"(filtered from _MAX_ total entries)","zero_records":"No matching records found","search":"Search:","all_selected_text":"All items on this page were selected. ","select_all_link":"Select all pages","clear_selection":"Clear Selection.","pagination":{"all":"All","next":"Next","previous":"Previous"},"select":{"rows":{"0":"","_":": Selected %d rows","1":": Selected 1 row"}},"datepicker":{"dayNames":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"dayNamesShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"dayNamesMin":["S","M","T","W","T","F","S"],"monthNames":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthNamesShort":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthNamesMin":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"nextText":"Next","prevText":"Prev","currentText":"Today","closeText":"Done","today":"Today","clear":"Clear"}};/* ]]> */ </script>			<script>
+				const lazyloadRunObserver = () => {
+					const lazyloadBackgrounds = document.querySelectorAll( `.e-con.e-parent:not(.e-lazyloaded)` );
+					const lazyloadBackgroundObserver = new IntersectionObserver( ( entries ) => {
+						entries.forEach( ( entry ) => {
+							if ( entry.isIntersecting ) {
+								let lazyloadBackground = entry.target;
+								if( lazyloadBackground ) {
+									lazyloadBackground.classList.add( 'e-lazyloaded' );
+								}
+								lazyloadBackgroundObserver.unobserve( entry.target );
+							}
+						});
+					}, { rootMargin: '200px 0px 200px 0px' } );
+					lazyloadBackgrounds.forEach( ( lazyloadBackground ) => {
+						lazyloadBackgroundObserver.observe( lazyloadBackground );
+					} );
+				};
+				const events = [
+					'DOMContentLoaded',
+					'elementor/lazyload/observe',
+				];
+				events.forEach( ( event ) => {
+					document.addEventListener( event, lazyloadRunObserver );
+				} );
+			</script>
+			<link rel='stylesheet' id='e-animation-zoomIn-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/animations/styles/zoomIn.min.css?ver=4.0.9' media='all' />
+<link rel='stylesheet' id='e-animation-fadeIn-css' href='https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/animations/styles/fadeIn.min.css?ver=4.0.9' media='all' />
+<link rel='stylesheet' id='cookie-law-info-table-css' href='https://workfromgreece.gr/wp-content/plugins/cookie-law-info/legacy/public/css/cookie-law-info-table.css?ver=3.5.0' media='all' />
+<link rel='stylesheet' id='qcld-wp-chatbot-style-css' href='https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/addons/chatbot-extended-ui/templates/template-08/style.css?ver=15.4.1' media='screen' />
+<script id="astra-theme-js-js-extra">
+var astra = {"break_point":"921","isRtl":"","is_scroll_to_id":"","is_scroll_to_top":"","is_header_footer_builder_active":"","responsive_cart_click":"flyout","is_dark_palette":""};
+//# sourceURL=astra-theme-js-js-extra
+</script>
+<script id="astra-theme-js-js" src="https://workfromgreece.gr/wp-content/themes/astra/assets/js/minified/style.min.js?ver=4.12.0"></script>
+<script id="spl-weather-block-script-js-extra">
+var splWeatherBlockFrontendLocalize = {"ajaxUrl":"https://workfromgreece.gr/wp-admin/admin-ajax.php","post_id":"2602","blockAPiNonce":"8c90d35890","_key":"f1c332851d7ec585f6b095dbf987c95eac12"};
+//# sourceURL=spl-weather-block-script-js-extra
+</script>
+<script id="spl-weather-block-script-js" src="https://workfromgreece.gr/wp-content/plugins/location-weather/includes/Blocks/assets/js/script.min.js?ver=3.0.3"></script>
+<script id="wp-hooks-js" src="https://workfromgreece.gr/wp-includes/js/dist/hooks.min.js?ver=7496969728ca0f95732d"></script>
+<script id="wp-i18n-js" src="https://workfromgreece.gr/wp-includes/js/dist/i18n.min.js?ver=781d11515ad3d91786ec"></script>
+<script id="wp-i18n-js-after">
+wp.i18n.setLocaleData( { 'text direction\u0004ltr': [ 'ltr' ] } );
+//# sourceURL=wp-i18n-js-after
+</script>
+<script id="swv-js" src="https://workfromgreece.gr/wp-content/plugins/contact-form-7/includes/swv/js/index.js?ver=6.1.6"></script>
+<script id="contact-form-7-js-before">
+var wpcf7 = {
+    "api": {
+        "root": "https:\/\/workfromgreece.gr\/wp-json\/",
+        "namespace": "contact-form-7\/v1"
+    },
+    "cached": 1
+};
+//# sourceURL=contact-form-7-js-before
+</script>
+<script id="contact-form-7-js" src="https://workfromgreece.gr/wp-content/plugins/contact-form-7/includes/js/index.js?ver=6.1.6"></script>
+<script id="qcmaskphone-js" src="https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/addons/conversational-forms-pro/assets/js/jquery.mask.js?ver=7.0"></script>
+<script id="wpform-fullcalendar-js" src="https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/addons/conversational-forms-pro/includes/calendar/index.global.min.js?ver=6.1.13"></script>
+<script id="qcld-wp-chatbot-qcquery-cake-js" src="https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/js/jquery.cookie.js?ver=15.4.1"></script>
+<script id="qcld-wp-chatbot-front-js-js-extra">
+var wp_chatbot_obj = {"wp_chatbot_position_x":"50","wp_chatbot_position_y":"50","wp_chatbot_position_mp_x":"50","wp_chatbot_position_mp_y":"50","enable_floating_icon":"1","wp_chatbot_position_in":"px","wp_chatbot_position_mp_in":"px","disable_icon_animation":"","delay_wp_chatbot_floating_icon":"100","delay_chat_window_open":"100","disable_wp_chatbot_history":"","delay_floating_notification_box":"100","disable_wp_chatbot_notification":"0","always_scroll_to_bottom":"","disable_featured_product":"","disable_product_search":"","disable_catalog":"","skip_wp_greetings":"","skip_wp_greetings_trigger_intent":"1","init_trigger_intent":{"en_US":"FAQ"},"qcld_disable_start_menu":"","skip_chat_reactions_menu":"","qlcd_wp_chatbot_like_text":"","qlcd_wp_chatbot_dislike_text":"","qlcd_wp_chatbot_share_text":"","qlcd_wp_chatbot_report_text":"","enable_chat_share_menu":"","enable_chat_report_menu":"","priority_openai_all":"","qcld_replace_start_menu":"","qcld_disable_repited_startmenu":"","show_menu_after_greetings":"0","disable_first_msg":"1","ask_email_wp_greetings":"","ask_name_confirmation":"","ask_name_auto_confirmation":"","ask_phone_wp_greetings":"","enable_wp_chatbot_open_initial":"","wp_keep_chat_window_open":"","disable_order_status":"","disable_sale_product":"","open_product_detail":"","order_user":"","ajax_url":"https://workfromgreece.gr/wp-admin/admin-ajax.php","image_path":"https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/images/","client_image":"","yes":{"en_US":"YES"},"no":{"en_US":"NO"},"or":{"en_US":"OR"},"host":{"en_US":"Work From Greece"},"agent":{"en_US":"WFG Bot"},"agent_image":"custom-agent.png","agent_image_path":"https://workfromgreece.gr/wp-content/uploads/2025/01/wfg-bot.png","shopper_demo_name":{"en_US":"Traveler"},"shopper_call_you":{"en_US":"Ok, I will just call you"},"agent_join":{"en_US":["has joined the conversation"]},"welcome":{"en_US":["Welcome to","Glad to have you at"]},"welcome_back":{"en_US":["Welcome back","Good to see your again"]},"hi_there":{"en_US":["Hi There!"]},"asking_name":{"en_US":["May I know your name?","What should I call you?"]},"asking_emailaddress":{"en_US":["May i know your email %%username%%? so i can get back to you if needed."]},"got_email":{"en_US":["Thanks for sharing your email %%username%%!"]},"email_ignore":{"en_US":["No problem %%username%%, if you do not want to share your email address!"]},"asking_phone_gt":{"en_US":["May i know your phone number %%username%%? so i can get back to you if needed."]},"got_phone":{"en_US":["Thanks for sharing your phone number %%username%%!"]},"phone_ignore":{"en_US":["No problem %%username%%, if you do not want to share your phone number!"]},"i_understand":{"en_US":["I understand that your name is %%username%%. Is that correct?"]},"i_am":{"en_US":["I am","This is"]},"name_greeting":{"en_US":["Nice to meet you, %%username%%!"]},"wildcard_msg":{"en_US":["Hi %%username%%. I am here to find what you need. What are you looking for?"]},"empty_filter_msg":{"en_US":["Sorry, I did not understand you."]},"do_you_want_to_subscribe":{"en_US":["Do you want to subscribe to our newsletter?"]},"chatbot_file_upload_succ":{"en_US":"File has been uploaded successfully!"},"qlcd_wp_chatbot_good_bye_text":{"en_US":"Ok Bye, See you soon!"},"qlcd_wp_chatbot_transcript_emailed":{"en_US":"Do you want the chat transcript to be emailed?"},"tvlyai_enabled":"0","is_page_rag_enabled":"0","chatbot_file_upload_fail":{"en_US":"Failed to upload the file."},"do_you_want_to_unsubscribe":{"en_US":["Do you want to unsubscribe from our newsletter?"]},"we_do_not_have_your_email":{"en_US":["We do not have your email in the ChatBot database."]},"you_have_successfully_unsubscribe":{"en_US":["You have successfully unsubscribed from our newsletter!"]},"is_typing":{"en_US":["is typing..."]},"send_a_msg":{"en_US":["Send a message."]},"viewed_products":{"en_US":["Recently viewed products"],"de_DE":["Recently viewed products"]},"shopping_cart":"","cart_updating":{"en_US":["Updating cart items ..."],"de_DE":["Updating cart items ..."]},"cart_removing":{"en_US":["Removing cart items ..."],"de_DE":["Removing cart items ..."]},"sys_key_help":{"en_US":"start"},"sys_key_product":{"en_US":"product","de_DE":"product"},"auto_hide_floating_button":"","sys_key_catalog":{"en_US":"catalog","de_DE":"catalog"},"sys_key_order":{"en_US":"order","de_DE":"order"},"sys_key_support":{"en_US":"faq"},"sys_key_reset":{"en_US":"reset"},"sys_goodbye_key":{"en_US":"goodbye, bye, see you soon, bye-bye, adieu, quit, stop chat, abort, stop, abort, so long"},"wbca_lg_operator_offline":"all operator is offline","sys_key_livechat":"livechat","help_welcome":{"en_US":["Welcome to Help Section."]},"tag_search_intent":["ChooseCoffee"],"back_to_start":{"en_US":["Back to Start"]},"help_msg":{"en_US":["\u003Ch3\u003EType and Hit Enter\u003C/h3\u003E  1. \u003Cb\u003Estart\u003C/b\u003E Get back to the main menu. \u003Cbr\u003E 2. \u003Cb\u003Efaq\u003C/b\u003E for  FAQ. \u003Cbr\u003E 3. \u003Cb\u003Ereset\u003C/b\u003E To clear chat history and start from the beginning.  4. \u003Cb\u003Elivechat\u003C/b\u003E  To navigating into the livechat window. 5. \u003Cb\u003Eunsubscribe\u003C/b\u003E to remove your email from our newsletter."]},"reset":{"en_US":["Do you want to clear our chat history and start over?"]},"wildcard_product":{"en_US":["Product Search"],"de_DE":["Product Search"]},"wildcard_catalog":{"en_US":["Catalog"],"de_DE":["Catalog"]},"featured_products":{"en_US":["Featured Products"],"de_DE":["Featured Products"]},"sale_products":{"en_US":["Products on  Sale"],"de_DE":["Products on  Sale"]},"wildcard_order":{"en_US":["Order Status"],"de_DE":["Order Status"]},"wildcard_support":{"en_US":"FAQ"},"product_asking":{"en_US":["What are you shopping for?"],"de_DE":["What are you shopping for?"]},"product_suggest":{"en_US":["You can browse our extensive catalog. Just pick a category from below:"],"de_DE":["You can browse our extensive catalog. Just pick a category from below:"]},"product_infinite":{"en_US":["Too many choices? Let's try another search term","I may have something else for you. Why not search again?"],"de_DE":["Too many choices? Let's try another search term","I may have something else for you. Why not search again?"]},"product_success":{"en_US":["Great! We have these products for","Found these products for"],"de_DE":["Great! We have these products for","Found these products for"]},"product_fail":{"en_US":["Oops! Nothing matches your criteria","Sorry, I found nothing"],"de_DE":["Oops! Nothing matches your criteria","Sorry, I found nothing"]},"support_welcome":{"en_US":["Welcome to WFG! You can ask me anything about the digital nomad life in Greece or choose an option from below."]},"typing_animation":"","site_search":{"en_US":"Site Search"},"wppt_post_types":["post","page"],"livechat_label":"Livechat","email_subscription":{"en_US":"Email Subscription"},"str_categories":{"en_US":"STR Categories"},"open_a_ticket":{"en_US":"Open a Ticket","de_DE":"Open a Ticket"},"ticket_url":"","unsubscribe":{"en_US":"Unsubscribe"},"send_us_email":{"en_US":"Send Us Email"},"leave_feedback":{"en_US":"Leave a Feedback"},"good_bye":{"en_US":"GoodBye"},"qcld_btn_n8n_txt":"","livechat":"","go_back_tooltip":{"en_US":["click to go back."]},"support_email":{"en_US":["Click me if you want to send us a email."]},"support_option_again":{"en_US":["You may choose an option from below."]},"ai_rate_limiting_message":"","asking_email":{"en_US":["Please provide your email address"]},"asking_search_keyword":{"en_US":["Hello #name!, Please enter your keyword for searching"]},"asking_msg":{"en_US":["Thank you for email address. Please write your message now."]},"support_phone":{"en_US":"Leave your number. We will call you back!"},"asking_phone":{"en_US":["Please provide your Phone number"]},"thank_for_phone":{"en_US":["Thank you for Phone number"]},"support_query":{"en_US":["Do I need to have a bank account in Greece to apply for Digital Nomad Visa?","Do I need a visa to work as a digital nomad in Greece?","How do you apply for a Digital Nomad Visa to work in Greece?","How to open a bank account in Greece?","Can I open a bank account online before I arrive in Greece? ","What is the cost of living in Greece?","Can I get a mortgage if I decide to settle down and buy a permanent or holiday home in Greece? ","Do I need to pay taxes as a digital nomad in Greece?","What is the internet speed in Greece like? ","Are there co-working spaces in Greece for digital nomads?","What is flight connectivity to Greece like?","What are the accommodation and co-living space options for remote workers in Greece?","Will I be able to rent a car as a digital nomad in Greece?","What type of healthcare coverage do I require as a remote worker in Greece? Do I have access to public hospitals? ","Is Greece a safe country to work in?"]},"custom_intent":[""],"custom_intent_label":[""],"custom_intent_email":["0"],"custom_menu":[""],"custom_menu_link":[""],"custom_menu_target":["0"],"custom_menu_type":["link"],"custom_menu_linktype":["link"],"simple_response_intent":[],"support_ans":{"en_US":["You are not obliged to open a Greek bank account to obtain a Digital Nomad Visa; but it could be proven useful if you wish to stay for an extended period in the country.","\u003Cul\u003E\r\n \t\u003Cli\u003EIf you are an \u003Cstrong\u003EEU, EEA or Swiss citizen\u003C/strong\u003E, you have the right to enter and move freely within Greece, according to EU law.\u003C/li\u003E\r\n \t\u003Cli\u003EFor \u003Cstrong\u003Ethird-party nationals\u003C/strong\u003E (ie non-EU, EEA &amp; Switzerland), you can apply for a \u003Cstrong\u003EDigital Nomad Visa\u003C/strong\u003E letting you live and work in Greece hassle-free. It gives you legal residence as a remote worker for up to a year, after which you can apply for a \u003Cstrong\u003EDigital Nomad Residence Permit\u003C/strong\u003E, if you want to stay longer.You\u2019ll need to prove that you have \u003Cstrong\u003Esufficient resources\u003C/strong\u003E for the length of your stay or a salary of at least \u20ac3,500 per month after taxes as a dependent employee or a self-employed person working remotely \u003Cstrong\u003Ewith employers outside Greece\u003C/strong\u003E. The monthly amount increases by 20% if you\u2019re accompanied by your spouse or a cohabitant and 15% for each child. The Digital Nomad Residence Permit is valid for up to two years (renewable every 2 years for 2 more years).Note that you won\u2019t have the right to work for a Greek company during this period, either on a permanent or freelance basis.\u003C/li\u003E\r\n\u003C/ul\u003E","You can apply for a Digital Nomad Visa at the \u003Cstrong\u003EGreek consular authority \u003C/strong\u003Ein your country of main residence as part of a \u003Cstrong\u003Efast track process\u003C/strong\u003E. The request can be made by email or registered letter and the consular authority is obliged to respond within 10 days, with the eventual residency permit being issued by the Greek Ministry of Migration and Asylum.","\u003Cem\u003EDigital nomads in Greece can open a bank account, provided they meet the requirements and have collected all required documentation. Most of the Greek banks will require the same documents, such as:\u003C/em\u003E\r\n\u003Cul class=\"wp-block-list\"\u003E\r\n \t\u003Cli\u003E\u003Cem\u003EValid passport or national ID card of your country.\r\n\u003C/em\u003E\u003Cem\u003ENon-EU/EEA citizens may also need to provide a digital nomad visa or a residence permit.\u003C/em\u003E\u003C/li\u003E\r\n \t\u003Cli\u003E\u003Cem\u003ETax identification number (TIN) or other tax-related documents.\u003C/em\u003E Depending on your country of residence you may be required to issue a Greek Tax Identification Number (AFM).\u003C/li\u003E\r\n \t\u003Cli\u003EProof of address in your home country such as a utility bill\u003Cem\u003E: \u003C/em\u003E\u003Cem\u003EDigital nomads may not have a permanent address in Greece, but they can still establish residency for banking purposes. Some banks may accept a temporary address, such as a hotel or coworking space, while others may require a more stable address, such as a rental agreement or a utility bill in Greece.\u003C/em\u003E\u003C/li\u003E\r\n \t\u003Cli\u003E\u003Cem\u003EProof of employment or source of income: \u003C/em\u003E\u003Cem\u003EDigital nomads may need to provide proof of income, such as bank statements, invoices, or contracts from clients or employers.\u003C/em\u003E\u003C/li\u003E\r\n\u003C/ul\u003E\r\nMost banks will require that your documents are officially translated in Greek or English.","\u003Cem\u003EWhile visiting a bank branch in person is a common requirement for opening an account, some banks in Greece offer \u003C/em\u003Edigital or remote account opening options. Residents of the European Union, Iceland, Norway and Switzerland may use digital onboarding through their mobile appliances (link \u003Ca href=\"https://www.eurobank.gr/en/international-customers/what-we-offer/digital-customer-onboarding\" target=\"_blank\" rel=\"noreferrer noopener\"\u003EDigital Customer Onboarding for International Customers | Eurobank\u003C/a\u003E ). Remote or proxy onboarding and all-inclusive services for digital nomads or international customers are also available. \u003Cem\u003E\u00a0For more information and solutions addressing your banking needs please click \u003C/em\u003E\u003Ca href=\"https://www.eurobank.gr/en/international-customers/what-we-offer/one-stop-hub\" target=\"_blank\" rel=\"noreferrer noopener\"\u003E\u003Cem\u003Ehere\u003C/em\u003E\u003C/a\u003E\u003Cem\u003E. \u003C/em\u003E","Greece\u003Cstrong\u003E has a reputation as a good value-for-money country within Europe. \u003C/strong\u003EThe cost of living for accommodation, transport, eating out and entertainment are well below the European Union average and many outdoor activities can be enjoyed without cost. You can see for yourself by comparing the cost of living with other European countries \u003Ca href=\"https://ec.europa.eu/eurostat/cache/website/price-levels/?country=EL&amp;lang=en\" target=\"_blank\" rel=\"noreferrer noopener\"\u003Ehere\u003C/a\u003E.","You may apply for a mortgage loan and get a financial preapproval within a few business days. The application process is easy and can be submitted either in person, or by email or by a proxy lawyer. For more information please click here (link \u003Ca href=\"https://www.eurobank.gr/en/international-customers/what-we-offer/mortgage-loan-for-non-residents\" target=\"_blank\" rel=\"noreferrer noopener\"\u003EMortgage Loan For Non Residents | Eurobank\u003C/a\u003E )","\u003C!-- wp:list --\u003E\r\n\u003Cul class=\"wp-block-list\"\u003E\r\n \t\u003Cli style=\"list-style-type: none;\"\u003E\r\n\u003Cul class=\"wp-block-list\"\u003E\u003C!-- wp:list-item --\u003E\r\n \t\u003Cli\u003EYou have no tax liability in Greece when working for fewer than 180 days in a calendar year a) as a salaried employee of a company based outside Greece or b) whilst offering services on a self-employed basis to companies based outside Greece.\u003C/li\u003E\r\n\u003C/ul\u003E\r\n\u003C/li\u003E\r\n\u003C/ul\u003E\r\n\u003C!-- /wp:list-item --\u003E \u003C!-- wp:list-item --\u003E\r\n\u003Cul class=\"wp-block-list\"\u003E\r\n \t\u003Cli style=\"list-style-type: none;\"\u003E\r\n\u003Cul class=\"wp-block-list\"\u003E\r\n \t\u003Cli\u003EIf you do live in Greece for 180 days or more of a calendar year, you may need to move your tax residency to Greece (including getting a Greek tax number) and pay local taxes. An extension to this time period was given to foreign tax residents during 2020 and 2021 due to the Covid-19 pandemic.\u003C/li\u003E\r\n\u003C/ul\u003E\r\n\u003C/li\u003E\r\n\u003C/ul\u003E\r\n\u003C!-- /wp:list-item --\u003E \u003C!-- wp:list-item --\u003E\r\n\u003Cul class=\"wp-block-list\"\u003E\r\n \t\u003Cli style=\"list-style-type: none;\"\u003E\r\n\u003Cul class=\"wp-block-list\"\u003E\r\n \t\u003Cli\u003EIf you work for a Greek company at any time during your stay in Greece, you will need to pay local taxes.\u003C/li\u003E\r\n\u003C/ul\u003E\r\n\u003C/li\u003E\r\n\u003C/ul\u003E\r\n\u003C!-- /wp:list-item --\u003E \u003C!-- wp:list-item --\u003E\r\n\u003Cul class=\"wp-block-list\"\u003E\r\n \t\u003Cli style=\"list-style-type: none;\"\u003E\r\n\u003Cul class=\"wp-block-list\"\u003E\r\n \t\u003Cli\u003EThe Greek state has recently introduced a range of benefits and tax incentives to attract foreign professionals to Greece and assume Greek tax residency (Article 5C of law 4172/2013). Such applications take place at specific times during the year. Therefore, you will need to refer to the competent authorities for more information.\u003C/li\u003E\r\n\u003C/ul\u003E\r\n\u003C/li\u003E\r\n\u003C/ul\u003E\r\n\u003C!-- /wp:list-item --\u003E\r\n\r\n\u003C!-- /wp:list --\u003E","There have been huge advances in internet speed in Greece in recent years. Fibre-optic technology is standard in many neighbourhoods and the 5G network has reached 99% countrywide population coverage, with the speed in some areas passing 1 Gbps. The average national download speed for 2023 was 62.35 Mbps in 2023, up 37.8% on the previous year. \u003Cem\u003E(Source:\u00a0\u003Ca href=\"https://hyperiontest.gr/\" target=\"_blank\" rel=\"noreferrer noopener\"\u003EHYPERION\u00a0\u003C/a\u003Edeveloped by the\u00a0\u003Ca href=\"http://www.eett.gr/\" target=\"_blank\" rel=\"noreferrer noopener\"\u003EHellenic Telecommunications and Post Commission (\u0395\u0395\u03a4\u03a4)\u003C/a\u003E\u00a0in collaboration with the\u00a0\u003Ca href=\"http://www.measurementlab.net/\" target=\"_blank\" rel=\"noreferrer noopener\"\u003EMeasurement Lab Partnership\u003C/a\u003E)\u003C/em\u003E","Yes, there is a growing number of \u003Cstrong\u003Eco-working spaces in Greece\u003C/strong\u003E, allowing you to easily become part of the\u003Cstrong\u003E digital nomad community\u003C/strong\u003E. Many co-working spaces in \u003Ca href=\"https://workfromgreece.gr/location/athens/\"\u003EAthens \u003C/a\u003E(like the Impact Hub, Found.ation and The Cube) have grown out of the city\u2019s incubator and tech start-up scene and you\u2019ll find other options favoured by remote workers. For more on co-working spaces in Athens and around Greece, see our Digital Nomad Destination Guide.","\u003Cul\u003E\r\n \t\u003Cli\u003EGreece has \u003Cstrong\u003Eexcellent flight connectivity\u003C/strong\u003E, with major international airport hubs in \u003Cstrong\u003EAthens \u003C/strong\u003Eand \u003Cstrong\u003EThessaloniki \u003C/strong\u003Eand 15 other regional airports (island and mainland) with seasonal international flights. There are also another \u003Cstrong\u003E18 airports\u003C/strong\u003E around the country with domestic flights to Athens and Thessaloniki.\u003C/li\u003E\r\n \t\u003Cli\u003EIn the 2024 edition of the World Economic Forum\u2019s \u003Ca href=\"https://www3.weforum.org/docs/WEF_Travel_and_Tourism_Development_Index_2024.pdf\" target=\"_blank\" rel=\"noreferrer noopener\"\u003ETravel &amp; Tourism Development Index\u003C/a\u003E Greece ranked \u003Cstrong\u003E12th out of 140 countries\u003C/strong\u003E in terms of the number of operating airlines, with \u003Cstrong\u003EAthens \u003C/strong\u003Edirectly connected with scheduled services with \u003Cstrong\u003E165 destinations\u003C/strong\u003E in \u003Cstrong\u003E57 countries\u003C/strong\u003E operated by a total of \u003Cstrong\u003E66 carriers\u003C/strong\u003E. Thessaloniki, Chania &amp; Heraklion (in Crete) and Rhodes were the next busiest airports.\u003C/li\u003E\r\n\u003C/ul\u003E","You\u2019ll find plenty of \u003Cstrong\u003Etemporary accommodation options in Greece\u003C/strong\u003E, whether you go for the city life of Athens or Thessaloniki or the slower pace of a Greek island or mainland village. As well as hotels, you find popular rental options such as \u003Cstrong\u003EAirbnb \u003C/strong\u003Eand \u003Cstrong\u003EBlueground \u003C/strong\u003Eas well as a growing number of \u003Cstrong\u003Eco-living options\u003C/strong\u003E that attract digital nomad communities.","Yes, you\u2019ll find plenty of short- and medium-term car rental options in Greece, with all the best-known car rental companies (such as Hertz, Avis and others) operating in the country. You are able to drive with your EU or UK driving licenses in Greece, as well as driving licenses from any of the signatories of the \u003Ca href=\"https://treaties.un.org/Pages/ViewDetailsIII.aspx?src=TREATY&amp;mtdsg_no=XI-B-19&amp;chapter=11\" target=\"_blank\" rel=\"noreferrer noopener\"\u003EVienna Convention on Road Traffic\u003C/a\u003E.","\u003Cul\u003E\r\n \t\u003Cli\u003EIf you\u2019re an \u003Cstrong\u003EEU citizen\u003C/strong\u003E, you should get a \u003Ca href=\"https://ec.europa.eu/social/main.jsp?catId=559\" target=\"_blank\" rel=\"noreferrer noopener\"\u003EEuropean Health Insurance Card\u003C/a\u003E\u00a0in the country in which you are insured before you come to Greece. This will give you access to the Greek national healthcare system (EOPYY), only paying for the medical care that Greek citizens would be required to pay for. The coverage includes emergencies as well as chronic or existing illnesses. Cards are issued by your \u003Ca href=\"https://ec.europa.eu/social/main.jsp?catId=563&amp;langId=en#nationalinfo\" target=\"_blank\" rel=\"noreferrer noopener\"\u003Enational health insurance provider\u003C/a\u003E. Of course, if you want more comprehensive coverage, you should get private health insurance.\u003C/li\u003E\r\n \t\u003Cli\u003EIf you\u2019re coming from elsewhere, you\u2019ll need to obtain \u003Cstrong\u003Eprivate health insurance \u003C/strong\u003Eas you won\u2019t be entitled to the benefits of the Greek public healthcare system. Regular travel insurance will give you emergency coverage for a limited period but for longer stays, you will need specialised health coverage, such as \u003Ca href=\"https://www.insurednomads.com/global-health-insurance\" target=\"_blank\" rel=\"noreferrer noopener\"\u003ENomad Insurance\u003C/a\u003E, which is designed for digital nomads and remote workers and offers global coverage.\u003C/li\u003E\r\n\u003C/ul\u003E","Greece is a \u003Cstrong\u003Esafe country\u003C/strong\u003E, with an outdoors culture and \u003Cstrong\u003Every\u003C/strong\u003E \u003Cstrong\u003Elow \u003C/strong\u003Elevels of violent crime. To put it into perspective, the rate of crimes reported to police in 2023 was \u003Cstrong\u003E46.5 per 100,000 inhabitants\u003C/strong\u003E, compared to an EU average of 52.5. We welcomed a record \u003Cstrong\u003E32 million visitors to Greece in 2023\u003C/strong\u003E (that\u2019s around three times the national population) so we\u2019re pretty experienced at making you feel safe and letting you enjoy all the things you love about \u003Cstrong\u003Ebeing in Greece\u003C/strong\u003E."]},"notification_interval":"5","notifications":{"en_US":["Welcome to Work From Greece!"]},"exitintentpagewise":"","notification_intents":{"en_US":[""]},"order_welcome":{"en_US":["Welcome to Order status section!"],"de_DE":["Welcome to Order status section!"]},"order_username_asking":{"en_US":["Please type your username?"],"de_DE":["Please type your username?"]},"order_username_password":{"en_US":["Please type your password"],"de_DE":["Please type your password"]},"order_email":"","order_login":"","order_nonce":"ef12e558f2","order_email_support":{"en_US":["Email our support center about your order."],"de_DE":["Email our support center about your order."]},"email_fail":{"en_US":"Sorry! fail to send email"},"invalid_email":{"en_US":["Sorry, Email address is not valid! Please provide a valid email."]},"stop_words":"a,able,about,above,abst,accordance,according,accordingly,across,act,actually,added,adj,affected,affecting,affects,after,afterwards,again,against,ah,all,almost,alone,along,already,also,although,always,am,among,amongst,an,and,announce,another,any,anybody,anyhow,anymore,anyone,anything,anyway,anyways,anywhere,apparently,approximately,are,aren,arent,arise,around,as,aside,ask,asking,at,auth,available,away,awfully,b,back,be,became,because,become,becomes,becoming,been,before,beforehand,begin,beginning,beginnings,begins,behind,being,believe,below,beside,besides,between,beyond,biol,both,brief,briefly,but,by,c,ca,came,can,cannot,can't,cause,causes,certain,certainly,co,com,come,comes,contain,containing,contains,could,couldnt,d,date,did,didn't,different,do,does,doesn't,doing,done,don't,down,downwards,due,during,e,each,ed,edu,effect,eg,eight,eighty,either,else,elsewhere,end,ending,enough,especially,et,et-al,etc,even,ever,every,everybody,everyone,everything,everywhere,ex,except,f,far,few,ff,fifth,first,five,fix,followed,following,follows,for,former,formerly,forth,found,four,from,further,furthermore,g,gave,get,gets,getting,give,given,gives,giving,go,goes,gone,got,gotten,h,had,happens,hardly,has,hasn't,have,haven't,having,he,hed,hence,her,here,hereafter,hereby,herein,heres,hereupon,hers,herself,hes,hi,hid,him,himself,his,hither,home,how,howbeit,however,hundred,i,id,ie,if,i'll,im,immediate,immediately,importance,important,in,inc,indeed,index,information,instead,into,invention,inward,is,isn't,it,itd,it'll,its,itself,i've,j,just,k,keep,keeps,kept,kg,km,know,known,knows,l,largely,last,lately,later,latter,latterly,least,less,lest,let,lets,like,liked,likely,line,little,'ll,look,looking,looks,ltd,m,made,mainly,make,makes,many,may,maybe,me,mean,means,meantime,meanwhile,merely,mg,might,million,miss,ml,more,moreover,most,mostly,mr,mrs,much,mug,must,my,myself,n,na,name,namely,nay,nd,near,nearly,necessarily,necessary,need,needs,neither,never,nevertheless,new,next,nine,ninety,no,nobody,non,none,nonetheless,noone,nor,normally,nos,not,noted,nothing,now,nowhere,o,obtain,obtained,obviously,of,off,often,oh,ok,okay,old,omitted,on,once,one,ones,only,onto,or,ord,other,others,otherwise,ought,our,ours,ourselves,out,outside,over,overall,owing,own,p,page,pages,part,particular,particularly,past,per,perhaps,placed,please,plus,poorly,possible,possibly,potentially,pp,predominantly,present,previously,primarily,probably,promptly,proud,provides,put,q,que,quickly,quite,qv,r,ran,rather,rd,re,readily,really,recent,recently,ref,refs,regarding,regardless,regards,related,relatively,research,respectively,resulted,resulting,results,right,run,s,said,same,saw,say,saying,says,sec,section,see,seeing,seem,seemed,seeming,seems,seen,self,selves,sent,seven,several,shall,she,shed,she'll,shes,should,shouldn't,show,showed,shown,showns,shows,significant,significantly,similar,similarly,since,six,slightly,so,some,somebody,somehow,someone,somethan,something,sometime,sometimes,somewhat,somewhere,soon,sorry,specifically,specified,specify,specifying,still,stop,strongly,sub,substantially,successfully,such,sufficiently,suggest,sup,sure,t,take,taken,taking,tell,tends,th,than,thank,thanks,thanx,that,that'll,thats,that've,the,their,theirs,them,themselves,then,thence,there,thereafter,thereby,thered,therefore,therein,there'll,thereof,therere,theres,thereto,thereupon,there've,these,they,theyd,they'll,theyre,they've,think,this,those,thou,though,thoughh,thousand,throug,through,throughout,thru,thus,til,tip,to,together,too,took,toward,towards,tried,tries,truly,try,trying,ts,twice,two,u,un,under,unfortunately,unless,unlike,unlikely,until,unto,up,upon,ups,us,use,used,useful,usefully,usefulness,uses,using,usually,v,value,various,'ve,very,via,viz,vol,vols,vs,w,want,wants,was,wasnt,way,we,wed,welcome,we'll,went,were,werent,we've,what,whatever,what'll,whats,when,whence,whenever,where,whereafter,whereas,whereby,wherein,wheres,whereupon,wherever,whether,which,while,whim,whither,who,whod,whoever,whole,who'll,whom,whomever,whos,whose,why,widely,willing,wish,with,within,without,wont,words,world,would,wouldnt,www,x,y,yes,yet,you,youd,you'll,your,youre,yours,yourself,yourselves,you've,z,zero","enable_messenger":"","messenger_label":{"en_US":["Chat with Us on Facebook Messenger"]},"fb_page_id":"","enable_skype":"","enable_whats":"","whats_label":{"en_US":["Chat with Us on WhatsApp"]},"whats_num":"","ret_greet":"a:2:{s:5:\"en_US\";s:5:\"Hello\";s:5:\"de_DE\";s:5:\"Hello\";}","enable_exit_intent":"","exit_intent_msg":"","exit_intent_custom_intent":"","exit_intent_bargain_pro_single_page":"","exit_intent_bargain_is_product_page":"","exit_intent_bargain_msg":"","exit_intent_email":"","exit_intent_once":"","enable_scroll_open":"","scroll_open_msg":"","scroll_open_custom_intent":"","scroll_open_email":"","scroll_open_percent":"50","scroll_open_once":"","enable_auto_open":"","auto_open_msg":"","auto_open_custom_intent":"","auto_open_email":"","auto_open_time":"10","auto_open_once":"","proactive_bg_color":"#ffffff","disable_feedback":"","disable_email_transcript":"","disable_leave_feedback":"","disable_good_bye":"","qcld_enable_n8n":"","qcld_wpbot_url":"","qcld_enable_openai_agentbuilder":"","disable_sitesearch":"1","no_result":{"en_US":["Sorry, No result found!"]},"did_you_mean":{"en_US":["Did you mean?"]},"email_subscription_success":{"en_US":["You have successfully subscribed to our newsletter. Thank you."]},"email_already_subscribe":{"en_US":["You have already subscribed to our newsletter."]},"disable_faq":"","disable_email_subscription":"","disable_voice_message":"","disable_str_categories":"","disable_open_ticket":"","disable_livechat":"","feedback_label":{"en_US":["Send Feedback"]},"enable_meta_title":"","meta_label":"a:2:{s:5:\"en_US\";s:13:\"*New Messages\";s:5:\"de_DE\";s:13:\"*New Messages\";}","phone_number":"","livechatlink":"","livechat_button_label":"Live Chat","qcbot_enable_str":"0","qcld_disable_beginning_startmenu":"","loading":{"en_US":"Loading..."},"call_gen":"1","call_sup":"","enable_ret_sound":"","enable_ret_user_show":"","enable_inactive_time_show":"","ret_inactive_user_once":"","mobile_full_screen":"1","enable_all_search":"","chatbot_content":"650","enable_gdpr":"1","wpbot_search_result_number":"5","gdpr_text":{"en_US":"We will never spam you! You can read our Privacy Policy here."},"no_result_attempt_message":{"en_US":""},"no_result_attempt_count":"3","inactive_time":"300","checkout_msg":"a:2:{s:5:\"en_US\";s:63:\"You have products in shopping cart, please complete your order.\";s:5:\"de_DE\";s:63:\"You have products in shopping cart, please complete your order.\";}","ai_df_enable":"","df_api_version":"v2","ai_df_token":"","df_defualt_reply":{"en_US":""},"df_agent_lan":{"en_US":""},"df_project_id":{"en_US":""},"df_project_key":{"en_US":""},"sound_bot_message":"","clear_cache":"0","template":"template-08","is_operator_online":"0","disable_livechat_operator_offline":"","is_livechat_active":"","imgurl":"https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/images/","hello":{"en_US":"Hello"},"ajax_nonce":"713ae18503","exitintent_all_page":"on","exitintent_pages":[],"exit_pagewise":"","trigger_url_exit":"","trigger_url_scroll":"","trigger_url_auto":"","scrollintent_pages":"","scrollintent_all_page":"on","scroll_pagewise":"","autointent_pages":"","autointent_all_page":"on","auto_pagewise":"","notification_navigation":"","current_pageid":"2602","disable_repeatative":"","botpreloadingtime":"100","start_menu":{"en_US":"\u003Cspan class=\"qcld-chatbot-wildcard ui-draggable ui-draggable-handle qc_draggable_item_remove\" data-wildcart=\"support\"\u003EFAQ\u003C/span\u003E\u003Cspan class=\"qcld-chatbot-suggest-email ui-draggable ui-draggable-handle qc_draggable_item_remove\"\u003ESend Us Email\u003C/span\u003E\u003Cspan class=\"qcld-chatbot-suggest-email wpbd_feedback ui-draggable ui-draggable-handle qc_draggable_item_remove\"\u003ELeave a Feedback\u003C/span\u003E"},"forms":[],"form_commands":[],"form_ids":[],"is_formbuilder_active":"1","is_chatsession_active":"1","open_livechat_window_first":"","livechat_autopopulation":"0","is_chat_session_active":"1","disable_auto_focus":"","open_ai_enable":"1","is_stream_enabled":"0","is_asst_enabled":"1","is_assistant_enabled_loggedin":"0","is_assistant_enabled_role":"0","qcld_openai_append_content":"","ollama_enabled":"0","openrouter_enabled":"0","qcld_openrouter_append_content":"","qcld_openrouter_prepend_content":"","mistral_enabled":"0","gemini_enabled":"0","woocommerce":"","your_offer_price":"Please, tell me what is your offer price.","your_offer_price_again":"It seems like you have not provided any offer amount. Please give me a number!","your_low_price_alert":"Your offered price {offer price} is too low for us.","your_too_low_price_alert":"The best we can do for you is {minimum amount}. Do you accept?","map_talk_to_boss":"Please tell me your final price. I will talk to my boss.","map_get_email_address":"Please tell me your email address so I can get back to you.","map_thanks_test":"Thank you.","map_acceptable_price":"Your offered price {offer price} is acceptable.","map_checkout_now_button_text":"Checkout Now","map_get_checkout_url":"","map_get_ajax_nonce":"e17a3900de","currency_symbol":"","order_status_without_login":"0","order_email_asking":"","order_id_asking":"","is_woowbot":"0","df_cardlink_open":"0","qc_site_search_priority":"0","is_mobile":"","disable_youtube_parse":"","language":"en_US","default_language":"en_US","start_menu_installed":"","qcld_bargain_allowed_times":"","voice_addon":"","bot_read":"","stt_service":"","entities":{"default":{"@name":{"entity":"@name"},"@age":{"entity":"@age"},"@number":{"entity":"@number"},"@date":{"entity":"@date"},"@date-of-birth":{"entity":"@date-of-birth"},"@place":{"entity":"@place"},"@day":{"entity":"@day"},"@email":{"entity":"@email"},"@color":{"entity":"@color"}}},"current_user_id":"0"};
+//# sourceURL=qcld-wp-chatbot-front-js-js-extra
+</script>
+<script id="qcld-wp-chatbot-front-js-js" src="https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/js/qcld-wp-chatbot-front.js?ver=15.4.1"></script>
+<script id="wpform-gcal-script-js-extra">
+var gcal_ajax = {"ajax_url":"https://workfromgreece.gr/wp-admin/admin-ajax.php","nonce":"1467b80556"};
+//# sourceURL=wpform-gcal-script-js-extra
+</script>
+<script id="wpform-gcal-script-js" src="https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/addons/conversational-forms-pro/includes/calendar/google-calendar.js"></script>
+<script id="pafe-2602-js" src="https://workfromgreece.gr/wp-content/uploads/premium-addons-elementor/pafe-2602.js?ver=1780895407"></script>
+<script id="elementor-webpack-runtime-js" src="https://workfromgreece.gr/wp-content/plugins/elementor/assets/js/webpack.runtime.min.js?ver=4.0.9"></script>
+<script id="elementor-frontend-modules-js" src="https://workfromgreece.gr/wp-content/plugins/elementor/assets/js/frontend-modules.min.js?ver=4.0.9"></script>
+<script id="jquery-ui-core-js" src="https://workfromgreece.gr/wp-includes/js/jquery/ui/core.min.js?ver=1.13.3"></script>
+<script id="elementor-frontend-js-extra">
+var PremiumSettings = {"ajaxurl":"https://workfromgreece.gr/wp-admin/admin-ajax.php","nonce":"1354284c27"};
+//# sourceURL=elementor-frontend-js-extra
+</script>
+<script id="elementor-frontend-js-before">
+var elementorFrontendConfig = {"environmentMode":{"edit":false,"wpPreview":false,"isScriptDebug":false},"i18n":{"shareOnFacebook":"Share on Facebook","shareOnTwitter":"Share on Twitter","pinIt":"Pin it","download":"Download","downloadImage":"Download image","fullscreen":"Fullscreen","zoom":"Zoom","share":"Share","playVideo":"Play Video","previous":"Previous","next":"Next","close":"Close","a11yCarouselPrevSlideMessage":"Previous slide","a11yCarouselNextSlideMessage":"Next slide","a11yCarouselFirstSlideMessage":"This is the first slide","a11yCarouselLastSlideMessage":"This is the last slide","a11yCarouselPaginationBulletMessage":"Go to slide"},"is_rtl":false,"breakpoints":{"xs":0,"sm":480,"md":768,"lg":1025,"xl":1440,"xxl":1600},"responsive":{"breakpoints":{"mobile":{"label":"Mobile Portrait","value":767,"default_value":767,"direction":"max","is_enabled":true},"mobile_extra":{"label":"Mobile Landscape","value":880,"default_value":880,"direction":"max","is_enabled":false},"tablet":{"label":"Tablet Portrait","value":1024,"default_value":1024,"direction":"max","is_enabled":true},"tablet_extra":{"label":"Tablet Landscape","value":1200,"default_value":1200,"direction":"max","is_enabled":false},"laptop":{"label":"Laptop","value":1366,"default_value":1366,"direction":"max","is_enabled":false},"widescreen":{"label":"Widescreen","value":2400,"default_value":2400,"direction":"min","is_enabled":false}},"hasCustomBreakpoints":false},"version":"4.0.9","is_static":false,"experimentalFeatures":{"additional_custom_breakpoints":true,"theme_builder_v2":true,"global_classes_should_enforce_capabilities":true,"e_variables":true,"e_opt_in_v4_page":true,"e_components":true,"e_interactions":true,"e_widget_creation":true,"import-export-customization":true,"e_pro_atomic_form":true,"e_pro_variables":true,"e_pro_interactions":true},"urls":{"assets":"https:\/\/workfromgreece.gr\/wp-content\/plugins\/elementor\/assets\/","ajaxurl":"https:\/\/workfromgreece.gr\/wp-admin\/admin-ajax.php","uploadUrl":"https:\/\/workfromgreece.gr\/wp-content\/uploads"},"nonces":{"floatingButtonsClickTracking":"31130e7b5a","atomicFormsSendForm":"e28d50d0cf"},"swiperClass":"swiper","settings":{"page":[],"editorPreferences":[]},"kit":{"viewport_mobile":767,"viewport_tablet":1024,"active_breakpoints":["viewport_mobile","viewport_tablet"],"global_image_lightbox":"yes","lightbox_enable_counter":"yes","lightbox_enable_fullscreen":"yes","lightbox_enable_zoom":"yes","lightbox_enable_share":"yes","lightbox_title_src":"title","lightbox_description_src":"description"},"post":{"id":2602,"title":"How%20to%20get%20a%20Digital%20Nomad%20Visa%20for%20Greece%20%7C%20Work%20From%20Greece","excerpt":"\u03a4he Digital Nomad Visa for Greece allows people who are not citizens of the European Union or European Economic Area and who work remotely to legally live and work in Greece for up to one year. It also allows you to bring your immediate family members with you, as long as you meet all the requirements. So if you\u2019ve been toying with the idea of becoming a digital nomad in Greece, let\u2019s have a look at the steps you need to follow to make that dream come true.","featuredImage":"https:\/\/workfromgreece.gr\/wp-content\/uploads\/2023\/05\/How-to-get-a-Digital-Nomad-Visa-for-Greece-1024x576.jpg"}};
+//# sourceURL=elementor-frontend-js-before
+</script>
+<script id="elementor-frontend-js" src="https://workfromgreece.gr/wp-content/plugins/elementor/assets/js/frontend.min.js?ver=4.0.9"></script>
+<script id="ecs-color-switcher-js" src="https://workfromgreece.gr/wp-content/plugins/ele-custom-skin/modules/color-scheme/assets/js/ecs-color-switcher.js?ver=4.3.1"></script>
+<script id="swiper-js" src="https://workfromgreece.gr/wp-content/plugins/elementor/assets/lib/swiper/v8/swiper.min.js?ver=8.4.5"></script>
+<script id="ecs-slider-js" src="https://workfromgreece.gr/wp-content/plugins/ele-custom-skin/modules/container-layout/assets/js/ecs-slider.js?ver=4.3.1"></script>
+<script id="ecs-scheme-selector-js" src="https://workfromgreece.gr/wp-content/plugins/ele-custom-skin-pro/assets/js/ecs-scheme-selector.js?ver=4.2.1"></script>
+<script id="smartmenus-js" src="https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/lib/smartmenus/jquery.smartmenus.min.js?ver=1.2.1"></script>
+<script id="imagesloaded-js" src="https://workfromgreece.gr/wp-includes/js/imagesloaded.min.js?ver=5.0.0"></script>
+<script id="qcld-wp-chatbot-slimsqccrl-js-js" src="https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/js/jquery.slimscroll.min.js?ver=15.4.1"></script>
+<script id="qcld-wp-chatbot-magnifict-qcpopup-js" src="https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/js/jquery.magnific-popup.min.js?ver=15.4.1"></script>
+<script id="qcld-wp-chatbot-plugin-js-extra">
+var wpbot_ajax = {"ajaxurl":"https://workfromgreece.gr/wp-admin/admin-ajax.php","stream_endpoint":"https://workfromgreece.gr/wp-admin/admin-ajax.php?action=qcld_stream_openai","nonce":"92fca1b4e4"};
+//# sourceURL=qcld-wp-chatbot-plugin-js-extra
+</script>
+<script id="qcld-wp-chatbot-plugin-js" src="https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/js/qcld-wp-chatbot-plugin.js?ver=15.4.1"></script>
+<script id="qcld-wp-chatbot-click-event-js" src="https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/js/qcld-wp-chatbot-click-events.js?ver=15.4.1"></script>
+<script id="jquery-ui-datepicker-js" src="https://workfromgreece.gr/wp-includes/js/jquery/ui/datepicker.min.js?ver=1.13.3"></script>
+<script id="jquery-ui-datepicker-js-after">
+jQuery(function(jQuery){jQuery.datepicker.setDefaults({"closeText":"Close","currentText":"Today","monthNames":["January","February","March","April","May","June","July","August","September","October","November","December"],"monthNamesShort":["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"],"nextText":"Next","prevText":"Previous","dayNames":["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],"dayNamesShort":["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],"dayNamesMin":["S","M","T","W","T","F","S"],"dateFormat":"dd/mm/yy","firstDay":1,"isRTL":false});});
+//# sourceURL=jquery-ui-datepicker-js-after
+</script>
+<script id="marked-js-js" src="https://workfromgreece.gr/wp-content/plugins/wpbot-pro-master/js/marked.min.js"></script>
+<script id="nomads-theme-js-core-js" src="https://workfromgreece.gr/wp-content/themes/work-from-greece/app.js?ver=1.0.9"></script>
+<script id="swiper-lib-js-js" src="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js?ver=1.0.9"></script>
+<script id="pa-elements-handler-js" src="https://workfromgreece.gr/wp-content/plugins/premium-addons-for-elementor/assets/frontend/min-js/elements-handler.min.js?ver=4.11.77"></script>
+<script id="bdt-uikit-js-extra">
+var element_pack_ajax_login_config = {"ajaxurl":"https://workfromgreece.gr/wp-admin/admin-ajax.php","language":"en","loadingmessage":"Sending user info, please wait...","unknownerror":"Unknown error, make sure access is correct!"};
+var ElementPackConfig = {"ajaxurl":"https://workfromgreece.gr/wp-admin/admin-ajax.php","nonce":"4faf9ca516","data_table":{"language":{"lengthMenu":"Show _MENU_ Entries","info":"Showing _START_ to _END_ of _TOTAL_ entries","search":"Search :","sZeroRecords":"No matching records found","paginate":{"previous":"Previous","next":"Next"}}},"contact_form":{"sending_msg":"Sending message please wait...","captcha_nd":"Invisible captcha not defined!","captcha_nr":"Could not get invisible captcha response!"},"mailchimp":{"subscribing":"Subscribing you please wait..."},"elements_data":{"sections":[],"columns":[],"widgets":[]}};
+//# sourceURL=bdt-uikit-js-extra
+</script>
+<script id="bdt-uikit-js" src="https://workfromgreece.gr/wp-content/plugins/bdthemes-element-pack/assets/js/bdt-uikit.min.js?ver=3.13.1"></script>
+<script id="ep-wrapper-link-js" src="https://workfromgreece.gr/wp-content/plugins/bdthemes-element-pack/assets/js/modules/ep-wrapper-link.min.js?ver=6.2.0"></script>
+<script id="mc4wp-forms-api-js" defer src="https://workfromgreece.gr/wp-content/plugins/mailchimp-for-wp/assets/js/forms.js?ver=4.12.5"></script>
+<script id="element-pack-helper-js" src="https://workfromgreece.gr/wp-content/plugins/bdthemes-element-pack/assets/js/common/helper.min.js?ver=6.2.0"></script>
+<script id="elementor-pro-webpack-runtime-js" src="https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/js/webpack-pro.runtime.min.js?ver=4.0.2"></script>
+<script id="elementor-pro-frontend-js-before">
+var ElementorProFrontendConfig = {"ajaxurl":"https:\/\/workfromgreece.gr\/wp-admin\/admin-ajax.php","nonce":"2bf7859c39","urls":{"assets":"https:\/\/workfromgreece.gr\/wp-content\/plugins\/elementor-pro\/assets\/","rest":"https:\/\/workfromgreece.gr\/wp-json\/"},"settings":{"lazy_load_background_images":true},"popup":{"hasPopUps":false},"shareButtonsNetworks":{"facebook":{"title":"Facebook","has_counter":true},"twitter":{"title":"Twitter"},"linkedin":{"title":"LinkedIn","has_counter":true},"pinterest":{"title":"Pinterest","has_counter":true},"reddit":{"title":"Reddit","has_counter":true},"vk":{"title":"VK","has_counter":true},"odnoklassniki":{"title":"OK","has_counter":true},"tumblr":{"title":"Tumblr"},"digg":{"title":"Digg"},"skype":{"title":"Skype"},"stumbleupon":{"title":"StumbleUpon","has_counter":true},"mix":{"title":"Mix"},"telegram":{"title":"Telegram"},"pocket":{"title":"Pocket","has_counter":true},"xing":{"title":"XING","has_counter":true},"whatsapp":{"title":"WhatsApp"},"email":{"title":"Email"},"print":{"title":"Print"},"x-twitter":{"title":"X"},"threads":{"title":"Threads"}},"facebook_sdk":{"lang":"en_US","app_id":""},"lottie":{"defaultAnimationUrl":"https:\/\/workfromgreece.gr\/wp-content\/plugins\/elementor-pro\/modules\/lottie\/assets\/animations\/default.json"}};
+//# sourceURL=elementor-pro-frontend-js-before
+</script>
+<script id="elementor-pro-frontend-js" src="https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/js/frontend.min.js?ver=4.0.2"></script>
+<script id="pro-elements-handlers-js" src="https://workfromgreece.gr/wp-content/plugins/elementor-pro/assets/js/elements-handlers.min.js?ver=4.0.2"></script>
+			<script>
+			/(trident|msie)/i.test(navigator.userAgent)&&document.getElementById&&window.addEventListener&&window.addEventListener("hashchange",function(){var t,e=location.hash.substring(1);/^[A-z0-9_-]+$/.test(e)&&(t=document.getElementById(e))&&(/^(?:a|select|input|button|textarea)$/i.test(t.tagName)||(t.tabIndex=-1),t.focus())},!1);
+			</script>
+			<!-- "This site uses ChatBot for WordPress - WPBot from https://www.wpbot.pro/" -->	</body>
+</html>
+<!-- Cache has NOT been created due to optimized resource -->

--- a/sources/GR_WORKFROMGREECE_DNV_2026-06-08.html.meta.json
+++ b/sources/GR_WORKFROMGREECE_DNV_2026-06-08.html.meta.json
@@ -1,0 +1,7 @@
+{
+  "source_id": "GR_WORKFROMGREECE_DNV_2026",
+  "url": "https://workfromgreece.gr/setting-up-in-greece/the-digital-nomad-visa-for-greece-who-is-eligible-and-how-to-get-one/",
+  "retrieved_at": "2026-06-08T00:00:00Z",
+  "sha256": "4264aae1c635faa665fb3afc374c535890890ed84cbaf2517ac1831f5682d1ea",
+  "local_path": "sources/GR_WORKFROMGREECE_DNV_2026-06-08.html"
+}

--- a/tools/build_content_hubs.py
+++ b/tools/build_content_hubs.py
@@ -97,6 +97,20 @@ VISA_FAQS = {
             "answer": "Decree expects coverage for the full stay; prepaid policies align closely with the requirement.",
         },
     ],
+    "GR_DNV_MFA_2026": [
+        {
+            "question": "Is insurance required for the Greece Digital Nomad Visa?",
+            "answer": "Yes. The Work From Greece portal that the Hellenic MFA designates for visa information lists travel insurance among the required documents.",
+        },
+        {
+            "question": "Does Greece state a coverage amount or require a Greek-authorized insurer?",
+            "answer": "The designated source does not state a coverage minimum or an insurer-authorization rule, so the engine records those as UNKNOWN rather than inferring them.",
+        },
+        {
+            "question": "Is travel insurance accepted for this route?",
+            "answer": "The designated required-documents list names travel insurance, so the current snapshot models only that insurance is mandatory.",
+        },
+    ],
 }
 
 RELATED_POSTS = {
@@ -124,6 +138,10 @@ RELATED_POSTS = {
     "MT_NOMAD_RESIDENCY_2026": [
         ("/posts/malta-nomad-insurance/", "Malta nomad insurance requirements"),
         ("/traps/malta-nomad-monthly-payments/", "Monthly payment pitfalls for Malta nomad visa"),
+    ],
+    "GR_DNV_MFA_2026": [
+        ("/posts/greece-dnv-insurance/", "Greece Digital Nomad Visa insurance requirements"),
+        ("/guides/how-to-read-results/", "How to read compliance results"),
     ],
 }
 

--- a/tools/editorial_targets.json
+++ b/tools/editorial_targets.json
@@ -98,5 +98,13 @@
   "content/visas/thailand/digital-nomad-visa-dtv/thai-e-visa/index.md": [
     900,
     1300
+  ],
+  "content/visas/greece/digital-nomad-visa/national-visa-type-d/index.md": [
+    900,
+    1400
+  ],
+  "content/posts/greece-dnv-insurance.md": [
+    450,
+    900
   ]
 }


### PR DESCRIPTION
## Summary

First expansion route from the 90-day roadmap. Evidence-first, modeled on the **Portugal E11 precedent** (mandatory-insurance rule only).

## Research finding (why this encoding)

The Hellenic MFA Digital Nomad Visa page publishes **no requirement details itself** — it officially delegates to the Work From Greece portal ("for all relevant information, please visit workfromgreece.gr"). That portal's required-documents list includes **travel insurance**, and states **no** coverage amount, **no** insurer-authorization rule, and does not exclude travel insurance. Common blog claims (€30k, "authorized in Greece") are secondary and contradict the designated source, so they are **not** encoded.

## What's included

- `sources/GR_WORKFROMGREECE_DNV_2026-06-08.html` (+ meta, sha256) — the MFA-designated source, stored byte-exact.
- `data/visas/GR/DNV/mfa/2026-06-08/visa_facts.json` — `GR_DNV_MFA_2026`, encodes `insurance.mandatory == true`. Coverage amount and insurer authorization left **UNKNOWN**.
- 7 mappings `GR_DNV_MFA_2026__*` — all **GREEN** on the single mandatory rule (consistent with Portugal).
- Enriched visa hub + `content/posts/greece-dnv-insurance.md`.
- `tools/build_content_hubs.py` (Greece FAQ + related posts), `tools/editorial_targets.json` (Greece targets).
- `.gitattributes`: `sources/** -text` so evidence files stay byte-exact and their sha256 stays valid.

## Affiliate discipline

**No affiliate links placed.** The post states compliant products will be linked only once GREEN rests on a primary Hellenic authority source — the current GREEN is based on the MFA-designated portal and models only "insurance mandatory".

## Verification (local)
`validate` · `lint_content` (0 err) · `seo_audit` · `check_editorial_targets` · `check_internal_links` all pass; `hugo --minify` clean. Staged evidence blob sha256 matches its meta after the `.gitattributes` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)