### PR TITLE
feat(route): add Japan Digital Nomad Visa route + currency-aware min_coverage

### DIFF
--- a/content/posts/japan-dnv-insurance.md
+++ b/content/posts/japan-dnv-insurance.md
@@ -1,0 +1,111 @@
+---
+title: "Japan Digital Nomad Visa insurance requirements (evidence-based)"
+date: 2026-06-08
+description: "Evidence-based summary of the private insurance requirement for Japan's Digital Nomad Visa, based on the Ministry of Foreign Affairs of Japan."
+tags: ["japan", "dnv", "digital-nomad-visa", "insurance", "compliance"]
+faq:
+  - question: "How much insurance coverage does the Japan Digital Nomad Visa require?"
+    answer: "The Ministry of Foreign Affairs requires insurance against death, injury or illness during the stay, with medical-treatment compensation of JPY 10 million or more."
+  - question: "How does the checker compare a JPY threshold against a USD or EUR policy limit?"
+    answer: "It converts both the threshold and the product limit to euro using fixed reference rates, so a large yen figure is compared like-for-like instead of as a raw number."
+  - question: "Is national health insurance an option for this visa?"
+    answer: "No. Digital Nomad visa holders are not enrolled in Japan's national health insurance, so private coverage meeting the JPY 10 million threshold is required."
+---
+
+## Short answer
+
+Japan's Digital Nomad Visa (a Designated Activities status, valid up to six months) requires private insurance against death, injury or illness during the stay, with medical-treatment compensation of JPY 10 million or more. This is item (6) of the necessary documents on the Ministry of Foreign Affairs of Japan visa page (Source: `JP_DNV_MOFA_2026`, Necessary documents, Digital Nomad, item (6); verified 2026-06-08).
+
+## Key findings at a glance
+
+| Item | Value |
+|---|---|
+| Route | Japan Digital Nomad Visa (Designated Activities) |
+| Authority | Ministry of Foreign Affairs of Japan |
+| Evidence verified | 2026-06-08 |
+| Snapshot | 2026-06-08 |
+| Modeled rules | Insurance mandatory; medical-treatment coverage of at least JPY 10 million |
+
+## What the authority requires
+
+- Private insurance is mandatory for the visa. (Source: `JP_DNV_MOFA_2026`, item (6); verified 2026-06-08)
+- The insurance must cover death, injury or illness during the stay in Japan. (Source: `JP_DNV_MOFA_2026`, item (6); verified 2026-06-08)
+- Medical-treatment compensation must be JPY 10 million or more. (Source: `JP_DNV_MOFA_2026`, item (6); verified 2026-06-08)
+
+Normalized requirements table:
+
+| Requirement | Source URL | Locator | Verified date |
+|---|---|---|---|
+| Insurance is mandatory | https://www.mofa.go.jp/ca/fna/pagewe_000001_00046.html | Necessary documents, item (6) | 2026-06-08 |
+| Medical coverage at least JPY 10 million | https://www.mofa.go.jp/ca/fna/pagewe_000001_00046.html | Necessary documents, item (6) | 2026-06-08 |
+
+## Verified requirements (PASS/FAIL/UNKNOWN)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Insurance is mandatory | PASS | MOFA necessary-documents list, item (6) |
+| Medical coverage at least JPY 10 million | PASS for products whose documented limit clears the threshold | MOFA necessary-documents list, item (6) |
+| Insurer-authorization rule | UNKNOWN | MOFA does not restrict the provider |
+
+## How we evaluate, and the currency note
+
+The checker compares each modeled requirement against product evidence. The coverage rule is where Japan needs care: the threshold is JPY 10 million, but the products in the checker document their limits in US dollars or euro. Comparing raw numbers would be wrong, so the engine converts both the threshold and each product limit to euro using fixed reference rates before comparing. JPY 10 million is roughly 61,000 euro, which a worldwide policy of USD 250,000 or EUR 1,000,000 clears comfortably. Where a product does not document an overall limit, the result is UNKNOWN rather than a guess. See /methodology/ for the full logic and the UNKNOWN > Wrong principle.
+
+## Who this visa is for and how long coverage must last
+
+The Japan Digital Nomad Visa is a Designated Activities status for individuals working remotely in Japan for a period not exceeding six months, and the Ministry of Foreign Affairs notes that no extension will be granted. Because the stay can run the full six months, the private insurance has to cover that entire period rather than a shorter trip window; a policy that lapses partway through leaves a gap the authority can question at the application stage. A spouse or child accompanying the main applicant is covered by the same designated activities framework and faces the same JPY 10 million insurance condition, which can be met through family coverage on the main applicant's policy where the documents confirm the scope. The page also explains the Certificate of Eligibility (COE): presenting a COE issued by a regional immigration bureau smooths the visa application and the landing examination, though the Ministry is explicit that a COE does not by itself assure the visa is issued. None of this changes the insurance rule the checker models, but it sets the period and the parties the JPY 10 million coverage has to apply to.
+
+## Proof package checklist
+
+- A certificate of insurance coverage and policy summary showing medical-treatment compensation of JPY 10 million or more.
+- Confirmation that the cover extends to death, injury and illness during the stay in Japan.
+- A policy valid for the full planned period of stay (up to six months).
+
+## Common rejection traps
+
+- Assuming Japan's national health insurance applies: Digital Nomad holders are not enrolled, so private cover is needed.
+- A medical-treatment limit below JPY 10 million.
+- Relying on a credit-card insurance perk without documents proving the compensation level.
+
+## FAQ
+
+**Q: How much coverage is required?**
+**A:** Medical-treatment compensation of JPY 10 million or more, covering death, injury or illness during the stay (Source: `JP_DNV_MOFA_2026`, item (6); verified 2026-06-08).
+
+**Q: How is a yen threshold compared with a dollar or euro policy?**
+**A:** The engine converts both to euro with fixed reference rates, so the comparison is like-for-like.
+
+**Q: Does national health insurance count?**
+**A:** No. Digital Nomad visa holders are not enrolled in Japan's national health insurance.
+
+## Check in the engine
+
+Use [the compliance checker](/ui/) with the current snapshot for this route:
+
+{{< checker_cta visa="JP_DNV_MOFA_2026" product="GENKI_TRAVELER_2026" snapshot="2026-06-08" >}}
+
+## Related reading
+
+- [Japan Digital Nomad Visa requirements (route page)](/visas/japan/digital-nomad-visa/designated-activities-mofa/)
+- [Digital nomad insurance in Asia](/posts/digital-nomad-insurance-asia/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## Where to find compliant insurance for the Japan Digital Nomad Visa
+
+In the current snapshot, the products that show GREEN for this route are those whose documented limit clears JPY 10 million once converted to a common currency: Genki Traveler, SafetyWing Nomad Insurance, and World Nomads Explorer. The Spanish health policies in the checker (ASISA, DKV, Sanitas) show UNKNOWN here because their documents do not state an overall coverage limit to compare against the threshold.
+
+- [Genki Traveler](https://genki.world/products/traveler) — paid link. We may earn a commission if you purchase through this link.
+
+> Use the compliance checker to confirm the current GREEN products for this route before you buy.
+
+## Disclaimer + Affiliate disclosure
+
+Not legal advice. Compliance results are evidence-based snapshots.
+
+If an affiliate link is present, it appears only after results and does not change the compliance outcome. The Genki link above is a paid affiliate link.
+
+Last updated: 2026-06-08
+
+## Evidence log
+
+- Source: JP_DNV_MOFA_2026

--- a/content/visas/japan/digital-nomad-visa/_index.md
+++ b/content/visas/japan/digital-nomad-visa/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Japan Digital Nomad Visa"
+visa_group: "japan-digital-nomad-visa"
+description: "Insurance requirements for Japan Digital Nomad Visa - evidence-based compliance checker"
+---
+
+## Japan Digital Nomad Visa Requirements
+
+All requirements below are derived from official sources. Missing evidence means UNKNOWN.
+
+## Routes
+
+| Authority | Route | Last Verified | Details |
+| --- | --- | --- | --- |
+| Ministry of Foreign Affairs of Japan | Designated Activities (MOFA) | 2026-06-08 | [View requirements](/visas/japan/digital-nomad-visa/designated-activities-mofa/) |
+
+## What the authority requires
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+## How we evaluate
+
+We compare these official requirements against insurance product specifications using our automated rule engine. Each requirement is matched to a product fact with evidence.
+
+## Check in the engine
+
+Try the compliance checker: [Open Checker](/ui/?visa=JP_DNV_MOFA_2026&snapshot=2026-06-08)
+
+## Disclaimer
+
+This is not legal advice. VisaFact provides evidence-based compliance checking only. Final visa decisions are made by government authorities. A GREEN result does not ensure visa approval.
+
+## Affiliate disclosure
+
+If affiliate links appear, they are shown only after compliance results and do not influence the compliance evaluation in any way.
+
+## Evidence log
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+
+{{< checker_cta visa="JP_DNV_MOFA_2026" snapshot="2026-06-08" >}}

--- a/content/visas/japan/digital-nomad-visa/designated-activities-mofa/index.md
+++ b/content/visas/japan/digital-nomad-visa/designated-activities-mofa/index.md
@@ -1,0 +1,103 @@
+---
+title: "Japan Digital Nomad Visa - Designated Activities (MOFA)"
+visa_id: "JP_DNV_MOFA_2026"
+last_verified: "2026-06-08"
+source_ids: ["JP_DNV_MOFA_2026"]
+description: "Official insurance requirements for Japan Digital Nomad Visa via Designated Activities (MOFA)"
+faq:
+  - question: "How much insurance coverage does the Japan Digital Nomad Visa require?"
+    answer: "The Ministry of Foreign Affairs requires insurance against death, injury or illness during the stay, with medical-treatment compensation of JPY 10 million or more."
+  - question: "How does the checker compare a JPY threshold against a USD or EUR policy limit?"
+    answer: "It converts both the threshold and the product limit to euro using fixed reference rates, so a large yen figure is compared like-for-like instead of as a raw number."
+  - question: "Is national health insurance an option for this visa?"
+    answer: "No. Digital Nomad visa holders are not enrolled in Japan's national health insurance, so private coverage meeting the JPY 10 million threshold is required."
+---
+
+## Japan Digital Nomad Visa
+
+**Route:** Designated Activities (MOFA)  
+**Authority:** Ministry of Foreign Affairs of Japan  
+**Last Verified:** 2026-06-08
+
+## Requirements
+
+| Requirement | Operator | Value | Evidence |
+| --- | --- | --- | --- |
+| `insurance.mandatory` | `==` | Yes | *Necessary documents, Digital Nomad, item (6)*: "Documents proving that the applicant has insurance against death, injury or illn..." ([source](/sources/JP_DNV_MOFA_2026-06-08.html)) |
+| `insurance.min_coverage` | `>=` | 10000000 | *Necessary documents, Digital Nomad, item (6)*: "compensation for medical treatment for injury or illness must be JPY 10 million ..." ([source](/sources/JP_DNV_MOFA_2026-06-08.html)) |
+
+## Source Documents
+
+- **JP_DNV_MOFA_2026**: [Local copy](/sources/JP_DNV_MOFA_2026-06-08.html) | [Original](https://www.mofa.go.jp/ca/fna/pagewe_000001_00046.html) | Retrieved: 2026-06-08
+
+## Related reading
+
+- [Japan Digital Nomad Visa insurance requirements](/posts/japan-dnv-insurance/)
+- [Digital nomad insurance in Asia](/posts/digital-nomad-insurance-asia/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## What the authority requires
+
+The points below are taken directly from the official source for the Japan Digital Nomad Visa (Designated Activities (MOFA)) route. Each one is recorded with a source identifier and a locator so it can be traced back to the original document. Where the source is silent on a point, the engine records UNKNOWN instead of inferring an answer.
+
+- The authority requires that insurance is mandatory.
+- The authority requires that the medical coverage meets the stated minimum of at least 10000000.
+
+This route is defined by a small number of explicit insurance points, which keeps the evidence trail short but also unusually clear. A concise official requirement still has to be matched precisely: a product is only GREEN here when its documented terms line up with the wording above, and a route with few stated rules does not imply that any policy will be accepted. Where the authority is silent, the engine deliberately holds the status at UNKNOWN or NOT_REQUIRED rather than reading extra conditions into the source, so the page reflects exactly what the document states and nothing more. Applicants on routes like this one should still keep the underlying policy wording on hand, because a consular officer may ask to see how each stated point is met even when the published checklist is short.
+
+## How we evaluate
+
+Every requirement is compared against the documented specification of each insurance product using an automated rule engine. A product is marked GREEN for a requirement only when product evidence explicitly satisfies it; a conflict produces RED; and absent evidence produces UNKNOWN rather than a guess. The route status is the combination of its per-requirement outcomes.
+
+- Rule `insurance.mandatory == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+- Rule `insurance.min_coverage >= 10000000` GREEN at or above the threshold, RED below it, UNKNOWN if unstated.
+
+## How each compliance status is decided for this route
+
+GREEN means every recorded requirement is satisfied by product evidence. RED means at least one requirement is contradicted by the product evidence. YELLOW means the evidence is partial: some requirements are met while others lack full proof. UNKNOWN means a requirement exists but the product evidence does not address it, so no claim is made. NOT_REQUIRED means the authority does not impose an insurance requirement for the route, which is itself an evidence-based finding drawn from the official document. A GREEN result reflects the evidence on the snapshot date and is not an assurance of a visa outcome, which always rests with the issuing authority.
+
+## Reading the evidence and snapshots
+
+Each requirement above links to a primary source through a source identifier and a locator (for example a page number, article, or section). The underlying documents are listed under Source Documents and are stored alongside this dataset so the wording can be checked directly. Results are tied to a dated snapshot (`2026-06-08`): a deep link to a past snapshot returns the same verdict even if the authority later changes its rules, which keeps every decision reproducible and auditable.
+
+## Proof package checklist
+
+Before applying for this route, prepare the following so the policy can be checked against each requirement:
+
+- A policy certificate that states the coverage limits, any deductible or co-payment, and the covered period.
+- Written confirmation of the insurer's status where the route requires authorization in a specific country.
+- Documentation that the coverage spans the full authorized stay rather than a partial term.
+- The official source wording for the route, so each clause can be matched to the requirements above.
+
+## Common questions
+
+**How much insurance coverage does the Japan Digital Nomad Visa require?**  
+The Ministry of Foreign Affairs requires insurance against death, injury or illness during the stay, with medical-treatment compensation of JPY 10 million or more.
+
+**How does the checker compare a JPY threshold against a USD or EUR policy limit?**  
+It converts both the threshold and the product limit to euro using fixed reference rates, so a large yen figure is compared like-for-like instead of as a raw number.
+
+**Is national health insurance an option for this visa?**  
+No. Digital Nomad visa holders are not enrolled in Japan's national health insurance, so private coverage meeting the JPY 10 million threshold is required.
+
+## Check in the engine
+
+Run a specific product against this route in the compliance checker: [Open Checker](/ui/?visa=JP_DNV_MOFA_2026&snapshot=2026-06-08). The checker shows the per-requirement outcome and the evidence behind each one.
+
+## Disclaimer
+
+This page is not legal advice. VisaFact provides evidence-based compliance checking only, and final visa decisions are made by government authorities. A GREEN result reflects documented evidence on the snapshot date; it does not ensure that a visa application will succeed. Always confirm the current requirements with the issuing authority before submitting an application.
+
+## Affiliate disclosure
+
+If affiliate links appear on related pages, they are shown only after the compliance result and never change the evaluation, which is generated independently from the official evidence.
+
+## Evidence log
+
+Each entry pairs a requirement with the source identifier and locator it was drawn from:
+
+- `insurance.mandatory` <- JP_DNV_MOFA_2026 (Necessary documents, Digital Nomad, item (6)): "Documents proving that the applicant has insurance against death, injury or illness during their sta"
+- `insurance.min_coverage` <- JP_DNV_MOFA_2026 (Necessary documents, Digital Nomad, item (6)): "compensation for medical treatment for injury or illness must be JPY 10 million or more"
+
+
+{{< checker_cta visa="JP_DNV_MOFA_2026" snapshot="2026-06-08" >}}

--- a/data/mappings/JP_DNV_MOFA_2026__ASISA_HEALTH_RESIDENTS_2026.json
+++ b/data/mappings/JP_DNV_MOFA_2026__ASISA_HEALTH_RESIDENTS_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "JP_DNV_MOFA_2026",
+  "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/JP_DNV_MOFA_2026__DKV_VISADO_2026.json
+++ b/data/mappings/JP_DNV_MOFA_2026__DKV_VISADO_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "JP_DNV_MOFA_2026",
+  "product_id": "DKV_VISADO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/JP_DNV_MOFA_2026__GENERIC_EXPAT_COMPLETE_2026.json
+++ b/data/mappings/JP_DNV_MOFA_2026__GENERIC_EXPAT_COMPLETE_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "JP_DNV_MOFA_2026",
+  "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/JP_DNV_MOFA_2026__GENKI_TRAVELER_2026.json
+++ b/data/mappings/JP_DNV_MOFA_2026__GENKI_TRAVELER_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "JP_DNV_MOFA_2026",
+  "product_id": "GENKI_TRAVELER_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/JP_DNV_MOFA_2026__SAFETYWING_NOMAD_2026.json
+++ b/data/mappings/JP_DNV_MOFA_2026__SAFETYWING_NOMAD_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "JP_DNV_MOFA_2026",
+  "product_id": "SAFETYWING_NOMAD_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/JP_DNV_MOFA_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
+++ b/data/mappings/JP_DNV_MOFA_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "JP_DNV_MOFA_2026",
+  "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/JP_DNV_MOFA_2026__WORLDNOMADS_EXPLORER_2026.json
+++ b/data/mappings/JP_DNV_MOFA_2026__WORLDNOMADS_EXPLORER_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "JP_DNV_MOFA_2026",
+  "product_id": "WORLDNOMADS_EXPLORER_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/ui_index.json
+++ b/data/ui_index.json
@@ -1,5 +1,5 @@
 {
-  "built_at": "2026-06-08T13:00:11.199881+00:00",
+  "built_at": "2026-06-08T13:21:11.887952+00:00",
   "snapshot_id": "2026-06-08",
   "visas": [
     {
@@ -411,6 +411,50 @@
               "source_id": "IT_SELFEMP_SF_INSURANCE_2026",
               "locator": "Travel Medical Insurance notice (Schengen short-stay, applies to the short-term self-employment visa)",
               "excerpt": "proof of 30,000 euro or $50,000 in medical expenses coverage for the duration of the applicant's trip"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "JP_DNV_MOFA_2026",
+      "country": "Japan",
+      "visa_name": "Digital Nomad Visa",
+      "route": "Designated Activities (MOFA)",
+      "authority": "Ministry of Foreign Affairs of Japan",
+      "last_verified": "2026-06-08",
+      "sources": [
+        {
+          "source_id": "JP_DNV_MOFA_2026",
+          "url": "https://www.mofa.go.jp/ca/fna/pagewe_000001_00046.html",
+          "retrieved_at": "2026-06-08T00:00:00Z",
+          "sha256": "4ef9d598abe8c7789dfffe8f2eeae83ab50d6056b404b1e9aa73a9363c0ccac5",
+          "local_path": "sources/JP_DNV_MOFA_2026-06-08.html"
+        }
+      ],
+      "requirements": [
+        {
+          "key": "insurance.mandatory",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "JP_DNV_MOFA_2026",
+              "locator": "Necessary documents, Digital Nomad, item (6)",
+              "excerpt": "Documents proving that the applicant has insurance against death, injury or illness during their stay in Japan (compensation for medical treatment for injury or illness must be JPY 10 million or more)."
+            }
+          ]
+        },
+        {
+          "key": "insurance.min_coverage",
+          "op": ">=",
+          "value": 10000000,
+          "currency": "JPY",
+          "evidence": [
+            {
+              "source_id": "JP_DNV_MOFA_2026",
+              "locator": "Necessary documents, Digital Nomad, item (6)",
+              "excerpt": "compensation for medical treatment for injury or illness must be JPY 10 million or more"
             }
           ]
         }
@@ -1419,7 +1463,7 @@
       "missing": [
         "specs.overall_limit"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-08"
     },
     {
       "visa_id": "IT_SELFEMP_SF_2026",
@@ -1429,7 +1473,7 @@
       "missing": [
         "specs.overall_limit"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-08"
     },
     {
       "visa_id": "IT_SELFEMP_SF_2026",
@@ -1439,7 +1483,7 @@
       "missing": [
         "specs.overall_limit"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-08"
     },
     {
       "visa_id": "IT_SELFEMP_SF_2026",
@@ -1447,7 +1491,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-08"
     },
     {
       "visa_id": "IT_SELFEMP_SF_2026",
@@ -1455,7 +1499,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-08"
     },
     {
       "visa_id": "IT_SELFEMP_SF_2026",
@@ -1465,10 +1509,74 @@
       "missing": [
         "specs.overall_limit"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-08"
     },
     {
       "visa_id": "IT_SELFEMP_SF_2026",
+      "product_id": "WORLDNOMADS_EXPLORER_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": "2026-06-08"
+    },
+    {
+      "visa_id": "JP_DNV_MOFA_2026",
+      "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "JP_DNV_MOFA_2026",
+      "product_id": "DKV_VISADO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "JP_DNV_MOFA_2026",
+      "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "JP_DNV_MOFA_2026",
+      "product_id": "GENKI_TRAVELER_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "JP_DNV_MOFA_2026",
+      "product_id": "SAFETYWING_NOMAD_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "JP_DNV_MOFA_2026",
+      "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "JP_DNV_MOFA_2026",
       "product_id": "WORLDNOMADS_EXPLORER_2026",
       "status": "GREEN",
       "reasons": [],
@@ -1917,6 +2025,13 @@
       "retrieved_at": "2026-06-08T00:00:00Z",
       "sha256": "3a89d56d842bd67c5c91e279664e62f319762b759b34ed2cf0b4b07b56d8499d",
       "local_path": "sources/IT_SELFEMP_SF_INSURANCE_2026-06-08.pdf"
+    },
+    "JP_DNV_MOFA_2026": {
+      "source_id": "JP_DNV_MOFA_2026",
+      "url": "https://www.mofa.go.jp/ca/fna/pagewe_000001_00046.html",
+      "retrieved_at": "2026-06-08T00:00:00Z",
+      "sha256": "4ef9d598abe8c7789dfffe8f2eeae83ab50d6056b404b1e9aa73a9363c0ccac5",
+      "local_path": "sources/JP_DNV_MOFA_2026-06-08.html"
     },
     "MT_RESIDENCY_FAQ_2026": {
       "source_id": "MT_RESIDENCY_FAQ_2026",

--- a/data/visas/JP/DNV/mofa/2026-06-08/visa_facts.json
+++ b/data/visas/JP/DNV/mofa/2026-06-08/visa_facts.json
@@ -1,0 +1,44 @@
+{
+  "id": "JP_DNV_MOFA_2026",
+  "country": "Japan",
+  "visa_name": "Digital Nomad Visa",
+  "route": "Designated Activities (MOFA)",
+  "authority": "Ministry of Foreign Affairs of Japan",
+  "last_verified": "2026-06-08",
+  "sources": [
+    {
+      "source_id": "JP_DNV_MOFA_2026",
+      "url": "https://www.mofa.go.jp/ca/fna/pagewe_000001_00046.html",
+      "retrieved_at": "2026-06-08T00:00:00Z",
+      "sha256": "4ef9d598abe8c7789dfffe8f2eeae83ab50d6056b404b1e9aa73a9363c0ccac5",
+      "local_path": "sources/JP_DNV_MOFA_2026-06-08.html"
+    }
+  ],
+  "requirements": [
+    {
+      "key": "insurance.mandatory",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "JP_DNV_MOFA_2026",
+          "locator": "Necessary documents, Digital Nomad, item (6)",
+          "excerpt": "Documents proving that the applicant has insurance against death, injury or illness during their stay in Japan (compensation for medical treatment for injury or illness must be JPY 10 million or more)."
+        }
+      ]
+    },
+    {
+      "key": "insurance.min_coverage",
+      "op": ">=",
+      "value": 10000000,
+      "currency": "JPY",
+      "evidence": [
+        {
+          "source_id": "JP_DNV_MOFA_2026",
+          "locator": "Necessary documents, Digital Nomad, item (6)",
+          "excerpt": "compensation for medical treatment for injury or illness must be JPY 10 million or more"
+        }
+      ]
+    }
+  ]
+}

--- a/sources/JP_DNV_MOFA_2026-06-08.html
+++ b/sources/JP_DNV_MOFA_2026-06-08.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Specified visa: Designated activities(Digital Nomad, Spouse or Child of Digital Nomad) | Ministry of Foreign Affairs of Japan</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=0.25,user-scalable=yes">
+    <meta name="description" content="">
+    <meta name="keywords" content="">
+    <meta name="robots" content="index,follow">
+    <meta name="copyright" content="Copyright (C) Ministry of Foreign Affairs of Japan.">
+    <link rel="shortcut icon" href="/files/100002787.ico">
+    <link rel="index" title="Ministry of Foreign Affairs of Japan" href="/index.html">
+    <link rel="stylesheet" href="/mofaj/style/old_import_en.css" media="all">
+    <link rel="stylesheet" href="/mofaj/style/layout.css" media="all">
+    <link rel="stylesheet" href="/mofaj/style/new_common.css" media="all">
+    <link rel="stylesheet" href="/mofaj/style/new_aly.css" media="all">
+    <link rel="stylesheet" href="/mofaj/style/print.css" media="print">
+    <!-- OGP -->
+    <meta property="og:locale" content="en_US">
+    <meta property="og:title" content="Specified visa: Designated activities(Digital Nomad, Spouse or Child of Digital Nomad)">
+    <meta property="og:type" content="government">
+    <meta property="og:url" content="https://www.mofa.go.jp/ca/fna/pagewe_000001_00046.html">
+    <meta name="twitter:card" content="summary">
+    <meta property="og:image" content="https://www.mofa.go.jp/files/100002817.jpg">
+    <meta property="og:site_name" content="Ministry of Foreign Affairs of Japan">
+    <meta property="fb:app_id" content="">
+    <script src="/mofaj/js/jquery-3-6-0.js"></script>
+    <script id="twitter-wjs" src="https://platform.twitter.com/widgets.js"></script>
+    <script>
+    var mofa_title = 'Specified visa: Designated activities(Digital Nomad, Spouse or Child of Digital Nomad)';
+    var mofa_fb_appid = '';
+    /* -----------------------------------------------------------------------------
+    SNS連携用JS
+    注：事前に mofa_fb_appid, mofa_title が定義されていることを前提とする
+    mofa_fb_appid: facebook アプリID
+    mofa_title: SNS掲載用のタイトル
+    ----------------------------------------------------------------------------- */
+    $(document).ready(function(){
+        // facebook いいそ！ボタン
+        var fb_url = "//www.facebook.com/plugins/like.php?href="+ encodeURIComponent(document.URL) +"&send=false&layout=button_count&width=115&show_faces=false&font&colorscheme=light&action=like&height=21&appId="+ mofa_fb_appid;
+        if ( $('html').attr('lang') == 'en' ) fb_url += "&locale=en_US"; //英語サイト用
+        $('#social-btn-fb').attr('src', fb_url);
+        
+        // メール ボタン
+        var mail_url = "mailto:?" + "body="+ encodeURI(document.URL);
+        $('#social-btn-mail').attr('href', mail_url);
+    });
+    </script>
+    <script src="/mofaj/js/common.js"></script>
+    <style>
+        #maincontents div.social-btn-wrapper:nth-of-type(2),
+        html[lang="en"] #maincontents div.social-btn-wrapper:nth-of-type(2){
+            max-width: 90px !important;
+        }
+    </style>
+    <style>
+.disc{margin-left:1em;}
+.disc li{margin-bottom:1em;}
+.bt li{font-weight:bold;}
+.tp{margin-top:1em; text-indent:0!important; margin-left:-4em;}
+.section .none{text-indent:-1.5em; padding-left: 2em; margin-bottom:1em;} 
+.section table{border:1px solid #999; width:100%; border-collapse: collapse; margin:1.5em 0 2em;} 
+.section th{text-align:center; border:1px solid #999; background-color:#ddd; border-collapse: collapse;white-space:nowrap;} 
+.section td{text-align:left;border:1px solid #999; border-collapse: collapse; padding:2px 2px 2px 5px;}
+
+    </style>
+</head>
+
+<body class="page-single en">
+    <noscript><p>The Ministry of Foreign Affairs website uses JavaScript.<br>Please turn on &quot;JavaScript&quot; and use it.</p></noscript>
+    <div id="wrapper">
+        <header id="header">
+            <div id="logo-mofa"><a href="/index.html"><img src="/files/100000047.png" alt="Ministry of Foreign Affairs of Japan"></a></div>
+            <div id="header-right">
+                <div class="menu-sub">
+                    <span><a href="#contents" title="Move to main text" tabindex="1">Skip to main content</a></span>
+                    <span><a href="/feedback/index.html">FAQ</a></span>
+                    <span><a href="/infotree/index.html">Site Map</a></span>
+                    <span><a href="/link/index.html">Links</a></span>
+                </div>
+                <div class="menu-language"><span><a href="/mofaj/index.html">Japanese</a></span><span><a href="/about/emb_cons/over/multi.html">Other Languages</a></span></div>
+                <div id="func">
+                    <form action="//www.mofa.go.jp/searchresult.html" id="cse-search-box" method="get" role="search">
+                        <input type="hidden" name="cx" value="011758268112499481406:fkqokg_sxzw">
+                        <input type="hidden" name="ie" value="UTF-8">
+                        <input type="hidden" name="oe" value="UTF-8">
+                        <input type="text" name="q" size="15" id="searchbox" aria-label="Search string text box" title="Enter the string you want to search for." placeholder="Custom Search">
+                        <button type="submit" id="searchbutton" aria-label="Search execution button" title="Perform a search"><span>Search</span></button>
+                    </form>
+                    <script src="//www.google.com/cse/brand?form=cse-search-box&amp;lang=en"></script>
+                    <dl id="textchanger">
+                        <dt>Font Size</dt>
+                        <dd class="small"><a href="#" title="Reduce the font size">S</a></dd>
+                        <dd class="middle"><a href="#" title="Make the font size standard">M</a></dd>
+                        <dd class="large"><a href="#" title="Increase the font size">L</a></dd>
+                    </dl>
+                    <!-- /#func -->
+                </div>
+                <!-- /#header-right -->
+            </div>
+            <!-- /#header -->
+        </header>
+
+        <nav id="navi-global" class="dsp-non">
+            <ul>
+                <li class="about"><a href="/about/index.html"><span>About Us</span></a></li>
+                <li class="press"><a href="/policy/culture/index.html"><span>News</span></a></li>
+                <li class="foreign"><a href="/policy/index.html"><span>Foreign Policy</span></a></li>
+                <li class="region"><a href="/region/index.html"><span>Countries & Regions</span></a></li>
+                <li class="consular"><a href="/p_pd/ipr/page7e_900126.html" class="now"><span>Consular Services</span></a></li>
+            </ul>
+            <!-- /#navi-global -->
+        </nav>
+        <div id="breadcrumb">
+<a href="/index.html">Top</a>&nbsp;&gt;&nbsp;<a href="/p_pd/ipr/page7e_900126.html">Consular Services</a>&nbsp;&gt;&nbsp;<a href="/j_info/visit/visa/index.html">VISA</a>&nbsp;&gt;&nbsp;Specified visa: Designated activities(Digital Nomad, Spouse or Child of Digital Nomad)
+        </div>
+
+        <main id="contents">
+            <article id="contents-article">
+                <div id="contents-header">
+                    <h1 class="title1"><span>VISA</span></h1>
+                    <h2 class="title2 title-logo"><span>Specified visa: Designated activities<br>(Digital Nomad, Spouse or Child of Digital Nomad)</span></h2>
+                    <!-- /#contents-header -->
+                </div>
+                <div id="contents-body">
+                    <div id="main">
+                        <div id="maincontents">
+                        <div class="rightalign">March 31, 2024</div>
+                        <div class="rightalign other-language">
+<a href="/mofaj/ca/fna/pagew_000001_00494.html">Japanese</a> </div>
+                        <div class="social-btn-top">
+                            <!-- twitter 公式ウィジェット -->
+                            <div class="social-btn-wrapper"><a id="social-btn-tw" href="https://twitter.com/share" class="twitter-share-button" data-text="" data-lang="en">Post</a></div>
+                            <script>(function ($) { var t = $('#social-btn-tw'); t.attr('data-text', mofa_title); })(jQuery)</script>
+                            <script>!function (d, s, id) { var js, fjs = d.getElementsByTagName(s)[0]; if (!d.getElementById(id)) { js = d.createElement(s); js.id = id; js.src = "//platform.twitter.com/widgets.js"; fjs.parentNode.insertBefore(js, fjs); } }(document, "script", "twitter-wjs");</script>
+                            <!-- facebook いいね！ボタン -->
+                            <div class="social-btn-wrapper"><iframe src="https://www.facebook.com/plugins/share_button.php?locale=en_US&href=https%3A%2F%2Fwww.mofa.go.jp%2Fca%2Ffna%2Fpagewe_000001_00046.html&layout=button_count&size=small&width=92&height=20&appId" width="92" height="20" style="border:none;overflow:hidden" allow="encrypted-media" title="fb:share_button Facebook Social Plugin"></iframe>
+                            </div>
+                            <!-- メール -->
+                            <div class="social-btn-wrapper"><a id="social-btn-mail" href="#" target="_blank"><img src="/files/100000048.gif" alt="e-mail"></a></div>
+                        </div>
+                        <div class="main-section section">
+                            <div class="section-block image-section-top">
+                                <div class="text"><div class="any-area"><table>
+	<tbody>
+		<tr>
+			<th scope="row">Period of stay</th>
+			<td>6 months (No extension will be granted)</td>
+		</tr>
+		<tr>
+			<th scope="row">Eligibility and activity</th>
+			<td>
+				<ul class="disc">
+					<li>Individuals wishing to work remotely in Japan for a period not exceeding six months.<br />
+						</li>
+					<li>Spouse or child accompanying an individual wishing to stay in Japan for a period not exceeding six months while working remotely.<br />
+						<br />
+						For eligible countries or regions, please visit<a href="https://www.moj.go.jp/isa/content/001416932.pdf" target="_blank"> the Immigration Services Agency website (English) (PDF) </a><img alt="Open a New Window" src="/files/000062251.gif" /></li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th scope="row">Necessary documents</th>
+			<td>
+				<ol class="pg bt">
+					<li>Digital Nomad</li>
+				</ol>
+
+				<ul>
+					<li class="none">(1) Visa application form (with a photo)</li>
+					<li class="none">(2) Passport</li>
+					<li class="none">(3) Certificate of eligibility ((Note) If the certificate of eligibility is presented, (4) to (6) below can be omitted.)</li>
+					<li class="none">(4)Documents explaining the applicant&#39;s planned activities and period of stay during their stay in Japan <a href="https://www.moj.go.jp/isa/content/001416531.docx">(Form) (Word)</a><img alt="" src="/files/000000166.gif" /></li>
+					<li class="none">(5) Documents proving that the applicant&#39;s annual income is JPY 10 million or more.						<ul>
+							<li class="none tp">(Note) Tax payment certificate, income certificate, employment contract, contract with a business partner (which clearly states the contract period and the contract amount.)</li>
+						</ul>
+					</li>
+					<li class="none">(6) Documents proving that the applicant has insurance against death, injury or illness during their stay in Japan (compensation for medical treatment for injury or illness must be JPY 10 million or more).</li>
+				</ul>
+				(Note) A copy of the certificate of insurance coverage and policy summary, a copy of the credit card and documents proving supplementary compensation.
+
+				<ol class="pg bt" start="2">
+					<li>Spouse or child of Digital Nomad</li>
+				</ol>
+
+				<ul>
+					<li class="none">(1) Visa application form (with a photo)</li>
+					<li class="none">(2) Passport</li>
+					<li class="none">(3) Certificate of eligibility ((Note) If the certificate of eligibility is presented, (3) to (5) below can be omitted)</li>
+					<li class="none">(4) Documents explaining the applicant&#39;s planned activities and period of stay during their stay in Japan<a href="https://www.moj.go.jp/isa/content/001416531.docx"> (Form) (Word)</a><img alt="" src="/files/000000166.gif" /></li>
+					<li class="none">(5) Documents proving that the applicant has insurance against death, injury and illness during their stay in Japan (compensation for medical treatment for injury and illness must be JPY 10 million yen or more)
+						<ul>
+							<li class="none tp">(Note) A copy of the certificate of insurance coverage and policy summary, a copy of the credit card and documents proving supplementary compensation.<br />
+								(A copy of documents confirming the scope of insurance coverage, in case family coverage is provided by the insurance of the spouse or parent.)</li>
+						</ul>
+					</li>
+					<li class="none">(6) Documents proving the relationship between the applicant and the spouse or parent with Digital Nomad visa</li>
+					<li class="none">(7) A copy of the passport of the applicant&rsquo;s spouse or parent with Digital Nomad visa</li>
+				</ul>
+				(Note) What is a Certificate of Eligibility(COE)?<br />
+				By presenting Certificate of Eligibility which is issued by a regional immigration bureau, the visa application at the Embassy or Consulate-General and the landing examination at the passport control will be processed smoothly. However, please note that a COE does not guarantee the issuance of a visa. For details, please visit the website of <a href="https://www.moj.go.jp/isa/" target="_blank">the Immigration Services Agency of JAPAN (Japanese).</a><img alt="Open a New Window" src="/files/000062250.gif" /></td>
+		</tr>
+	</tbody>
+</table>
+</div></div>
+                            </div>
+                        </div>
+
+
+                        </div>
+                        <!-- /#main -->
+                    </div>
+                </div>
+            </article>
+            <!-- /#contents -->
+        </main>
+        <div id="pagetop" class="link-arrow"><span><a href="#header">Page Top</a></span></div>
+        <div class="index"><a href="/j_info/visit/visa/index.html">Back to VISA</a></div>
+<footer id="footer">
+    <div id="footer-sitemaps">
+        <div class="wrapper link-arrow">
+            <dl>
+                <dt><a href="/about/index.html">About Us</a></dt>
+                <dd>
+                    <ul>
+                        <li><a href="/about/page22e_000390.html">Ministers</a></li>
+                        <li><a href="/about/hq/list.html">Officials</a></li>
+                        <li><a href="/about/hq/org.html">Organization</a></li>
+                        <li><a href="/about/hq/map.html">Location</a></li>
+                        <li><a href="/about/emb_cons/over/index.html">Embassies &amp; Consulates</a></li>
+                        <li><a href="/about/hq/record/index.html">Diplomatic Archives</a></li>
+                        <li><a href="/about/page22e_000497.html">About this Site</a></li>
+                    </ul>
+                </dd>
+            </dl>
+            <dl>
+                <dt><a href="/policy/culture/index.html">News</a></dt>
+                <dd>
+                    <ul>
+                        <li><a href="/press/release/index.html">Press Releases </a></li>
+                        <li><a href="/press/kaiken/index.html">Press Conferences</a></li>
+                        <li><a href="/p_pd/ipr/page22e_000518.html">Speeches</a></li>
+                        <li><a href="/announce/cai/index.html">Contributions &amp; Interviews</a></li>
+                        <li><a href="/announce/info/index.html">Other Information</a></li>
+                    </ul>
+                </dd>
+            </dl>
+            <dl>
+                <dt><a href="/policy/index.html">Foreign Policy</a></dt>
+                <dd>
+                    <ul>
+                        <li><a href="/policy/other/bluebook/index.html">Diplomatic Bluebook</a></li>
+                        <li><a href="/policy/political_and_security.html">Japan's Security / Peace &amp; Stability of the International Community</a></li>
+                        <li><a href="/policy/global_and_oda.html">Global Issues &amp; ODA</a></li>
+                        <li><a href="/policy/economy/index.html">Economic Diplomacy</a></li>
+                        <li><a href="/policy/culture/public_diplomacy.html">Public Diplomacy</a></li>
+                        <li><a href="/p_pd/ipr/page7e_900124.html">Others</a></li>
+                    </ul>
+                </dd>
+            </dl>
+            <dl>
+                <dt><a href="/region/index.html">Countries &amp; Regions</a></dt>
+                <dd>
+                    <ul>
+                        <li><a href="/region/asia-paci/index.html">Asia</a></li>
+                        <li><a href="/region/asia-paci/index2.html">Oceania</a></li>
+                        <li><a href="/region/n-america/index.html">North America</a></li>
+                        <li><a href="/region/latin/index.html">Latin America and the Caribbean</a></li>
+                        <li><a href="/region/europe/index.html">Europe</a></li>
+                        <li><a href="/region/middle_e/index.html">Middle East</a></li>
+                        <li><a href="/region/africa/index.html">Africa</a></li>
+                    </ul>
+                </dd>
+            </dl>
+            <dl>
+                <dt><a href="/p_pd/ipr/page7e_900126.html">Consular Services</a></dt>
+                <dd>
+                    <ul>
+                        <li><a href="/j_info/visit/visa/index.html">Visa</a></li>
+                        <li><a href="/ca/fna/page3e_001006.html">Residing in Japan</a></li>
+                        <li><a href="/ca/cs/page22e_000416.html">Certification</a></li>
+                        <li><a href="/j_info/japan/general/index.html">Information about Japan (Links)</a></li>
+                        <li><a href="/fp/hr_ha/page22e_000249.html">The Hague Convention</a></li>
+                    </ul>
+                </dd>
+            </dl>
+            <!-- /.wrapper -->
+        </div>
+        <!-- /#footer-sitemaps -->
+    </div>
+    <div class="bg-navy">
+        <div class="wrapper">
+            <ul class="menu-sub">
+                <li><a href="/about/legalmatters.html">Legal Matters</a></li>
+                <li><a href="/about/accessibility.html">Accessibility</a></li>
+                <li><a href="/about/privacy.html">Privacy Policy</a></li>
+                <li><a href="/about/page22e_000497.html">About this Site</a></li>
+                <!-- /.menu-sub -->
+            </ul>
+            <p>Copyright &copy; Ministry of Foreign Affairs of Japan</p>
+            <!-- /.wrapper -->
+        </div>
+        <!-- /.bg-navy -->
+    </div>
+    <p class="address link-warrow">Ministry of Foreign Affairs of Japan 2-2-1 Kasumigaseki, Chiyoda-ku, Tokyo 100<span>-</span>8919, Japan <a href="/about/hq/map.html" class="link-map">MAP</a><span class="phoneNo">Phone: +81<span>-</span>(0)3<span>-</span>3580<span>-</span>3311&nbsp;&nbsp;</span><span class="houjinNo">Japan Corporate Number(JCN): 9000012040001</span></p>
+    <!-- /#footer -->
+</footer>
+    <!-- /#wrapper -->
+    </div>
+
+</body>
+
+</html>

--- a/sources/JP_DNV_MOFA_2026-06-08.html.meta.json
+++ b/sources/JP_DNV_MOFA_2026-06-08.html.meta.json
@@ -1,0 +1,7 @@
+{
+  "source_id": "JP_DNV_MOFA_2026",
+  "url": "https://www.mofa.go.jp/ca/fna/pagewe_000001_00046.html",
+  "retrieved_at": "2026-06-08T00:00:00Z",
+  "sha256": "4ef9d598abe8c7789dfffe8f2eeae83ab50d6056b404b1e9aa73a9363c0ccac5",
+  "local_path": "sources/JP_DNV_MOFA_2026-06-08.html"
+}

--- a/tools/build_content_hubs.py
+++ b/tools/build_content_hubs.py
@@ -139,6 +139,20 @@ VISA_FAQS = {
             "answer": "No. The consulate states that non-medical services such as trip cancellation, lost baggage, or repatriation of remains do not count toward the 30,000 euro medical-expenses requirement.",
         },
     ],
+    "JP_DNV_MOFA_2026": [
+        {
+            "question": "How much insurance coverage does the Japan Digital Nomad Visa require?",
+            "answer": "The Ministry of Foreign Affairs requires insurance against death, injury or illness during the stay, with medical-treatment compensation of JPY 10 million or more.",
+        },
+        {
+            "question": "How does the checker compare a JPY threshold against a USD or EUR policy limit?",
+            "answer": "It converts both the threshold and the product limit to euro using fixed reference rates, so a large yen figure is compared like-for-like instead of as a raw number.",
+        },
+        {
+            "question": "Is national health insurance an option for this visa?",
+            "answer": "No. Digital Nomad visa holders are not enrolled in Japan's national health insurance, so private coverage meeting the JPY 10 million threshold is required.",
+        },
+    ],
 }
 
 RELATED_POSTS = {
@@ -180,6 +194,11 @@ RELATED_POSTS = {
         ("/posts/italy-selfemployment-insurance/", "Italy self-employment visa insurance requirements"),
         ("/guides/schengen-30000-insurance/", "Schengen 30,000 EUR insurance rule"),
         ("/posts/digital-nomad-insurance-europe/", "Digital nomad insurance in Europe"),
+    ],
+    "JP_DNV_MOFA_2026": [
+        ("/posts/japan-dnv-insurance/", "Japan Digital Nomad Visa insurance requirements"),
+        ("/posts/digital-nomad-insurance-asia/", "Digital nomad insurance in Asia"),
+        ("/guides/how-to-read-results/", "How to read compliance results"),
     ],
 }
 

--- a/tools/editorial_targets.json
+++ b/tools/editorial_targets.json
@@ -122,5 +122,13 @@
   "content/posts/italy-selfemployment-insurance.md": [
     900,
     1050
+  ],
+  "content/visas/japan/digital-nomad-visa/designated-activities-mofa/index.md": [
+    900,
+    1300
+  ],
+  "content/posts/japan-dnv-insurance.md": [
+    900,
+    1100
   ]
 }

--- a/tools/rules/coverage.py
+++ b/tools/rules/coverage.py
@@ -1,6 +1,16 @@
 """Coverage-related rules."""
 from tools.rules.base import Rule, RuleResult, get_req, product_spec
 
+# Fixed conversion rates to EUR, pinned for snapshot reproducibility
+# (mid-2026 reference values; intentionally static, never fetched live, so a
+# given snapshot always evaluates a min_coverage threshold the same way).
+FX_TO_EUR = {
+    "EUR": 1.0,
+    "USD": 0.92,
+    "GBP": 1.17,
+    "JPY": 0.0061,
+}
+
 
 class ComprehensiveCoverageRule(Rule):
     """Check if comprehensive coverage is required and provided."""
@@ -105,11 +115,26 @@ class MinimumCoverageRule(Rule):
                 status="UNKNOWN",
                 missing=["specs.overall_limit"]
             )
-        if limit < req["value"]:
+
+        # Compare like-for-like. When the requirement states a currency and the
+        # product limit has one too, convert both to EUR using fixed rates so a
+        # large threshold in one currency (e.g. JPY 10,000,000) is not falsely
+        # judged against a smaller raw number in another (e.g. USD 250,000).
+        # When no currency is given, fall back to the historical raw compare.
+        threshold = req["value"]
+        req_ccy = req.get("currency")
+        prod_ccy = product_spec(product, "currency")
+        limit_cmp, threshold_cmp = limit, threshold
+        if req_ccy in FX_TO_EUR and prod_ccy in FX_TO_EUR:
+            limit_cmp = limit * FX_TO_EUR[prod_ccy]
+            threshold_cmp = threshold * FX_TO_EUR[req_ccy]
+
+        if limit_cmp < threshold_cmp:
+            unit = f" {req_ccy}" if req_ccy else ""
             return RuleResult(
                 status="RED",
                 reasons=[{
-                    "text": f"Minimum coverage {req['value']} required, product has {limit}",
+                    "text": f"Minimum coverage {threshold}{unit} required, product has {limit} {prod_ccy or ''}".strip(),
                     "evidence": req["evidence"]
                 }]
             )


### PR DESCRIPTION
## Summary

Adds the **Japan Digital Nomad Visa** route — route 3 of the remaining four (Spain ✅ → Italy ✅ → **Japan** → Colombia).

Evidence is the **Ministry of Foreign Affairs of Japan** Designated Activities visa page (the primary authority, dated March 31 2024). The MOFA host WAF-blocks automated fetch, so the page was retrieved via a real browser and stored byte-exact (sha256-validated).

**Requirement (necessary documents, item 6):** private insurance against death, injury or illness during the stay, with **medical-treatment compensation of JPY 10 million or more.**

## Engine change: currency-aware `min_coverage`

The old rule compared raw numbers, so a JPY 10,000,000 threshold would have falsely marked every product RED (e.g. SafetyWing's USD 250,000 ≈ ¥37M really *exceeds* it, but `250000 < 10000000`). The rule is now **currency-aware**:

- A `min_coverage` requirement may carry a `currency`. When it and the product limit both have a known currency, both are converted to EUR with **fixed, reproducibility-pinned rates** before comparing.
- With no currency, it falls back to the historical raw compare — so **existing routes (incl. Italy) are unchanged** (verified: no existing mapping changed).

## Compliance results

| Product | Status | Why |
|---|---|---|
| Genki / SafetyWing / World Nomads | **GREEN** | limits clear JPY 10M once converted to EUR |
| ASISA / DKV / Sanitas / GenericInsurer | UNKNOWN | no documented overall limit |

Genki (GREEN) is surfaced via a paid affiliate link — after results, no influence.

## Gates (all green locally)
validate · content lint · editorial targets · internal links · SEO audit · Hugo build · ui-compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)