### PR TITLE
🎨 Palette: Accessible Mobile Menu Toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-08 - Accessible Toggle Buttons
+**Learning:** Icon-only toggle buttons in the UI, such as mobile menu buttons, require dynamic ARIA attributes (like `aria-expanded` and `aria-controls`) mapped to their visual state to ensure screen readers correctly interpret their state and functionality. The visual toggling of CSS classes must be synced programmatically with ARIA property values.
+**Action:** When implementing or modifying dynamic interactions, ensure that visual class changes are mapped to their corresponding ARIA attributes (e.g., `aria-expanded`) programmatically in the JavaScript logic.

--- a/ui/index.html
+++ b/ui/index.html
@@ -111,7 +111,9 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+        aria-label="Toggle menu"
+        aria-expanded="false"
+        aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -1176,9 +1178,10 @@
     $("mobileMenuBtn")?.addEventListener("click", () => {
       const menu = $("mobileMenu");
       const btn = $("mobileMenuBtn");
-      const isOpen = !menu.classList.contains("hidden");
+      const isCurrentlyHidden = menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
-      btn.querySelector("span").textContent = isOpen ? "menu" : "close";
+      btn.setAttribute("aria-expanded", String(isCurrentlyHidden));
+      btn.querySelector("span").textContent = isCurrentlyHidden ? "close" : "menu";
     });
 
     init().catch(err => {


### PR DESCRIPTION
💡 What: Added `aria-expanded` and `aria-controls` to the mobile menu toggle button, and updated the javascript listener to accurately toggle this attribute when the menu opens and closes.
🎯 Why: To ensure screen readers properly announce the state and function of the icon-only toggle button, improving overall accessibility for keyboard and assistive tech users.
♿ Accessibility: Mapped the visual state of the mobile menu to programmatic ARIA attributes. Also recorded this pattern in `.jules/palette.md` for future interactions.

---
*PR created automatically by Jules for task [14138278423286927949](https://jules.google.com/task/14138278423286927949) started by @W73QB*