### PR TITLE
feat(route): add Czech long-term business visa route (evidence-based)

### DIFF
--- a/content/posts/czech-business-visa-insurance.md
+++ b/content/posts/czech-business-visa-insurance.md
@@ -1,0 +1,110 @@
+---
+title: "Czech long-term business visa insurance requirements (evidence-based)"
+date: 2026-06-10
+description: "Evidence-based summary of the medical insurance requirement for the Czech long-term visa for the purpose of doing business, based on the Official Information Portal for Foreigners."
+tags: ["czech-republic", "business-visa", "freelance", "insurance", "compliance"]
+faq:
+  - question: "How much insurance coverage does the Czech long-term business visa require?"
+    answer: "The Official Information Portal for Foreigners states the coverage amount must be at least EUR 400,000 per insured event, with no cost sharing by the insured person."
+  - question: "Why do SafetyWing, World Nomads and Genki Traveler show RED?"
+    answer: "Their documented limits convert to below EUR 400,000, and a deductible (cost sharing) conflicts with the no-cost-sharing rule, so the engine marks them RED."
+  - question: "Why are the Spanish health policies UNKNOWN rather than GREEN?"
+    answer: "Their documents do not state an overall coverage limit to compare against the EUR 400,000 threshold, so the engine records UNKNOWN instead of assuming they clear it."
+---
+
+## Short answer
+
+The Czech long-term visa for the purpose of doing business requires comprehensive medical insurance whose coverage amount (the agreed limit per insured event) is at least EUR 400,000, with no cost sharing by the insured person. Since 20 September 2023 the policy can be arranged with any insurer authorised to provide it in the Czech Republic (Source: `CZ_IPC_INSURANCE_2026`, Medical Insurance; verified 2026-06-10).
+
+## Key findings at a glance
+
+| Item | Value |
+|---|---|
+| Route | Czech long-term business visa (doing business) |
+| Authority | Ministry of the Interior of the Czech Republic (IPC) |
+| Evidence verified | 2026-06-10 |
+| Snapshot | 2026-06-10 |
+| Modeled rules | Insurance mandatory; coverage at least EUR 400,000; no cost sharing (no deductible) |
+
+## What the authority requires
+
+- Medical insurance is mandatory for the visa. (Source: `CZ_IPC_INSURANCE_2026`, Medical Insurance; verified 2026-06-10)
+- The coverage amount must be at least EUR 400,000 per insured event. (Source: `CZ_IPC_INSURANCE_2026`, Medical Insurance; verified 2026-06-10)
+- There must be no cost sharing by the insured person (no deductible). (Source: `CZ_IPC_INSURANCE_2026`, Medical Insurance; verified 2026-06-10)
+
+Normalized requirements table:
+
+| Requirement | Source URL | Locator | Verified date |
+|---|---|---|---|
+| Insurance is mandatory | https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/ | Medical Insurance | 2026-06-10 |
+| Coverage at least EUR 400,000 | https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/ | Medical Insurance | 2026-06-10 |
+| No cost sharing (no deductible) | https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/ | Medical Insurance | 2026-06-10 |
+
+## Verified requirements (PASS/FAIL/UNKNOWN)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Insurance is mandatory | PASS | IPC Medical Insurance page |
+| Coverage at least EUR 400,000 | RED below the threshold; UNKNOWN where no limit is documented | IPC: at least EUR 400,000 |
+| No cost sharing (no deductible) | RED where a deductible is documented | IPC: no cost sharing by the insured person |
+
+## How we evaluate
+
+The checker compares each modeled requirement against product evidence. The EUR 400,000 threshold is high, so a product is GREEN only when its documented overall limit clears EUR 400,000 (after currency conversion) and it documents no deductible. A documented limit below the threshold, or any deductible, produces RED; a missing limit produces UNKNOWN rather than a guess. See /methodology/ for the full logic and the UNKNOWN > Wrong principle.
+
+## Why the common nomad products do not pass
+
+This route is unusually strict, and the result is honest about it:
+
+- SafetyWing Nomad Insurance and World Nomads Explorer have documented limits that convert to roughly EUR 230,000 and EUR 138,000 — both below EUR 400,000 — so they are RED.
+- Genki Traveler clears the limit but documents a deductible, which conflicts with the no-cost-sharing rule, so it is RED.
+- The Spanish health policies (ASISA, DKV, Sanitas) are de-facto high-limit, but their documents do not state an overall figure to compare against EUR 400,000, so they are UNKNOWN rather than GREEN.
+
+## Proof package checklist
+
+- A certificate stating the coverage amount (agreed limit per insured event) is at least EUR 400,000.
+- Confirmation that the policy applies no cost sharing (no deductible, no co-payment) to the insured person.
+- An insurer authorised to provide the insurance in the Czech Republic.
+
+## FAQ
+
+**Q: How much coverage is required?**
+**A:** At least EUR 400,000 per insured event, with no cost sharing (Source: `CZ_IPC_INSURANCE_2026`; verified 2026-06-10).
+
+**Q: Why do the popular nomad products show RED?**
+**A:** Their limits convert to below EUR 400,000, or they carry a deductible, which the no-cost-sharing rule rejects.
+
+**Q: Why are the Spanish health policies UNKNOWN?**
+**A:** They do not document an overall limit to compare against the threshold, so the engine does not assume they clear it.
+
+## Check in the engine
+
+Use [the compliance checker](/ui/) with the current snapshot for this route:
+
+{{< checker_cta visa="CZ_LONGTERM_BUSINESS_IPC_2026" snapshot="2026-06-10" >}}
+
+## Related reading
+
+- [Czech long-term business visa requirements (route page)](/visas/czech-republic/long-term-business-visa/doing-business-ipc/)
+- [Schengen 30,000 EUR insurance rule](/guides/schengen-30000-insurance/)
+- [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
+
+## Where to find compliant insurance for the Czech business visa
+
+No product is singled out on this page yet. The EUR 400,000, no-cost-sharing requirement is strict, and none of the products currently in the checker documents both a limit at or above EUR 400,000 and no deductible, so each one shows RED or UNKNOWN rather than GREEN. A product will be listed here once its evidence clears both conditions and it shows GREEN for this route.
+
+> Use the compliance checker to see the current status of each product for this route.
+
+*No affiliate links on this page at this time. We only link to products once their GREEN status rests on documented evidence for this route. See [affiliate disclosure](/affiliate-disclosure/).*
+
+## Disclaimer + Affiliate disclosure
+
+Not legal advice. Compliance results are evidence-based snapshots.
+
+If an affiliate link is present, it appears only after results and does not change the compliance outcome.
+
+Last updated: 2026-06-10
+
+## Evidence log
+
+- Source: CZ_IPC_INSURANCE_2026

--- a/content/visas/czech-republic/long-term-business-visa/_index.md
+++ b/content/visas/czech-republic/long-term-business-visa/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Czech Republic Long-term Business Visa"
+visa_group: "czech-republic-long-term-business-visa"
+description: "Insurance requirements for Czech Republic Long-term Business Visa - evidence-based compliance checker"
+---
+
+## Czech Republic Long-term Business Visa Requirements
+
+All requirements below are derived from official sources. Missing evidence means UNKNOWN.
+
+## Routes
+
+| Authority | Route | Last Verified | Details |
+| --- | --- | --- | --- |
+| Ministry of the Interior of the Czech Republic (IPC) | Doing Business (IPC) | 2026-06-10 | [View requirements](/visas/czech-republic/long-term-business-visa/doing-business-ipc/) |
+
+## What the authority requires
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+## How we evaluate
+
+We compare these official requirements against insurance product specifications using our automated rule engine. Each requirement is matched to a product fact with evidence.
+
+## Check in the engine
+
+Try the compliance checker: [Open Checker](/ui/?visa=CZ_LONGTERM_BUSINESS_IPC_2026&snapshot=2026-06-10)
+
+## Disclaimer
+
+This is not legal advice. VisaFact provides evidence-based compliance checking only. Final visa decisions are made by government authorities. A GREEN result does not ensure visa approval.
+
+## Affiliate disclosure
+
+If affiliate links appear, they are shown only after compliance results and do not influence the compliance evaluation in any way.
+
+## Evidence log
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+
+{{< checker_cta visa="CZ_LONGTERM_BUSINESS_IPC_2026" snapshot="2026-06-10" >}}

--- a/content/visas/czech-republic/long-term-business-visa/doing-business-ipc/index.md
+++ b/content/visas/czech-republic/long-term-business-visa/doing-business-ipc/index.md
@@ -1,0 +1,105 @@
+---
+title: "Czech Republic Long-term Business Visa - Doing Business (IPC)"
+visa_id: "CZ_LONGTERM_BUSINESS_IPC_2026"
+last_verified: "2026-06-10"
+source_ids: ["CZ_IPC_INSURANCE_2026"]
+description: "Official insurance requirements for Czech Republic Long-term Business Visa via Doing Business (IPC)"
+faq:
+  - question: "How much insurance coverage does the Czech long-term business visa require?"
+    answer: "The Official Information Portal for Foreigners states the coverage amount must be at least EUR 400,000 per insured event, with no cost sharing by the insured person."
+  - question: "Why do SafetyWing, World Nomads and Genki Traveler show RED?"
+    answer: "Their documented limits convert to below EUR 400,000, and a deductible (cost sharing) conflicts with the no-cost-sharing rule, so the engine marks them RED rather than accepting them."
+  - question: "Why are the Spanish health policies UNKNOWN rather than GREEN?"
+    answer: "Their policy documents do not state an overall coverage limit to compare against the EUR 400,000 threshold, so the engine records UNKNOWN instead of assuming they clear it."
+---
+
+## Czech Republic Long-term Business Visa
+
+**Route:** Doing Business (IPC)  
+**Authority:** Ministry of the Interior of the Czech Republic (IPC)  
+**Last Verified:** 2026-06-10
+
+## Requirements
+
+| Requirement | Operator | Value | Evidence |
+| --- | --- | --- | --- |
+| `insurance.mandatory` | `==` | Yes | *Medical Insurance (Official Information Portal for Foreigners, ipc.gov.cz)*: "The insurance coverage amount (the agreed limit per insured event) must be at le..." ([source](/sources/CZ_IPC_INSURANCE_2026-06-10.html)) |
+| `insurance.min_coverage` | `>=` | 400000 | *Medical Insurance, coverage amount*: "The insurance coverage amount (the agreed limit per insured event) must be at le..." ([source](/sources/CZ_IPC_INSURANCE_2026-06-10.html)) |
+| `insurance.no_deductible` | `==` | Yes | *Medical Insurance, coverage amount*: "must be at least EUR 400,000, with no cost sharing by the insured person..." ([source](/sources/CZ_IPC_INSURANCE_2026-06-10.html)) |
+
+## Source Documents
+
+- **CZ_IPC_INSURANCE_2026**: [Local copy](/sources/CZ_IPC_INSURANCE_2026-06-10.html) | [Original](https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/) | Retrieved: 2026-06-10
+
+## Related reading
+
+- [Czech long-term business visa insurance requirements](/posts/czech-business-visa-insurance/)
+- [Schengen 30,000 EUR insurance rule](/guides/schengen-30000-insurance/)
+- [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
+
+## What the authority requires
+
+The points below are taken directly from the official source for the Czech Republic Long-term Business Visa (Doing Business (IPC)) route. Each one is recorded with a source identifier and a locator so it can be traced back to the original document. Where the source is silent on a point, the engine records UNKNOWN instead of inferring an answer.
+
+- The authority requires that insurance is mandatory.
+- The authority requires that the medical coverage meets the stated minimum of at least 400000.
+- The authority requires that the policy carries no deductible.
+
+## How we evaluate
+
+Every requirement is compared against the documented specification of each insurance product using an automated rule engine. A product is marked GREEN for a requirement only when product evidence explicitly satisfies it; a conflict produces RED; and absent evidence produces UNKNOWN rather than a guess. The route status is the combination of its per-requirement outcomes.
+
+- Rule `insurance.mandatory == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+- Rule `insurance.min_coverage >= 400000` GREEN at or above the threshold, RED below it, UNKNOWN if unstated.
+- Rule `insurance.no_deductible == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+
+## How each compliance status is decided for this route
+
+GREEN means every recorded requirement is satisfied by product evidence. RED means at least one requirement is contradicted by the product evidence. YELLOW means the evidence is partial: some requirements are met while others lack full proof. UNKNOWN means a requirement exists but the product evidence does not address it, so no claim is made. NOT_REQUIRED means the authority does not impose an insurance requirement for the route, which is itself an evidence-based finding drawn from the official document. A GREEN result reflects the evidence on the snapshot date and is not an assurance of a visa outcome, which always rests with the issuing authority.
+
+## Reading the evidence and snapshots
+
+Each requirement above links to a primary source through a source identifier and a locator (for example a page number, article, or section). The underlying documents are listed under Source Documents and are stored alongside this dataset so the wording can be checked directly. Results are tied to a dated snapshot (`2026-06-10`): a deep link to a past snapshot returns the same verdict even if the authority later changes its rules, which keeps every decision reproducible and auditable.
+
+## Proof package checklist
+
+Before applying for this route, prepare the following so the policy can be checked against each requirement:
+
+- A policy certificate that states the coverage limits, any deductible or co-payment, and the covered period.
+- Written confirmation of the insurer's status where the route requires authorization in a specific country.
+- Documentation that the coverage spans the full authorized stay rather than a partial term.
+- The official source wording for the route, so each clause can be matched to the requirements above.
+
+## Common questions
+
+**How much insurance coverage does the Czech long-term business visa require?**  
+The Official Information Portal for Foreigners states the coverage amount must be at least EUR 400,000 per insured event, with no cost sharing by the insured person.
+
+**Why do SafetyWing, World Nomads and Genki Traveler show RED?**  
+Their documented limits convert to below EUR 400,000, and a deductible (cost sharing) conflicts with the no-cost-sharing rule, so the engine marks them RED rather than accepting them.
+
+**Why are the Spanish health policies UNKNOWN rather than GREEN?**  
+Their policy documents do not state an overall coverage limit to compare against the EUR 400,000 threshold, so the engine records UNKNOWN instead of assuming they clear it.
+
+## Check in the engine
+
+Run a specific product against this route in the compliance checker: [Open Checker](/ui/?visa=CZ_LONGTERM_BUSINESS_IPC_2026&snapshot=2026-06-10). The checker shows the per-requirement outcome and the evidence behind each one.
+
+## Disclaimer
+
+This page is not legal advice. VisaFact provides evidence-based compliance checking only, and final visa decisions are made by government authorities. A GREEN result reflects documented evidence on the snapshot date; it does not ensure that a visa application will succeed. Always confirm the current requirements with the issuing authority before submitting an application.
+
+## Affiliate disclosure
+
+If affiliate links appear on related pages, they are shown only after the compliance result and never change the evaluation, which is generated independently from the official evidence.
+
+## Evidence log
+
+Each entry pairs a requirement with the source identifier and locator it was drawn from:
+
+- `insurance.mandatory` <- CZ_IPC_INSURANCE_2026 (Medical Insurance (Official Information Portal for Foreigners, ipc.gov.cz)): "The insurance coverage amount (the agreed limit per insured event) must be at least EUR 400,000, wit"
+- `insurance.min_coverage` <- CZ_IPC_INSURANCE_2026 (Medical Insurance, coverage amount): "The insurance coverage amount (the agreed limit per insured event) must be at least EUR 400,000"
+- `insurance.no_deductible` <- CZ_IPC_INSURANCE_2026 (Medical Insurance, coverage amount): "must be at least EUR 400,000, with no cost sharing by the insured person"
+
+
+{{< checker_cta visa="CZ_LONGTERM_BUSINESS_IPC_2026" snapshot="2026-06-10" >}}

--- a/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__ASISA_HEALTH_RESIDENTS_2026.json
+++ b/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__ASISA_HEALTH_RESIDENTS_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+  "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__DKV_VISADO_2026.json
+++ b/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__DKV_VISADO_2026.json
@@ -1,0 +1,10 @@
+{
+  "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+  "product_id": "DKV_VISADO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.deductible.amount",
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__GENERIC_EXPAT_COMPLETE_2026.json
+++ b/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__GENERIC_EXPAT_COMPLETE_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+  "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__GENKI_NATIVE_2026.json
+++ b/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__GENKI_NATIVE_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+  "product_id": "GENKI_NATIVE_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.deductible.amount"
+  ]
+}

--- a/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__GENKI_TRAVELER_2026.json
+++ b/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__GENKI_TRAVELER_2026.json
@@ -1,0 +1,18 @@
+{
+  "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+  "product_id": "GENKI_TRAVELER_2026",
+  "status": "RED",
+  "reasons": [
+    {
+      "text": "Visa requires zero deductible but product has 50",
+      "evidence": [
+        {
+          "source_id": "CZ_IPC_INSURANCE_2026",
+          "locator": "Medical Insurance, coverage amount",
+          "excerpt": "must be at least EUR 400,000, with no cost sharing by the insured person"
+        }
+      ]
+    }
+  ],
+  "missing": []
+}

--- a/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__SAFETYWING_NOMAD_2026.json
+++ b/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__SAFETYWING_NOMAD_2026.json
@@ -1,0 +1,28 @@
+{
+  "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+  "product_id": "SAFETYWING_NOMAD_2026",
+  "status": "RED",
+  "reasons": [
+    {
+      "text": "Visa requires zero deductible but product has 250",
+      "evidence": [
+        {
+          "source_id": "CZ_IPC_INSURANCE_2026",
+          "locator": "Medical Insurance, coverage amount",
+          "excerpt": "must be at least EUR 400,000, with no cost sharing by the insured person"
+        }
+      ]
+    },
+    {
+      "text": "Minimum coverage 400000 EUR required, product has 250000 USD",
+      "evidence": [
+        {
+          "source_id": "CZ_IPC_INSURANCE_2026",
+          "locator": "Medical Insurance, coverage amount",
+          "excerpt": "The insurance coverage amount (the agreed limit per insured event) must be at least EUR 400,000"
+        }
+      ]
+    }
+  ],
+  "missing": []
+}

--- a/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
+++ b/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
@@ -1,0 +1,10 @@
+{
+  "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+  "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.deductible.amount",
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__WORLDNOMADS_EXPLORER_2026.json
+++ b/data/mappings/CZ_LONGTERM_BUSINESS_IPC_2026__WORLDNOMADS_EXPLORER_2026.json
@@ -1,0 +1,20 @@
+{
+  "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+  "product_id": "WORLDNOMADS_EXPLORER_2026",
+  "status": "RED",
+  "reasons": [
+    {
+      "text": "Minimum coverage 400000 EUR required, product has 150000 USD",
+      "evidence": [
+        {
+          "source_id": "CZ_IPC_INSURANCE_2026",
+          "locator": "Medical Insurance, coverage amount",
+          "excerpt": "The insurance coverage amount (the agreed limit per insured event) must be at least EUR 400,000"
+        }
+      ]
+    }
+  ],
+  "missing": [
+    "specs.deductible.amount"
+  ]
+}

--- a/data/ui_index.json
+++ b/data/ui_index.json
@@ -1,6 +1,6 @@
 {
-  "built_at": "2026-06-08T23:47:06.448335+00:00",
-  "snapshot_id": "2026-06-08",
+  "built_at": "2026-06-09T23:07:13.507202+00:00",
+  "snapshot_id": "2026-06-09",
   "visas": [
     {
       "id": "CO_DNV_CANCILLERIA_2026",
@@ -107,6 +107,62 @@
               "source_id": "CR_DECREE_43619_2026",
               "locator": "Article 9 - Minimum Coverage Amount",
               "excerpt": "gastos m\u00e9dicos en casos de enfermedades en Costa Rica por al menos US $50 000,00 - at least US$50,000 for medical expenses related to illness in Costa Rica"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+      "country": "Czech Republic",
+      "visa_name": "Long-term Business Visa",
+      "route": "Doing Business (IPC)",
+      "authority": "Ministry of the Interior of the Czech Republic (IPC)",
+      "last_verified": "2026-06-10",
+      "sources": [
+        {
+          "source_id": "CZ_IPC_INSURANCE_2026",
+          "url": "https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/",
+          "retrieved_at": "2026-06-10T00:00:00Z",
+          "sha256": "9ddbe03ceba165c54745267b9c3ca926e6f24a89d4af205ba79df6e6b08e7592",
+          "local_path": "sources/CZ_IPC_INSURANCE_2026-06-10.html"
+        }
+      ],
+      "requirements": [
+        {
+          "key": "insurance.mandatory",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "CZ_IPC_INSURANCE_2026",
+              "locator": "Medical Insurance (Official Information Portal for Foreigners, ipc.gov.cz)",
+              "excerpt": "The insurance coverage amount (the agreed limit per insured event) must be at least EUR 400,000, with no cost sharing by the insured person."
+            }
+          ]
+        },
+        {
+          "key": "insurance.min_coverage",
+          "op": ">=",
+          "value": 400000,
+          "currency": "EUR",
+          "evidence": [
+            {
+              "source_id": "CZ_IPC_INSURANCE_2026",
+              "locator": "Medical Insurance, coverage amount",
+              "excerpt": "The insurance coverage amount (the agreed limit per insured event) must be at least EUR 400,000"
+            }
+          ]
+        },
+        {
+          "key": "insurance.no_deductible",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "CZ_IPC_INSURANCE_2026",
+              "locator": "Medical Insurance, coverage amount",
+              "excerpt": "must be at least EUR 400,000, with no cost sharing by the insured person"
             }
           ]
         }
@@ -1170,6 +1226,127 @@
       "last_verified": "2026-01-15"
     },
     {
+      "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+      "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+      "product_id": "DKV_VISADO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.deductible.amount",
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+      "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+      "product_id": "GENKI_NATIVE_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.deductible.amount"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+      "product_id": "GENKI_TRAVELER_2026",
+      "status": "RED",
+      "reasons": [
+        {
+          "text": "Visa requires zero deductible but product has 50",
+          "evidence": [
+            {
+              "source_id": "CZ_IPC_INSURANCE_2026",
+              "locator": "Medical Insurance, coverage amount",
+              "excerpt": "must be at least EUR 400,000, with no cost sharing by the insured person"
+            }
+          ]
+        }
+      ],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+      "product_id": "SAFETYWING_NOMAD_2026",
+      "status": "RED",
+      "reasons": [
+        {
+          "text": "Visa requires zero deductible but product has 250",
+          "evidence": [
+            {
+              "source_id": "CZ_IPC_INSURANCE_2026",
+              "locator": "Medical Insurance, coverage amount",
+              "excerpt": "must be at least EUR 400,000, with no cost sharing by the insured person"
+            }
+          ]
+        },
+        {
+          "text": "Minimum coverage 400000 EUR required, product has 250000 USD",
+          "evidence": [
+            {
+              "source_id": "CZ_IPC_INSURANCE_2026",
+              "locator": "Medical Insurance, coverage amount",
+              "excerpt": "The insurance coverage amount (the agreed limit per insured event) must be at least EUR 400,000"
+            }
+          ]
+        }
+      ],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+      "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.deductible.amount",
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+      "product_id": "WORLDNOMADS_EXPLORER_2026",
+      "status": "RED",
+      "reasons": [
+        {
+          "text": "Minimum coverage 400000 EUR required, product has 150000 USD",
+          "evidence": [
+            {
+              "source_id": "CZ_IPC_INSURANCE_2026",
+              "locator": "Medical Insurance, coverage amount",
+              "excerpt": "The insurance coverage amount (the agreed limit per insured event) must be at least EUR 400,000"
+            }
+          ]
+        }
+      ],
+      "missing": [
+        "specs.deductible.amount"
+      ],
+      "last_verified": ""
+    },
+    {
       "visa_id": "DE_FREELANCE_EMBASSY_LONDON_2026",
       "product_id": "ASISA_HEALTH_RESIDENTS_2026",
       "status": "GREEN",
@@ -1727,7 +1904,7 @@
         }
       ],
       "missing": [],
-      "last_verified": "2026-06-08"
+      "last_verified": "2026-06-09"
     },
     {
       "visa_id": "GR_DNV_MFA_2026",
@@ -2308,6 +2485,13 @@
       "sha256": "cdd9951eab3b18839fde2282203098c611f59671533d24ec90e298850f0917b0",
       "local_path": "sources/CR_Decreto_43619_2026-01-12.md",
       "note": "Executive Decree No. 43619-H-MGP-TUR - Article 9 establishes insurance must cover ENTIRE authorized stay period"
+    },
+    "CZ_IPC_INSURANCE_2026": {
+      "source_id": "CZ_IPC_INSURANCE_2026",
+      "url": "https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/",
+      "retrieved_at": "2026-06-10T00:00:00Z",
+      "sha256": "9ddbe03ceba165c54745267b9c3ca926e6f24a89d4af205ba79df6e6b08e7592",
+      "local_path": "sources/CZ_IPC_INSURANCE_2026-06-10.html"
     },
     "DE_D_VISA_HEALTH_INSURANCE_2026": {
       "source_id": "DE_D_VISA_HEALTH_INSURANCE_2026",

--- a/data/visas/CZ/BUSINESS/ipc/2026-06-10/visa_facts.json
+++ b/data/visas/CZ/BUSINESS/ipc/2026-06-10/visa_facts.json
@@ -1,0 +1,56 @@
+{
+  "id": "CZ_LONGTERM_BUSINESS_IPC_2026",
+  "country": "Czech Republic",
+  "visa_name": "Long-term Business Visa",
+  "route": "Doing Business (IPC)",
+  "authority": "Ministry of the Interior of the Czech Republic (IPC)",
+  "last_verified": "2026-06-10",
+  "sources": [
+    {
+      "source_id": "CZ_IPC_INSURANCE_2026",
+      "url": "https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/",
+      "retrieved_at": "2026-06-10T00:00:00Z",
+      "sha256": "9ddbe03ceba165c54745267b9c3ca926e6f24a89d4af205ba79df6e6b08e7592",
+      "local_path": "sources/CZ_IPC_INSURANCE_2026-06-10.html"
+    }
+  ],
+  "requirements": [
+    {
+      "key": "insurance.mandatory",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "CZ_IPC_INSURANCE_2026",
+          "locator": "Medical Insurance (Official Information Portal for Foreigners, ipc.gov.cz)",
+          "excerpt": "The insurance coverage amount (the agreed limit per insured event) must be at least EUR 400,000, with no cost sharing by the insured person."
+        }
+      ]
+    },
+    {
+      "key": "insurance.min_coverage",
+      "op": ">=",
+      "value": 400000,
+      "currency": "EUR",
+      "evidence": [
+        {
+          "source_id": "CZ_IPC_INSURANCE_2026",
+          "locator": "Medical Insurance, coverage amount",
+          "excerpt": "The insurance coverage amount (the agreed limit per insured event) must be at least EUR 400,000"
+        }
+      ]
+    },
+    {
+      "key": "insurance.no_deductible",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "CZ_IPC_INSURANCE_2026",
+          "locator": "Medical Insurance, coverage amount",
+          "excerpt": "must be at least EUR 400,000, with no cost sharing by the insured person"
+        }
+      ]
+    }
+  ]
+}

--- a/sources/CZ_IPC_INSURANCE_2026-06-10.html
+++ b/sources/CZ_IPC_INSURANCE_2026-06-10.html
@@ -1,0 +1,1014 @@
+
+
+<!doctype html>
+<html id="client-html" lang="en-GB">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="description" content="Informační portál pro cizince">
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+<link rel="apple-touch-icon" sizes="180x180" href="https://ipc.gov.cz/wp-content/themes/iq-theme/dist/img/apple-touch-icon.png?v=2">
+<link rel="icon" type="image/png" sizes="32x32" href="https://ipc.gov.cz/wp-content/themes/iq-theme/dist/img/favicon-32x32.png?v=2">
+<link rel="icon" type="image/png" sizes="16x16" href="https://ipc.gov.cz/wp-content/themes/iq-theme/dist/img/favicon-16x16.png?v=2">
+<link rel="manifest" href="https://ipc.gov.cz/wp-content/themes/iq-theme/dist/img/site.webmanifest?v=2">
+<link rel="mask-icon" href="https://ipc.gov.cz/wp-content/themes/iq-theme/dist/img/safari-pinned-tab.svg?v=2" color="#2364a5">
+<link rel="shortcut icon" href="https://ipc.gov.cz/wp-content/themes/iq-theme/dist/img/favicon.ico?v=2">
+<meta name="msapplication-TileColor" content="#2364a5">
+<meta name="msapplication-config" content="https://ipc.gov.cz/wp-content/themes/iq-theme/dist/img/browserconfig.xml?v=2">
+<meta name="theme-color" content="#ffffff">
+
+
+<meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+<link rel="alternate" href="https://ipc.gov.cz/formulare-a-dokumenty/nalezitosti-dokumenty/doklad-o-zdravotnim-pojisteni/" hreflang="cs" />
+<link rel="alternate" href="https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/" hreflang="en" />
+
+	<!-- This site is optimized with the Yoast SEO plugin v20.9 - https://yoast.com/wordpress/plugins/seo/ -->
+	<title>Medical Insurance - ipc.gov.cz</title>
+	<link rel="canonical" href="https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/" />
+	<meta property="og:locale" content="en_GB" />
+	<meta property="og:locale:alternate" content="cs_CZ" />
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content="Medical Insurance - ipc.gov.cz" />
+	<meta property="og:url" content="https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/" />
+	<meta property="og:site_name" content="ipc.gov.cz" />
+	<meta property="article:modified_time" content="2025-10-15T13:56:06+00:00" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:label1" content="Est. reading time" />
+	<meta name="twitter:data1" content="8 minutes" />
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebPage","@id":"https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/","url":"https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/","name":"Medical Insurance - ipc.gov.cz","isPartOf":{"@id":"https://ipc.gov.cz/en/#website"},"datePublished":"2022-12-21T15:58:23+00:00","dateModified":"2025-10-15T13:56:06+00:00","breadcrumb":{"@id":"https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/#breadcrumb"},"inLanguage":"en-GB","potentialAction":[{"@type":"ReadAction","target":["https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/"]}]},{"@type":"BreadcrumbList","@id":"https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"name":"Forms and Documents","item":"https://ipc.gov.cz/en/forms-and-documents/"},{"@type":"ListItem","position":2,"name":"Documents","item":"https://ipc.gov.cz/en/forms-and-documents/documents/"},{"@type":"ListItem","position":3,"name":"Medical Insurance"}]},{"@type":"WebSite","@id":"https://ipc.gov.cz/en/#website","url":"https://ipc.gov.cz/en/","name":"ipc.gov.cz","description":"Informační portál pro cizince","potentialAction":[{"@type":"SearchAction","target":{"@type":"EntryPoint","urlTemplate":"https://ipc.gov.cz/en/?s={search_term_string}"},"query-input":"required name=search_term_string"}],"inLanguage":"en-GB"}]}</script>
+	<!-- / Yoast SEO plugin. -->
+
+
+<link rel='stylesheet' id='wp-block-library-css' href='https://ipc.gov.cz/wp-includes/css/dist/block-library/style.min.css?ver=6.1.10' type='text/css' media='all' />
+<link rel='stylesheet' id='classic-theme-styles-css' href='https://ipc.gov.cz/wp-includes/css/classic-themes.min.css?ver=1' type='text/css' media='all' />
+<style id='global-styles-inline-css' type='text/css'>
+body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: #abb8c3;--wp--preset--color--white: #ffffff;--wp--preset--color--pale-pink: #f78da7;--wp--preset--color--vivid-red: #cf2e2e;--wp--preset--color--luminous-vivid-orange: #ff6900;--wp--preset--color--luminous-vivid-amber: #fcb900;--wp--preset--color--light-green-cyan: #7bdcb5;--wp--preset--color--vivid-green-cyan: #00d084;--wp--preset--color--pale-cyan-blue: #8ed1fc;--wp--preset--color--vivid-cyan-blue: #0693e3;--wp--preset--color--vivid-purple: #9b51e0;--wp--preset--color--white-base: #ffffff;--wp--preset--color--gray-background: #f5f5f5;--wp--preset--color--gray-inactive: #dddddd;--wp--preset--color--gray-light: #a8a8a8;--wp--preset--color--gray-mid: #686868;--wp--preset--color--gray-base: #3b3b3b;--wp--preset--color--blue-hover: #e5ebf0;--wp--preset--color--blue-inactive-3: #edf0f2;--wp--preset--color--blue-inactive-2: #d3dfec;--wp--preset--color--blue-inactive-1: #91b0d0;--wp--preset--color--blue-focus: #007bff;--wp--preset--color--blue-light: #3077b7;--wp--preset--color--blue-base: #2362a2;--wp--preset--color--blue-dark: #254e80;--wp--preset--color--yellow-base: #ecae1a;--wp--preset--color--yellow-dark: #dd9f0c;--wp--preset--color--success-base: #6fbd2c;--wp--preset--color--error-base: #c52a3a;--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%);--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%);--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange: linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%);--wp--preset--gradient--luminous-vivid-orange-to-vivid-red: linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%);--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray: linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%);--wp--preset--gradient--cool-to-warm-spectrum: linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%);--wp--preset--gradient--blush-light-purple: linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%);--wp--preset--gradient--blush-bordeaux: linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%);--wp--preset--gradient--luminous-dusk: linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%);--wp--preset--gradient--pale-ocean: linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%);--wp--preset--gradient--electric-grass: linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%);--wp--preset--gradient--midnight: linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%);--wp--preset--duotone--dark-grayscale: url('#wp-duotone-dark-grayscale');--wp--preset--duotone--grayscale: url('#wp-duotone-grayscale');--wp--preset--duotone--purple-yellow: url('#wp-duotone-purple-yellow');--wp--preset--duotone--blue-red: url('#wp-duotone-blue-red');--wp--preset--duotone--midnight: url('#wp-duotone-midnight');--wp--preset--duotone--magenta-yellow: url('#wp-duotone-magenta-yellow');--wp--preset--duotone--purple-green: url('#wp-duotone-purple-green');--wp--preset--duotone--blue-orange: url('#wp-duotone-blue-orange');--wp--preset--font-size--small: 13px;--wp--preset--font-size--medium: 20px;--wp--preset--font-size--large: 36px;--wp--preset--font-size--x-large: 42px;--wp--preset--spacing--20: 0.44rem;--wp--preset--spacing--30: 0.67rem;--wp--preset--spacing--40: 1rem;--wp--preset--spacing--50: 1.5rem;--wp--preset--spacing--60: 2.25rem;--wp--preset--spacing--70: 3.38rem;--wp--preset--spacing--80: 5.06rem;}:where(.is-layout-flex){gap: 0.5em;}body .is-layout-flow > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-flow > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-flow > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignleft{float: left;margin-inline-start: 0;margin-inline-end: 2em;}body .is-layout-constrained > .alignright{float: right;margin-inline-start: 2em;margin-inline-end: 0;}body .is-layout-constrained > .aligncenter{margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > :where(:not(.alignleft):not(.alignright):not(.alignfull)){max-width: var(--wp--style--global--content-size);margin-left: auto !important;margin-right: auto !important;}body .is-layout-constrained > .alignwide{max-width: var(--wp--style--global--wide-size);}body .is-layout-flex{display: flex;}body .is-layout-flex{flex-wrap: wrap;align-items: center;}body .is-layout-flex > *{margin: 0;}:where(.wp-block-columns.is-layout-flex){gap: 2em;}.has-black-color{color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-color{color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-color{color: var(--wp--preset--color--white) !important;}.has-pale-pink-color{color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-color{color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-color{color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-color{color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-color{color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-color{color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-color{color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-color{color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-color{color: var(--wp--preset--color--vivid-purple) !important;}.has-black-background-color{background-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-background-color{background-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-background-color{background-color: var(--wp--preset--color--white) !important;}.has-pale-pink-background-color{background-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-background-color{background-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-background-color{background-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-background-color{background-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-background-color{background-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-background-color{background-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-background-color{background-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-background-color{background-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-background-color{background-color: var(--wp--preset--color--vivid-purple) !important;}.has-black-border-color{border-color: var(--wp--preset--color--black) !important;}.has-cyan-bluish-gray-border-color{border-color: var(--wp--preset--color--cyan-bluish-gray) !important;}.has-white-border-color{border-color: var(--wp--preset--color--white) !important;}.has-pale-pink-border-color{border-color: var(--wp--preset--color--pale-pink) !important;}.has-vivid-red-border-color{border-color: var(--wp--preset--color--vivid-red) !important;}.has-luminous-vivid-orange-border-color{border-color: var(--wp--preset--color--luminous-vivid-orange) !important;}.has-luminous-vivid-amber-border-color{border-color: var(--wp--preset--color--luminous-vivid-amber) !important;}.has-light-green-cyan-border-color{border-color: var(--wp--preset--color--light-green-cyan) !important;}.has-vivid-green-cyan-border-color{border-color: var(--wp--preset--color--vivid-green-cyan) !important;}.has-pale-cyan-blue-border-color{border-color: var(--wp--preset--color--pale-cyan-blue) !important;}.has-vivid-cyan-blue-border-color{border-color: var(--wp--preset--color--vivid-cyan-blue) !important;}.has-vivid-purple-border-color{border-color: var(--wp--preset--color--vivid-purple) !important;}.has-vivid-cyan-blue-to-vivid-purple-gradient-background{background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;}.has-light-green-cyan-to-vivid-green-cyan-gradient-background{background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;}.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;}.has-luminous-vivid-orange-to-vivid-red-gradient-background{background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;}.has-very-light-gray-to-cyan-bluish-gray-gradient-background{background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;}.has-cool-to-warm-spectrum-gradient-background{background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;}.has-blush-light-purple-gradient-background{background: var(--wp--preset--gradient--blush-light-purple) !important;}.has-blush-bordeaux-gradient-background{background: var(--wp--preset--gradient--blush-bordeaux) !important;}.has-luminous-dusk-gradient-background{background: var(--wp--preset--gradient--luminous-dusk) !important;}.has-pale-ocean-gradient-background{background: var(--wp--preset--gradient--pale-ocean) !important;}.has-electric-grass-gradient-background{background: var(--wp--preset--gradient--electric-grass) !important;}.has-midnight-gradient-background{background: var(--wp--preset--gradient--midnight) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-medium-font-size{font-size: var(--wp--preset--font-size--medium) !important;}.has-large-font-size{font-size: var(--wp--preset--font-size--large) !important;}.has-x-large-font-size{font-size: var(--wp--preset--font-size--x-large) !important;}
+.wp-block-navigation a:where(:not(.wp-element-button)){color: inherit;}
+:where(.wp-block-columns.is-layout-flex){gap: 2em;}
+.wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
+</style>
+<link rel='stylesheet' id='iq-vendors~client~40f653a3-css' href='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/css/vendors~client~40f653a3.css?ver=81beeff896c5ccb9c6e6d1649961c583' type='text/css' media='all' />
+<link rel='stylesheet' id='iq-client~e36e0bff-css' href='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/css/client~e36e0bff.css?ver=81beeff896c5ccb9c6e6d1649961c583' type='text/css' media='all' />
+<link rel="https://api.w.org/" href="https://ipc.gov.cz/wp-json/" /><link rel="alternate" type="application/json" href="https://ipc.gov.cz/wp-json/wp/v2/pages/2475" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://ipc.gov.cz/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://ipc.gov.cz/wp-includes/wlwmanifest.xml" />
+<meta name="generator" content="WordPress 6.1.10" />
+<link rel='shortlink' href='https://ipc.gov.cz/?p=2475' />
+<link rel="alternate" type="application/json+oembed" href="https://ipc.gov.cz/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fipc.gov.cz%2Fen%2Fforms-and-documents%2Fdocuments%2Fmedical-insurance%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://ipc.gov.cz/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fipc.gov.cz%2Fen%2Fforms-and-documents%2Fdocuments%2Fmedical-insurance%2F&#038;format=xml" />
+
+        <script>
+            window.pageDependencies = [];
+        </script>
+
+
+
+<script>
+    window.dataLayer = window.dataLayer || [];
+
+    function gtag() {
+        window.dataLayer.push(arguments);
+    };
+
+    gtag('consent', 'default', JSON.parse("{\"ad_storage\":\"denied\",\"analytics_storage\":\"denied\",\"functionality_storage\":\"denied\",\"personalization_storage\":\"denied\",\"security_storage\":\"denied\"}"));
+
+    function gtmUpdateConsent(options) {
+        gtag('consent', 'update', options);
+    }
+
+    function gtmRecord(...args) {
+        window.dataLayer.push(...args);
+    }
+</script>
+
+    <script>
+        (function (w, d, s, l, i) {
+            w[l] = w[l] || [];
+            w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' });
+            const f = d.getElementsByTagName(s)[0],
+                j = d.createElement(s),
+                dl = l != 'dataLayer' ? '&l=' + l : '';
+            j.async = true;
+            j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+            f.parentNode.insertBefore(j, f);
+        })(window, document, 'script', 'dataLayer', "GTM-5JVGQVH");
+    </script>
+    </head>
+    <body class="page">
+        <div id="client-app" data-props="&#123;&quot;appConfig&quot;:&#123;&quot;registrationSuccess&quot;:&#123;&quot;cs&quot;:&quot;https:\/\/ipc.gov.cz\/registrace-uspesna\/&quot;,&quot;en&quot;:&quot;https:\/\/ipc.gov.cz\/en\/registration-successful\/&quot;},&quot;registrationSuccessIgnorant&quot;:&#123;&quot;cs&quot;:&quot;https:\/\/ipc.gov.cz\/stranka\/&quot;,&quot;en&quot;:&quot;https:\/\/ipc.gov.cz\/en\/page\/&quot;},&quot;authenticationFailed&quot;:&#123;&quot;cs&quot;:&quot;https:\/\/ipc.gov.cz\/overeni-nebylo-uspesne\/&quot;,&quot;en&quot;:&quot;https:\/\/ipc.gov.cz\/en\/authentication-failed\/&quot;},&quot;euCitizenInfo&quot;:&#123;&quot;cs&quot;:&quot;https:\/\/ipc.gov.cz\/kdo-jsou-obcane-evropske-unie-a-jejich-rodinni-prislusnici\/&quot;,&quot;en&quot;:&quot;https:\/\/ipc.gov.cz\/en\/who-are-eu-citizens-and-their-family-members-2\/&quot;},&quot;subsidiary&quot;:&#123;&quot;cs&quot;:&quot;https:\/\/ipc.gov.cz\/pracoviste\/&quot;,&quot;en&quot;:&quot;https:\/\/ipc.gov.cz\/en\/subsidiaries\/&quot;},&quot;questionnaireThanks&quot;:&#123;&quot;cs&quot;:&quot;https:\/\/ipc.gov.cz\/dekujeme-za-vyplneni-dotazniku\/&quot;,&quot;en&quot;:&quot;https:\/\/ipc.gov.cz\/dekujeme-za-vyplneni-dotazniku\/&quot;},&quot;temporaryProtectionDisabled&quot;:true,&quot;temporaryProtectionCreateFormDisabled&quot;:true,&quot;temporaryProtectionFinishFormDisabled&quot;:true,&quot;temporaryProtectionCreateReservationDisabled&quot;:true,&quot;temporaryProtectionRegistrationDisabled&quot;:true,&quot;temporaryProtectionQuestionnaireDisabled&quot;:true,&quot;temporaryProtectionConfirmationDisabled&quot;:false,&quot;specialStayDisabled&quot;:false,&quot;specialStayUnavailableMessageOnly&quot;:false,&quot;specialStayConditionsAndRegistrationDisabled&quot;:true,&quot;maintenanceBackofficeEnabled&quot;:false,&quot;maintenanceBackofficeRegistrationEnabled&quot;:false,&quot;maintenanceBackofficeIgnoreForKey&quot;:&quot;cbff5f5b-d8c2-4f4e-b4bc-be1ee3247b96&quot;,&quot;maintenanceBackoffice&quot;:&#123;&quot;cs&quot;:&quot;https:\/\/ipc.gov.cz\/technicka-odstavka\/&quot;,&quot;en&quot;:&quot;https:\/\/ipc.gov.cz\/en\/technical-shutdown-is-in-progress\/&quot;,&quot;uk&quot;:&quot;https:\/\/ipc.gov.cz\/uk\/technicka-odstavka-ua\/&quot;}}}"></div>
+        <div class="page__body">
+<header class="header" role="banner">
+    <div class="header__wrapper">
+        <div class="header__portal container">
+            <div class="header__column">
+                <a href="https://ipc.gov.cz/en/" class="header__logo" aria-label="Go to the homepage">
+                    <svg xmlns="http://www.w3.org/2000/svg" id="Layer_1" data-name="Layer 1" viewBox="203.07 443.47 570.48 259.16"><defs><style>.cls-2{stroke-width:0}.cls-4,.cls-5,.cls-8{font-size:67px}.cls-2{fill:#fff}.cls-4{letter-spacing:-.03em}.cls-5{letter-spacing:-.02em}.cls-14{font-size:73.82px;letter-spacing:-.03em}.cls-8{letter-spacing:0}</style></defs><text transform="matrix(.9 0 0 1 407.39 509.69)" font-family="Roboto-Black,Roboto" font-weight="800" fill="#fff"><tspan class="cls-14" x="0" y="0">I</tspan><tspan class="cls-4" x="19.69" y="0">N</tspan><tspan x="64.39" y="0" letter-spacing="-.01em" font-size="67">F</tspan><tspan class="cls-4" x="100.03" y="0">OR</tspan><tspan class="cls-8" x="185.3" y="0">M</tspan><tspan class="cls-4" x="244.36" y="0">A</tspan><tspan class="cls-5" x="287.65" y="0">Č</tspan><tspan class="cls-4" x="330.62" y="0">NÍ</tspan><tspan x="393.19" y="0" font-size="65" letter-spacing="-.04em"> </tspan><tspan class="cls-14" x="0" y="88.58">P</tspan><tspan class="cls-4" x="45.46" y="88.58">O</tspan><tspan x="89.38" y="88.58" letter-spacing="-.04em" font-size="67">R</tspan><tspan x="130.47" y="88.58" font-size="67" letter-spacing="-.13em">T</tspan><tspan class="cls-5" x="163.66" y="88.58">Á</tspan><tspan x="208.29" y="88.58" letter-spacing="-.04em" font-size="67">L</tspan><tspan class="cls-8" x="242.26" y="88.58"> </tspan><tspan class="cls-4" x="259.28" y="88.58">PRO</tspan><tspan class="cls-14" x="0" y="177.17">C</tspan><tspan class="cls-4" x="45.86" y="177.17">IZINCE</tspan></text><path fill="#fff" stroke="#fff" stroke-miterlimit="10" stroke-width="1.16" d="M358.14 600.38L358.14 687.27 203.84 687.27 203.84 600.06 280.18 649 358.14 600.38z"/><path d="M280.79 454.29c37.48 0 67.87 30.39 67.87 67.87s-30.39 67.87-67.87 67.87M212.92 522.15c0-37.48 30.39-67.87 67.87-67.87" fill="none" stroke-width="19.7" stroke="#fff" stroke-miterlimit="10"/><path class="cls-2" d="M286.01,598.94l-3.83.94h-3.5v-76.08c.62-.63.97-.98,1.59-1.61h19.72v62.82c-3.06,3.11-5.37,5.47-7.76,7.9-1.96,2-3.19,3.24-5.7,5.79"/><path class="cls-2" d="M280.4 522.21L257.31 522.15 280.43 543.94 280.4 522.21z"/><ellipse cx="287.87" cy="502.28" rx="14.06" ry="14.12" transform="rotate(-89.86 287.865 502.273)" stroke-width="0" fill="#ebae20"/></svg>
+                </a>
+                <div class="header__perex">
+                    Official Information Portal for Foreigners of the Ministry of the Interior of the Czech Republic
+                </div>
+            </div>
+            <div class="header__column show-only__desktop">
+
+
+
+<div data-type="client-search" data-props="&#123;&quot;isNarrow&quot;:true}">
+    <div class="search-box search-box--narrow">
+        <div class="search-box__form">
+            <div class="search-box__wrapper">
+                <input
+                    type="search"
+                    autocomplete="off"
+                    class="search-box__input"
+                    placeholder="Search"
+                    aria-label="Search"
+               >
+                <div class="search-box__button">
+                    <button
+                        class="button__primary icon__only icon--20x20 icon--search"
+                        aria-label="Search"
+                    ></button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<div data-type="client-combo-menu">
+
+
+	<div
+		class="spinner__loader has-white-base-color"
+		role="status"
+		style="min-width: 1.5rem; max-width: 1.5rem; min-height: 1.5rem; max-height: 1.5rem;"
+	>
+
+
+<span class="screen-reader-only">
+    Načítavání obsahu
+</span>
+	</div>
+</div>
+
+
+<div class="lang-switcher">
+    <img alt="flag">
+    <select
+      aria-label="Language switcher"
+      class="lang-switcher__select"
+      onchange="
+        debugger;
+        const locales = ['cs', 'en', 'uk'];
+        var currentPathParts = window.location.pathname.split('/').filter(Boolean);
+
+        // Remove the locale segment (0th part) from current path
+        if (currentPathParts.length > 0) {
+          if (locales.includes(currentPathParts[0])) {
+            currentPathParts.shift();
+          }
+        }
+
+        const isProfile = currentPathParts[0] === 'profile';
+        if (isProfile) {
+            const targetLocale = this.value.split('/').filter(Boolean)[0];
+            currentPathParts = ['', targetLocale, ...currentPathParts];
+            window.location.pathname = currentPathParts.join('/') + window.location.search;
+        } else {
+            window.location = this.value.split('?')[0] + window.location.search;
+        }
+      "
+    >
+            <option
+                value="https://ipc.gov.cz/uk/"
+                data-flag="https://ipc.gov.cz/wp-content/plugins/polylang/flags/ua.png"
+                
+            >
+                    UA
+            </option>
+            <option
+                value="https://ipc.gov.cz/formulare-a-dokumenty/nalezitosti-dokumenty/doklad-o-zdravotnim-pojisteni/"
+                data-flag="https://ipc.gov.cz/wp-content/plugins/polylang/flags/cz.png"
+                
+            >
+                    CS
+            </option>
+            <option
+                value="https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/"
+                data-flag="https://ipc.gov.cz/wp-content/plugins/polylang/flags/gb.png"
+                selected
+            >
+                    EN
+            </option>
+    </select>
+</div>
+            </div>
+            <div class="header__column show-only__mobile">
+<div data-type="client-user-menu">
+
+
+	<div
+		class="spinner__loader has-white-base-color"
+		role="status"
+		style="min-width: 1.5rem; max-width: 1.5rem; min-height: 1.5rem; max-height: 1.5rem;"
+	>
+
+
+<span class="screen-reader-only">
+    Načítavání obsahu
+</span>
+	</div>
+</div>
+<button class="button__outline-light hamburger show-only__mobile">
+    Menu
+</button>
+            </div>
+        </div>
+        <div class="header__mobile-search show-only__mobile container">
+
+
+
+<div data-type="client-search" data-props="&#123;&quot;isNarrow&quot;:false}">
+    <div class="search-box">
+        <div class="search-box__form">
+            <div class="search-box__wrapper">
+                <input
+                    type="search"
+                    autocomplete="off"
+                    class="search-box__input"
+                    placeholder="Search"
+                    aria-label="Search"
+               >
+                <div class="search-box__button">
+                    <button
+                        class="button__primary icon__only icon--20x20 icon--search"
+                        aria-label="Search"
+                    ></button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+        </div>
+    </div>
+    <hr class="header__divider show-only__desktop">
+
+<nav class="main-menu main-menu--desktop show-only__desktop" aria-label="Hlavní menu">
+        <ul class="main-menu__menu">
+                <li class="main-menu__item">
+                    <a href="https://ipc.gov.cz/en/forms-and-documents/" class="main-menu__link">Forms and Documents</a>
+                </li>
+                <li class="main-menu__item">
+                    <a href="https://ipc.gov.cz/en/visa-and-residence-permit-types/" class="main-menu__link">Visa and Residence Permit Types</a>
+                </li>
+                <li class="main-menu__item">
+                    <a href="https://ipc.gov.cz/en/obligations-for-foreigners/" class="main-menu__link">Obligations</a>
+                </li>
+                <li class="main-menu__item">
+                    <a href="https://ipc.gov.cz/en/new-reservation" class="main-menu__link">Reservation system</a>
+                </li>
+                <li class="main-menu__item">
+                    <a href="https://ipc.gov.cz/en/need-advice/" class="main-menu__link">Need advice?</a>
+                </li>
+                <li class="main-menu__item">
+                    <a href="https://ipc.gov.cz/en/contacts/" class="main-menu__link">Contacts</a>
+                </li>
+        </ul>
+</nav>
+<nav class="main-menu main-menu--mobile show-only__mobile" aria-hidden="true" hidden aria-label="Hlavní menu">
+    <div class="main-menu__mobile-top">
+
+
+<div class="lang-switcher">
+    <img alt="flag">
+    <select
+      aria-label="Language switcher"
+      class="lang-switcher__select"
+      onchange="
+        debugger;
+        const locales = ['cs', 'en', 'uk'];
+        var currentPathParts = window.location.pathname.split('/').filter(Boolean);
+
+        // Remove the locale segment (0th part) from current path
+        if (currentPathParts.length > 0) {
+          if (locales.includes(currentPathParts[0])) {
+            currentPathParts.shift();
+          }
+        }
+
+        const isProfile = currentPathParts[0] === 'profile';
+        if (isProfile) {
+            const targetLocale = this.value.split('/').filter(Boolean)[0];
+            currentPathParts = ['', targetLocale, ...currentPathParts];
+            window.location.pathname = currentPathParts.join('/') + window.location.search;
+        } else {
+            window.location = this.value.split('?')[0] + window.location.search;
+        }
+      "
+    >
+            <option
+                value="https://ipc.gov.cz/uk/"
+                data-flag="https://ipc.gov.cz/wp-content/plugins/polylang/flags/ua.png"
+                
+            >
+                    UA
+            </option>
+            <option
+                value="https://ipc.gov.cz/formulare-a-dokumenty/nalezitosti-dokumenty/doklad-o-zdravotnim-pojisteni/"
+                data-flag="https://ipc.gov.cz/wp-content/plugins/polylang/flags/cz.png"
+                
+            >
+                    CS
+            </option>
+            <option
+                value="https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/"
+                data-flag="https://ipc.gov.cz/wp-content/plugins/polylang/flags/gb.png"
+                selected
+            >
+                    EN
+            </option>
+    </select>
+</div>
+<button class="button__outline-light hamburger show-only__mobile">
+    Menu
+</button>
+    </div>
+        <ul class="main-menu__menu">
+                <li class="main-menu__item">
+                    <a href="https://ipc.gov.cz/en/forms-and-documents/" class="main-menu__link">Forms and Documents</a>
+                </li>
+                <li class="main-menu__item">
+                    <a href="https://ipc.gov.cz/en/visa-and-residence-permit-types/" class="main-menu__link">Visa and Residence Permit Types</a>
+                </li>
+                <li class="main-menu__item">
+                    <a href="https://ipc.gov.cz/en/obligations-for-foreigners/" class="main-menu__link">Obligations</a>
+                </li>
+                <li class="main-menu__item">
+                    <a href="https://ipc.gov.cz/en/new-reservation" class="main-menu__link">Reservation system</a>
+                </li>
+                <li class="main-menu__item">
+                    <a href="https://ipc.gov.cz/en/need-advice/" class="main-menu__link">Need advice?</a>
+                </li>
+                <li class="main-menu__item">
+                    <a href="https://ipc.gov.cz/en/contacts/" class="main-menu__link">Contacts</a>
+                </li>
+        </ul>
+    <div class="main-menu__mobile-bottom">
+        <hr>
+<div data-type="client-login-button">
+
+
+	<div
+		class="spinner__loader has-white-base-color"
+		role="status"
+		style="min-width: 1.5rem; max-width: 1.5rem; min-height: 1.5rem; max-height: 1.5rem;"
+	>
+
+
+<span class="screen-reader-only">
+    Načítavání obsahu
+</span>
+	</div>
+</div>
+    </div>
+</nav>
+<div class="main-menu__mobile-backdrop show-only__mobile"></div>
+</header>
+            <main class="page__content" role="main">
+<div data-type="client-cookies"></div>
+<div class="container--default">
+<nav
+    class="breadcrumb"
+    aria-label="Drobečková navigace"
+>
+    <span class="breadcrumb__item">
+        <a href="https://ipc.gov.cz/en/" class="breadcrumb__link">
+            Home
+        </a>
+    </span>
+        <span class="breadcrumb__item">
+                <a href="https://ipc.gov.cz/en/forms-and-documents/" class="breadcrumb__link">
+                    Forms and Documents
+                </a>
+        </span>
+        <span class="breadcrumb__item">
+                <a href="https://ipc.gov.cz/en/forms-and-documents/documents/" class="breadcrumb__link">
+                    Documents
+                </a>
+        </span>
+        <span class="breadcrumb__item">
+                <strong class="breadcrumb__link">
+                    Medical Insurance
+                </strong>
+        </span>
+</nav>
+    <h1 class="page__heading">Medical Insurance</h1>
+    <div class="font-size__20">
+    <p>The type of certificate of travel and medical insurance depends on the type of application you file and where you file it. When you apply for a long-term visa or a long-term residence permit at an office of the Diplomatic Mission of the Czech Republic, the type of required document is not the same as the one demanded, if you apply for it in the Czech Republic. It also makes a difference, whether you are a citizen of the European Union, or not. </p>
+</div>
+
+
+
+
+
+<div
+    class="iq-tabs iq-tabs--tabsOnly"
+    style="margin-bottom: 2.5rem;"
+    data-tab-block
+    data-id="5d601ee1-cd3c-43ee-a5b8-76c0ede754f2"
+>
+    <div role="tablist" class="iq-tabs__tabs">
+            <div
+                id="1"
+                class="iq-tabs__tab"
+                data-tab-item
+                data-id="f67062c8-a5f4-4c4e-bd01-f42102604af2"
+                data-selected="true"
+                data-default="true"
+            >
+                <button
+                    id="iq-tab-button-f67062c8-a5f4-4c4e-bd01-f42102604af2"
+                    data-tab-button
+                    role="tab"
+                    aria-selected="true"
+                    aria-controls="iq-tab-panel-f67062c8-a5f4-4c4e-bd01-f42102604af2"
+                >
+                    <h2 class="h3 nomargin__all">
+                        
+                            APPLYING FROM OUTSIDE CZECHIA
+                    </h2>
+                </button>
+            </div>
+            <div
+                id="2"
+                class="iq-tabs__tab"
+                data-tab-item
+                data-id="289d3f6d-f490-42f1-baa3-6e12d7d27227"
+                data-selected="false"
+                data-default="false"
+            >
+                <button
+                    id="iq-tab-button-289d3f6d-f490-42f1-baa3-6e12d7d27227"
+                    data-tab-button
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="iq-tab-panel-289d3f6d-f490-42f1-baa3-6e12d7d27227"
+                >
+                    <h2 class="h3 nomargin__all">
+                        
+                            APPLYING IN CZECHIA
+                    </h2>
+                </button>
+            </div>
+            <div
+                id="3"
+                class="iq-tabs__tab"
+                data-tab-item
+                data-id="5e4197a8-c163-41d0-9058-ed917cb3ee53"
+                data-selected="false"
+                data-default="false"
+            >
+                <button
+                    id="iq-tab-button-5e4197a8-c163-41d0-9058-ed917cb3ee53"
+                    data-tab-button
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="iq-tab-panel-5e4197a8-c163-41d0-9058-ed917cb3ee53"
+                >
+                    <h2 class="h3 nomargin__all">
+                        
+                            EU CITIZENS AND THEIR FAMILY MEMBERS
+                    </h2>
+                </button>
+            </div>
+            <div
+                id="4"
+                class="iq-tabs__tab"
+                data-tab-item
+                data-id="20f41f6c-7c43-4c3b-9632-0bafc16e13fb"
+                data-selected="false"
+                data-default="false"
+            >
+                <button
+                    id="iq-tab-button-20f41f6c-7c43-4c3b-9632-0bafc16e13fb"
+                    data-tab-button
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="iq-tab-panel-20f41f6c-7c43-4c3b-9632-0bafc16e13fb"
+                >
+                    <h2 class="h3 nomargin__all">
+                        
+                            PERSONS UNDER 18 YEARS OF AGE
+                    </h2>
+                </button>
+            </div>
+    </div>
+        <h3
+            class="h1 iq-tabs__title show-only__mobile"
+            data-tab-title
+            data-id="f67062c8-a5f4-4c4e-bd01-f42102604af2"
+            data-default="true"
+            
+        >
+            APPLYING FROM OUTSIDE CZECHIA
+        </h3>
+        <h3
+            class="h1 iq-tabs__title show-only__mobile"
+            data-tab-title
+            data-id="289d3f6d-f490-42f1-baa3-6e12d7d27227"
+            data-default="false"
+            hidden
+        >
+            APPLYING IN CZECHIA
+        </h3>
+        <h3
+            class="h1 iq-tabs__title show-only__mobile"
+            data-tab-title
+            data-id="5e4197a8-c163-41d0-9058-ed917cb3ee53"
+            data-default="false"
+            hidden
+        >
+            EU CITIZENS AND THEIR FAMILY MEMBERS
+        </h3>
+        <h3
+            class="h1 iq-tabs__title show-only__mobile"
+            data-tab-title
+            data-id="20f41f6c-7c43-4c3b-9632-0bafc16e13fb"
+            data-default="false"
+            hidden
+        >
+            PERSONS UNDER 18 YEARS OF AGE
+        </h3>
+    
+
+
+<div
+    id="iq-tab-panel-f67062c8-a5f4-4c4e-bd01-f42102604af2"
+    class="iq-tab"
+    data-tab
+    data-id="f67062c8-a5f4-4c4e-bd01-f42102604af2"
+    data-default="true"
+    
+    role="tabpanel"
+    aria-labelledby="iq-tab-button-f67062c8-a5f4-4c4e-bd01-f42102604af2"
+>
+    
+
+<h3>Application&nbsp;for a long-term visa or&nbsp;for&nbsp;a long-term residence permit&nbsp;filed at&nbsp;a&nbsp;diplomatic&nbsp;mission&nbsp;office&nbsp;</h3>
+
+
+
+<p>If you wish to stay in the Czech Republic for a period exceeding 90 days from the date of your entry into the Czech Republic, you must ensure, that you have a travel insurance covering a comprehensive medical care. From September 20, 2023 such insurance can be arranged with any insurance company authorised to provide it in the Czech Republic.</p>
+
+
+
+<p>The insurance coverage amount (the agreed limit per insured event) must be at least EUR 400,000, with no cost sharing by the insured person. This limit applies both to insurance covering necessary and urgent care and to comprehensive health insurance.</p>
+
+
+
+<p><strong>If you applied for long-term visa or for long-term residence permit at an office of the Diplomatic Mission&nbsp;of the Czech Republic,&nbsp;you&nbsp;have to submit a&nbsp;certificate&nbsp;proving your travel medical insurance,&nbsp;before you&nbsp;can&nbsp;collect your long-term visa or&nbsp;your long-term visa for the purpose of residence permit,&nbsp;meeting&nbsp;the following criteria:&nbsp;</strong></p>
+
+
+
+<ul>
+<li>Travel&nbsp;and&nbsp;medical insurance&nbsp;covering necessary and urgent medical care for the initial 90 days of your stay,&nbsp;and at the same time another&nbsp;agreement concluded with an insurance company authorised to provide comprehensive medical insurance in the Czech Republic.</li>
+
+
+
+<li>You may also submit a&nbsp;Certificate of&nbsp;Agreement with insurance company on a comprehensive medical insurance for the&nbsp;entire&nbsp;period of your stay. </li>
+</ul>
+
+
+
+<p><strong>Certificate of comprehensive travel&nbsp;and medical&nbsp;insurance&nbsp;must confirm:</strong></p>
+
+
+
+<ul>
+<li>The period of insurance validity (insurance must be concluded for the entire period of your stay in the Czech Republic).</li>
+
+
+
+<li>The scope of insurance coverage (the agreement must include the coverage of expenses).</li>
+</ul>
+
+
+
+<p>Insurance agreement must not exclude an accident indemnity, in cases where the accident is caused by your intentional or wrongful act, joint culpability, or as a result of alcohol-, narcotic- and psychotropic substance misuse.</p>
+
+
+
+<p>If you conclude an insurance agreement abroad, you must also submit a certified translation of your insurance agreement and of the general terms and conditions into the Czech language.</p>
+
+
+
+<p>On request, you have to submit the proof of payment of the insurance premium stated on the comprehensive travel and medical insurance certificate.</p>
+
+
+
+<p><strong>You will not need to submit your travel and medical insurance certificate provided that:</strong></p>
+
+
+
+<ul>
+<li>you are participating in the public health insurance,</li>
+
+
+
+<li>the costs of your health care are covered <a href="https://ipc.gov.cz/en/list-of-countries-and-categories-of-nationals-who-are-or-may-be-exempted-from-the-obligation-to-provide-proof-of-travel-medical-insurance-on-the-basis-of-an-international-treaty/" target="_blank" rel="noreferrer noopener">on the basis of an international agreement, e. g. on the basis of programme Erasmus or Fullbright programme</a>,</li>
+
+
+
+<li>you prove that your health care is covered by different means (for example on the grounds of a written obligation of a legal person, if your stay in the Czech Republic is beneficial for the spiritual values development, human rights protection or other humanitarian values, protection of nature, cultural heritage, scientific progress, educational development, physical education and sports, on the basis of a written obligation of a state authority or based on an obligation arising from an invitation certified by police).</li>
+</ul>
+
+
+</div>
+
+
+
+
+
+<div
+    id="iq-tab-panel-289d3f6d-f490-42f1-baa3-6e12d7d27227"
+    class="iq-tab"
+    data-tab
+    data-id="289d3f6d-f490-42f1-baa3-6e12d7d27227"
+    data-default="false"
+    hidden data-hidden="true"
+    role="tabpanel"
+    aria-labelledby="iq-tab-button-289d3f6d-f490-42f1-baa3-6e12d7d27227"
+>
+    
+
+<h3>Application for a long-term visa or for a long-term residence permit filed in the territory of the Czech Republic</h3>
+
+
+
+<p>If you apply for a long-term visa, a long-term residence permit or extension of validity of the two above residence permits in the Czech Republic, your certificate of travel and medical insurance must prove, that the relevant insurance is valid for comprehensive health care.</p>
+
+
+
+<p>From September 20, 2023 the comprehensive medical insurance can be arranged with any insurance company authorised to provide it in the Czech Republic.</p>
+
+
+
+<p><strong>Thus, if you apply for the above-mentioned residence permits or for an extension of their validity, with effect from September 20, 2023, your certificate of travel and medical insurance can be arranged with any insurance company authorised to provide it in the Czech Republic.</strong></p>
+
+
+
+<p><strong>You will not need to submit your travel and medical insurance certificate provided that</strong>:</p>
+
+
+
+<ul>
+<li>you are participating in the public health insurance,</li>
+
+
+
+<li>the costs of your health care are covered <a href="https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/list-of-countries-and-categories-of-nationals-who-are-or-may-be-exempted-from-the-obligation-to-provide-proof-of-travel-medical-insurance-on-the-basis-of-an-international-treaty/" target="_blank" rel="noreferrer noopener">on the basis of an international agreement, e. g. on the basis of programme Erasmus or Fullbright programme</a>,</li>
+
+
+
+<li>you prove that your health care is covered by some other means (for example on the grounds of a written obligation of a legal person, if your stay in the Czech Republic is beneficial for the spiritual values development, human rights protection or other humanitarian values, protection of nature, cultural heritage, scientific progress, educational development, physical education and sports, on the basis of a written obligation of a state authority or based on an obligation arising from an invitation certified by police).</li>
+</ul>
+
+
+</div>
+
+
+
+
+
+<div
+    id="iq-tab-panel-5e4197a8-c163-41d0-9058-ed917cb3ee53"
+    class="iq-tab"
+    data-tab
+    data-id="5e4197a8-c163-41d0-9058-ed917cb3ee53"
+    data-default="false"
+    hidden data-hidden="true"
+    role="tabpanel"
+    aria-labelledby="iq-tab-button-5e4197a8-c163-41d0-9058-ed917cb3ee53"
+>
+    
+
+<h3>EU citizens and their family members</h3>
+
+
+
+<p><strong>For EU citizens and their family members, who are not EU citizens, a sufficient certificate of medical insurance is, as follows:</strong></p>
+
+
+
+<ul>
+<li>European/British Health Insurance Card (EHIC/GHIC)
+<ul>
+<li>These are insurance cards issued by insurance companies in individual member states and Island, Liechtenstein, Norway, Sweden or insurance cards of UK citizens.</li>
+</ul>
+</li>
+
+
+
+<li>Certificate which is a temporary substitute for European Health Insurance Card</li>
+
+
+
+<li>Registration Certificate</li>
+
+
+
+<li>Card of a beneficiary of European Union medical insurance staying in the Czech Republic</li>
+
+
+
+<li>Insurance card of an insurance beneficiary living in the Czech Republic</li>
+
+
+
+<li>Any of the S1 forms, i.e., E 106, E 109, E 112, E 120 or E 121</li>
+</ul>
+
+
+
+<p>EU citizens and their close family members can also submit another document, instead of the above mentioned one, if covering the corresponding scope of indemnation to the travel and medical insurance institute.</p>
+
+
+
+<p><strong>For distant family members who are not themselves EU citizens, it can be considered proof of medical insurance:</strong></p>
+
+
+
+<ul>
+<li>European/British Health Insurance Card (EHIC/GHIC)
+<ul>
+<li>These are insurance cards issued by insurance companies in individual member states and Island, Liechtenstein, Norway,Sweden or insurance cards of UK citizens.</li>
+</ul>
+</li>
+
+
+
+<li>Certificate of a concluded comprehensive medical insurance</li>
+</ul>
+
+
+
+<p>For the list of Regulated institutions and registered financial market entities, which are authorized to provide their insurance services within the Czech Republic, see the&nbsp;<a href="https://www.cnb.cz/en/supervision-financial-market/lists-registers/" target="_blank" rel="noreferrer noopener">List of regulated entities on the website of the Czech National Bank</a>. The list includes relevant categories like subsidiaries of foreign insurance companies and international insurance corporations which offer transfrontier insurance services within the Czech Republic. </p>
+
+
+
+
+<div data-type="client-alert" data-props="&#123;&quot;id&quot;:&quot;alert-a57798b5-d695-4e41-92e0-3809ce424f16&quot;,&quot;content&quot;:&quot;&lt;p&gt;The aforesaid list gives the insurance companies which are authorised to provide their services within the Czech Republic, but does not give the information whether, and to which extent they insure foreigners.&lt;\/p&gt;&quot;,&quot;type&quot;:&quot;alert--form-warning&quot;,&quot;icon&quot;:&quot;icon--warning&quot;,&quot;marginBottom&quot;:0,&quot;isNarrow&quot;:true,&quot;forceOpen&quot;:false}">
+
+
+<div class="spinner__wrapper flex flex--justify-center flex--align-center width__100">
+	<div
+		class="spinner__loader"
+		role="status"
+		style="min-width: 3rem; max-width: 3rem; min-height: 3rem; max-height: 3rem;"
+	>
+
+
+<span class="screen-reader-only">
+    Načítavání obsahu
+</span>
+	</div>
+</div>
+</div>
+
+
+
+</div>
+
+
+
+
+
+<div
+    id="iq-tab-panel-20f41f6c-7c43-4c3b-9632-0bafc16e13fb"
+    class="iq-tab"
+    data-tab
+    data-id="20f41f6c-7c43-4c3b-9632-0bafc16e13fb"
+    data-default="false"
+    hidden data-hidden="true"
+    role="tabpanel"
+    aria-labelledby="iq-tab-button-20f41f6c-7c43-4c3b-9632-0bafc16e13fb"
+>
+    
+
+<p>Persons under 18 years of age who have a <strong>valid long-term residence permit</strong> are participants in the Public Health Insurance System. This applies to <a href="https://ipc.gov.cz/en/visa-and-residence-permit-types/third-country-nationals/long-term-residence-permits/" target="_blank" rel="noreferrer noopener">all types of long-term residence, regardless of the purpose of the stay</a>. The expenses related to the Public Health Insurance System of persons under 18 years of age are always covered by the minor’s legal representative, guardian or trustee.</p>
+
+
+
+<p>The participation in the Public Health Insurance System commences automatically from the day, when the person under 18 years of age takes over his or her first <a href="https://ipc.gov.cz/wp-content/uploads/2023/01/DP-1.png" target="_blank" rel="noreferrer noopener">long-term residence card</a>. That is a biometric ID data card (<a href="https://ipc.gov.cz/wp-content/uploads/2023/01/DP-1.png" target="_blank" rel="noreferrer noopener">the specimen of this ID card is available at this link</a>).</p>
+
+
+
+<p>A minor child is a participant in the Public Health Insurance System <strong>until the age of 18,</strong> or <strong>until the expiration of his or her long-term residence permit</strong>.</p>
+
+
+
+<p>After reaching 18 years of age it is obligatory to register for Comprehensive Private Health Insurance. If the person who has attained 18 years of age is employed, the employer will usually cover the Public Health Insurance premium for him or her.&nbsp;&nbsp;</p>
+
+
+
+<p>Everyone can choose the Health Insurance Company which he or she wishes to be insured with. However, children who are born in the Czech Republic are an exception. <strong>A baby born in the Czech Republic has to be insured with the same health insurance company as the mother on the day of his or her birth.</strong> If the mother is not participating in the Public Health Insurance System, then the child has to be insured with the same health insurance company as his or her father.</p>
+
+
+
+<p>For more information about the residence of a foreign national born in the Czech Republic, click <a href="https://ipc.gov.cz/en/visa-and-residence-permit-types/third-country-nationals/residence-of-a-child-born-in-the-czech-republic/" target="_blank" rel="noreferrer noopener">here</a>.</p>
+
+
+
+
+<div data-type="client-alert" data-props="&#123;&quot;id&quot;:&quot;alert-f486ab77-b01f-4a9d-a2df-35ca111ec4e7&quot;,&quot;content&quot;:&quot;&lt;p&gt; Participation in the Public Health Insurance System does not apply to foreigners under the age of 18 who have been issued a &lt;a href=\&quot;https:\/\/ipc.gov.cz\/en\/visa-and-residence-permit-types\/third-country-nationals\/long-term-visa\/\&quot; target=\&quot;_blank\&quot; rel=\&quot;noreferrer noopener\&quot;&gt;long-term visa&lt;\/a&gt;, or have been issued a &lt;a href=\&quot;https:\/\/ipc.gov.cz\/en\/visa-and-residence-permit-types\/eu-nationals\/temporary-residence-permit-of-an-eu-citizens-family-member\/\&quot; target=\&quot;_blank\&quot; rel=\&quot;noreferrer noopener\&quot;&gt;temporary residence permit for a family member of an EU citizen&lt;\/a&gt;. These foreign nationals have to be insured under the Private Health Insurance System.&lt;\/p&gt;&lt;p&gt; &lt;a id=\&quot;_msocom_1\&quot;&gt;&lt;\/a&gt; &lt;\/p&gt;&quot;,&quot;type&quot;:&quot;alert--form-warning&quot;,&quot;icon&quot;:&quot;icon--warning&quot;,&quot;marginBottom&quot;:0,&quot;isNarrow&quot;:true,&quot;forceOpen&quot;:false}">
+
+
+<div class="spinner__wrapper flex flex--justify-center flex--align-center width__100">
+	<div
+		class="spinner__loader"
+		role="status"
+		style="min-width: 3rem; max-width: 3rem; min-height: 3rem; max-height: 3rem;"
+	>
+
+
+<span class="screen-reader-only">
+    Načítavání obsahu
+</span>
+	</div>
+</div>
+</div>
+
+
+
+</div>
+
+
+
+</div>
+
+
+</div>
+            </main>
+<footer class="footer" role="contentinfo">
+    <div class="footer__content container">
+        <div class="footer__top">
+            <div class="footer__logo-wrapper">
+                <a 
+                    href="https://european-union.europa.eu/" 
+                    class="footer__logo" 
+                    data-type="hideLinkIcon"
+                    aria-label="Logo – Funded by the European Union, Asylum, Migration and Integration Fund – go to the EU website"
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 48" fill="none"><g clip-path="url(#clip0_2321_61765)" fill="#fff"><path d="M79.7251 14.036C79.7286 14.0876 79.7286 14.1395 79.7251 14.1911 79.7206 14.2284 79.7093 14.2645 79.6916 14.2976 79.6792 14.3224 79.6602 14.3434 79.6369 14.3584 79.6176 14.37 79.5955 14.3763 79.573 14.3767H77.3219V16.4666H79.4513C79.4738 16.4669 79.4959 16.4732 79.5152 16.4848 79.5371 16.4977 79.5558 16.5154 79.57 16.5365 79.5862 16.5689 79.5965 16.6039 79.6004 16.6399 79.6059 16.6946 79.6059 16.7496 79.6004 16.8042 79.6056 16.8558 79.6056 16.9078 79.6004 16.9594 79.5965 16.9954 79.5862 17.0304 79.57 17.0628 79.5557 17.0863 79.5371 17.107 79.5152 17.1236 79.4968 17.1375 79.4743 17.1449 79.4513 17.1449H77.3219V19.7063C77.3221 19.7318 77.3139 19.7567 77.2985 19.7771 77.2831 19.7975 77.2614 19.8121 77.2367 19.8189L77.112 19.8462C77.0462 19.8519 76.9801 19.8519 76.9143 19.8462 76.8495 19.8516 76.7844 19.8516 76.7196 19.8462L76.5888 19.8189C76.5625 19.8106 76.5399 19.7933 76.5249 19.7702 76.5111 19.7518 76.5036 19.7293 76.5036 19.7063V14.0147C76.4983 13.967 76.5043 13.9187 76.5212 13.8737 76.5381 13.8288 76.5655 13.7885 76.6009 13.7561 76.6601 13.7098 76.7327 13.6842 76.8078 13.6831H79.573C79.5955 13.6834 79.6176 13.6897 79.6369 13.7014 79.661 13.7168 79.68 13.739 79.6916 13.7652 79.7096 13.7993 79.721 13.8365 79.7251 13.8748 79.7286 13.9284 79.7286 13.9823 79.7251 14.036zM81.7815 19.706C81.782 19.7296 81.7757 19.7529 81.7632 19.7729 81.7463 19.7948 81.7229 19.8108 81.6963 19.8186L81.5716 19.8459C81.4413 19.8622 81.3095 19.8622 81.1792 19.8459L81.0514 19.8186C81.0248 19.8108 81.0014 19.7948 80.9845 19.7729 80.972 19.7529 80.9657 19.7296 80.9662 19.706V13.8075C80.9648 13.7833 80.9724 13.7595 80.9875 13.7406 81.0047 13.7176 81.0295 13.7015 81.0575 13.695 81.0989 13.681 81.1418 13.6719 81.1853 13.6676 81.248 13.6624 81.3111 13.6624 81.3739 13.6676 81.4397 13.6622 81.5058 13.6622 81.5716 13.6676 81.6142 13.6715 81.6561 13.6807 81.6963 13.695 81.7234 13.7016 81.7472 13.7178 81.7632 13.7406 81.776 13.7605 81.7824 13.7839 81.7815 13.8075V19.706zM88.0634 19.493C88.0651 19.5438 88.0557 19.5945 88.0357 19.6412 88.0157 19.688 87.9857 19.7299 87.9478 19.7637 87.9133 19.791 87.8741 19.8117 87.8322 19.8246 87.7906 19.8366 87.7476 19.8428 87.7044 19.8428H87.4337C87.3579 19.8435 87.2824 19.8353 87.2085 19.8185 87.1429 19.7982 87.0819 19.7651 87.0291 19.7212 86.9631 19.6674 86.9048 19.605 86.8557 19.5356 86.7877 19.4386 86.7267 19.337 86.6732 19.2314L84.7993 15.7361C84.7019 15.5536 84.6015 15.365 84.4951 15.1673 84.3886 14.9695 84.3034 14.7779 84.2182 14.5893 84.2182 14.8174 84.2182 15.0517 84.2334 15.2889 84.2487 15.5262 84.2334 15.7604 84.2334 15.9947V19.7059C84.2334 19.729 84.226 19.7514 84.2121 19.7698 84.1964 19.7936 84.1727 19.8108 84.1452 19.8185L84.0205 19.8459C83.8892 19.8621 83.7564 19.8621 83.625 19.8459L83.5034 19.8185C83.4767 19.8092 83.4535 19.7923 83.4364 19.7698 83.424 19.7507 83.4167 19.7287 83.4151 19.7059V14.0356C83.4092 13.9849 83.4161 13.9336 83.4353 13.8863 83.4544 13.8389 83.4852 13.7972 83.5247 13.7649 83.5914 13.7121 83.6738 13.6832 83.7589 13.6827H84.1635C84.2433 13.6817 84.3229 13.6899 84.4008 13.7071 84.4621 13.7221 84.52 13.749 84.5711 13.7862 84.628 13.8271 84.6774 13.8775 84.7171 13.9352 84.7724 14.0139 84.8222 14.0962 84.8662 14.1816L86.3081 16.8799C86.3994 17.0442 86.4845 17.2054 86.5667 17.3605L86.804 17.826C86.881 17.9781 86.9571 18.1271 87.0321 18.2732 87.1082 18.4222 87.1812 18.5774 87.2542 18.7173 87.2542 18.4678 87.2542 18.2062 87.2542 17.9355 87.2542 17.6648 87.2542 17.4062 87.2542 17.1537V13.8075C87.2539 13.7853 87.2614 13.7638 87.2755 13.7466 87.2919 13.7236 87.3154 13.7065 87.3424 13.698 87.3818 13.6799 87.424 13.6686 87.4671 13.6645 87.535 13.6607 87.6031 13.6607 87.6709 13.6645 87.7338 13.6609 87.7967 13.6609 87.8595 13.6645 87.9037 13.6682 87.947 13.6796 87.9873 13.698 88.013 13.7074 88.0352 13.7244 88.0512 13.7466 88.0641 13.7644 88.0715 13.7855 88.0725 13.8075L88.0634 19.493zM94.3025 19.5388C94.3243 19.5932 94.3377 19.6507 94.3421 19.7091 94.3445 19.7271 94.3425 19.7454 94.3361 19.7624 94.3297 19.7794 94.3193 19.7946 94.3056 19.8065 94.2691 19.8327 94.2257 19.8475 94.1809 19.8491 94.1231 19.8491 94.044 19.8491 93.9466 19.8491H93.7093C93.6651 19.845 93.6213 19.8369 93.5785 19.8247 93.5527 19.8155 93.5297 19.7998 93.5116 19.7791 93.4954 19.7576 93.4821 19.7341 93.4721 19.7091L92.9428 18.2125H90.3875L89.8855 19.6879C89.8767 19.7153 89.8634 19.741 89.846 19.7639 89.8269 19.7849 89.8042 19.8024 89.7791 19.8156 89.7371 19.8318 89.6931 19.842 89.6483 19.846 89.5763 19.8498 89.5042 19.8498 89.4323 19.846 89.3574 19.8516 89.2821 19.8516 89.2072 19.846 89.1631 19.8428 89.1209 19.8269 89.0855 19.8004 89.0726 19.788 89.0628 19.7727 89.057 19.7558 89.0512 19.7389 89.0495 19.7208 89.052 19.7031 89.0565 19.6456 89.0699 19.5892 89.0916 19.5358L91.1541 13.8259C91.1633 13.7941 91.18 13.7649 91.2027 13.7407 91.2277 13.7152 91.2593 13.6973 91.294 13.689 91.3433 13.6734 91.3944 13.6642 91.4461 13.6616 91.5069 13.6616 91.586 13.6616 91.6803 13.6616 91.7746 13.6616 91.8659 13.6616 91.9328 13.6616 91.9875 13.6642 92.0416 13.6734 92.094 13.689 92.1291 13.6986 92.1614 13.7163 92.1883 13.7407 92.2109 13.7667 92.2284 13.7966 92.2401 13.8289L94.3025 19.5388zM91.656 14.5012L90.5943 17.5645H92.7237L91.656 14.5012zM99.9698 19.493C99.9718 19.5483 99.9614 19.6034 99.9393 19.6542 99.919 19.6963 99.89 19.7337 99.8542 19.7637 99.8201 19.7916 99.7808 19.8123 99.7386 19.8246 99.697 19.8366 99.654 19.8428 99.6108 19.8428H99.3431C99.2674 19.8435 99.1918 19.8353 99.118 19.8185 99.0514 19.7983 98.9894 19.7652 98.9355 19.7212 98.8713 19.6665 98.8141 19.6042 98.7651 19.5356 98.6971 19.4386 98.6361 19.337 98.5826 19.2314L96.7057 15.7361C96.6083 15.5536 96.511 15.365 96.4015 15.1673 96.2919 14.9695 96.2098 14.7779 96.1246 14.5893 96.1246 14.8174 96.1246 15.0517 96.1246 15.2889 96.1246 15.5262 96.1246 15.7604 96.1246 15.9947V19.7059C96.1328 19.7273 96.1339 19.7508 96.1277 19.7729 96.1114 19.7961 96.0878 19.8132 96.0608 19.8215L95.936 19.8489C95.8702 19.8543 95.8041 19.8543 95.7383 19.8489 95.6725 19.8545 95.6064 19.8545 95.5406 19.8489L95.4158 19.8215C95.3895 19.8132 95.367 19.796 95.352 19.7729 95.3381 19.7544 95.3307 19.732 95.3307 19.709V14.0356C95.3247 13.9849 95.3317 13.9336 95.3508 13.8863 95.3699 13.8389 95.4007 13.7972 95.4402 13.7649 95.5066 13.7117 95.5893 13.6827 95.6744 13.6827H96.076C96.1557 13.6817 96.2353 13.6899 96.3132 13.7071 96.3756 13.7221 96.4345 13.7489 96.4866 13.7862 96.5427 13.8281 96.5919 13.8783 96.6327 13.9352 96.6879 14.0139 96.7377 14.0962 96.7817 14.1816L98.2236 16.8799C98.3119 17.0442 98.397 17.2054 98.4822 17.3605L98.7195 17.826C98.7965 17.9781 98.8726 18.1271 98.9476 18.2732L99.1697 18.7173C99.1697 18.4678 99.1697 18.2062 99.1697 17.9355 99.1697 17.6648 99.1697 17.4062 99.1697 17.1537V13.8075C99.1696 13.7858 99.176 13.7647 99.188 13.7466 99.2064 13.7243 99.2306 13.7075 99.2579 13.698 99.2973 13.6799 99.3395 13.6686 99.3826 13.6645 99.4505 13.6607 99.5186 13.6607 99.5865 13.6645 99.6493 13.6609 99.7122 13.6609 99.7751 13.6645 99.8183 13.6682 99.8605 13.6795 99.8998 13.698 99.9258 13.7083 99.9488 13.7251 99.9667 13.7466 99.9787 13.7647 99.985 13.7858 99.985 13.8075L99.9698 19.493zM105.71 18.9606C105.71 19.0093 105.71 19.0549 105.71 19.0945 105.707 19.1272 105.702 19.1597 105.695 19.1918 105.688 19.2182 105.678 19.2437 105.665 19.2679 105.645 19.2971 105.622 19.3246 105.598 19.35 105.534 19.4025 105.467 19.4503 105.397 19.493 105.278 19.569 105.151 19.6332 105.02 19.6846 104.852 19.7505 104.679 19.8024 104.502 19.8398 103.928 19.9624 103.33 19.9159 102.781 19.7059 102.465 19.5756 102.184 19.3735 101.959 19.1158 101.722 18.8346 101.545 18.5073 101.439 18.1545 101.308 17.7279 101.246 17.2834 101.254 16.8373 101.247 16.3754 101.314 15.9154 101.451 15.4745 101.567 15.1027 101.756 14.7575 102.005 14.4584 102.238 14.1862 102.529 13.97 102.857 13.8257 103.204 13.6765 103.58 13.6019 103.958 13.6067 104.131 13.6058 104.305 13.6221 104.475 13.6553 104.633 13.6863 104.789 13.729 104.941 13.7831 105.073 13.8278 105.201 13.887 105.321 13.9595 105.404 14.0043 105.481 14.0584 105.552 14.1208 105.583 14.1499 105.611 14.1826 105.634 14.2181 105.648 14.2429 105.658 14.2695 105.665 14.2972 105.674 14.3322 105.681 14.3677 105.686 14.4037 105.686 14.4463 105.686 14.4949 105.686 14.5527 105.689 14.6064 105.689 14.6603 105.686 14.714 105.681 14.7516 105.67 14.7885 105.655 14.8235 105.647 14.8497 105.631 14.8729 105.61 14.8904 105.601 14.8981 105.591 14.904 105.58 14.9076 105.569 14.9113 105.557 14.9127 105.546 14.9117 105.476 14.9 105.412 14.8682 105.36 14.8204 105.263 14.7463 105.162 14.6782 105.056 14.6166 104.911 14.5329 104.757 14.4646 104.597 14.4128 104.388 14.3449 104.169 14.313 103.949 14.3185 103.691 14.3148 103.436 14.371 103.204 14.4828 102.975 14.5956 102.777 14.7614 102.626 14.9664 102.456 15.2003 102.332 15.4632 102.257 15.7422 102.087 16.4253 102.087 17.1398 102.257 17.8229 102.33 18.0945 102.454 18.3496 102.622 18.5743 102.774 18.7718 102.973 18.9277 103.2 19.0275 103.446 19.134 103.712 19.1869 103.979 19.1827 104.196 19.1862 104.413 19.1564 104.621 19.0945 104.784 19.0431 104.941 18.9748 105.09 18.8906 105.195 18.8294 105.296 18.7624 105.394 18.6899 105.45 18.6411 105.518 18.6094 105.591 18.5986 105.61 18.5941 105.63 18.5941 105.649 18.5986 105.667 18.6121 105.68 18.6314 105.686 18.6534 105.698 18.6888 105.705 18.7256 105.707 18.7629 105.712 18.8287 105.713 18.8947 105.71 18.9606zM111.855 16.6856C111.861 17.1399 111.802 17.5928 111.679 18.0302 111.576 18.4022 111.398 18.7491 111.155 19.0492 110.919 19.3312 110.619 19.5523 110.279 19.6942 109.496 19.9886 108.633 19.9951 107.846 19.7124 107.521 19.5814 107.234 19.3725 107.009 19.104 106.778 18.8163 106.611 18.4823 106.519 18.1245 106.405 17.6857 106.35 17.2333 106.358 16.7799 106.353 16.3338 106.411 15.8893 106.532 15.4597 106.643 15.0918 106.829 14.751 107.079 14.4588 107.318 14.1789 107.619 13.959 107.958 13.817 108.345 13.6615 108.758 13.5849 109.175 13.5919 109.579 13.5843 109.98 13.6535 110.358 13.7957 110.682 13.928 110.969 14.1368 111.195 14.4041 111.43 14.687 111.601 15.0183 111.694 15.3745 111.807 15.8021 111.862 16.2432 111.855 16.6856zM110.991 16.7434C110.993 16.4167 110.963 16.0906 110.9 15.77 110.848 15.4937 110.745 15.2296 110.596 14.9912 110.453 14.7717 110.255 14.5942 110.021 14.4771 109.743 14.3448 109.437 14.2811 109.129 14.2915 108.819 14.2815 108.512 14.3495 108.235 14.4893 108.001 14.6173 107.8 14.7999 107.651 15.0216 107.493 15.2575 107.384 15.5221 107.329 15.8004 107.261 16.1061 107.229 16.4183 107.231 16.7312 107.229 17.0659 107.259 17.3999 107.319 17.729 107.37 18.0086 107.473 18.276 107.624 18.5169 107.766 18.7348 107.963 18.9111 108.196 19.028 108.48 19.1631 108.793 19.2268 109.108 19.2135 109.424 19.2258 109.739 19.1567 110.021 19.0127 110.258 18.8851 110.46 18.7 110.608 18.4743 110.762 18.2337 110.87 17.9666 110.927 17.6864 110.983 17.3712 111.004 17.051 110.991 16.7312V16.7434zM115.515 19.6877C115.503 19.7196 115.484 19.7486 115.46 19.7729 115.434 19.7972 115.403 19.815 115.369 19.8246 115.319 19.8385 115.268 19.8477 115.216 19.852H114.985 114.803C114.758 19.8557 114.713 19.8557 114.669 19.852 114.636 19.8479 114.603 19.8408 114.572 19.8307 114.547 19.8248 114.523 19.8145 114.502 19.8002 114.484 19.7882 114.468 19.7727 114.456 19.7546 114.445 19.7339 114.435 19.7126 114.426 19.6907L112.418 13.9809C112.395 13.9275 112.381 13.8711 112.375 13.8135 112.373 13.795 112.376 13.7764 112.384 13.7594 112.391 13.7423 112.403 13.7275 112.418 13.7162 112.458 13.6886 112.506 13.6737 112.555 13.6736 112.618 13.6736 112.703 13.6736 112.81 13.6736 112.881 13.6701 112.952 13.6701 113.023 13.6736 113.064 13.6755 113.104 13.6848 113.142 13.701 113.168 13.7103 113.192 13.7272 113.209 13.7497 113.224 13.7747 113.238 13.8012 113.248 13.8288L115.01 19.0002 116.722 13.8288C116.729 13.799 116.741 13.7703 116.756 13.7436 116.771 13.7187 116.795 13.7003 116.823 13.6919 116.866 13.6759 116.911 13.6667 116.957 13.6645 117.014 13.6645 117.09 13.6645 117.185 13.6645 117.262 13.6587 117.339 13.6587 117.416 13.6645 117.459 13.6654 117.501 13.6803 117.535 13.7071 117.545 13.721 117.552 13.7368 117.555 13.7535 117.559 13.7703 117.559 13.7876 117.556 13.8044 117.549 13.8627 117.534 13.9199 117.513 13.9748L115.515 19.6877zM122.697 19.5388C122.717 19.5937 122.73 19.651 122.736 19.7092 122.737 19.7271 122.735 19.745 122.728 19.7617 122.722 19.7785 122.712 19.7938 122.7 19.8065 122.663 19.8327 122.62 19.8475 122.575 19.8491 122.516 19.8491 122.437 19.8491 122.338 19.8491H122.103C122.059 19.8454 122.015 19.8372 121.973 19.8248 121.946 19.8163 121.923 19.8005 121.906 19.7792 121.888 19.7579 121.874 19.7343 121.863 19.7092L121.337 18.2125H118.782L118.277 19.6879C118.269 19.7151 118.256 19.7408 118.24 19.7639 118.22 19.7857 118.197 19.8033 118.17 19.8157 118.129 19.8315 118.086 19.8417 118.042 19.8461 117.97 19.8499 117.898 19.8499 117.826 19.8461 117.751 19.8516 117.676 19.8516 117.601 19.8461 117.556 19.8421 117.513 19.8264 117.477 19.8004 117.464 19.7877 117.455 19.7723 117.449 19.7555 117.443 19.7387 117.441 19.7208 117.443 19.7031 117.449 19.6455 117.463 19.5891 117.486 19.5358L119.551 13.8259C119.561 13.7938 119.579 13.7646 119.603 13.7407 119.626 13.7147 119.657 13.6966 119.691 13.689 119.74 13.6735 119.792 13.6643 119.843 13.6617 119.907 13.6617 119.983 13.6617 120.08 13.6617 120.178 13.6617 120.266 13.6617 120.33 13.6617 120.385 13.664 120.439 13.6732 120.491 13.689 120.527 13.6987 120.56 13.7164 120.589 13.7407 120.611 13.7667 120.629 13.7966 120.64 13.829L122.697 19.5388zM120.05 14.5012L118.991 17.5646H121.121L120.05 14.5012zM120.619 11.9855C120.65 11.9507 120.685 11.9191 120.722 11.8912 120.756 11.8691 120.793 11.8517 120.832 11.8395 120.88 11.8257 120.93 11.8176 120.981 11.8151 121.049 11.8116 121.117 11.8116 121.185 11.8151 121.259 11.814 121.334 11.8212 121.407 11.8364 121.449 11.8452 121.489 11.864 121.522 11.8912 121.533 11.9005 121.54 11.9126 121.544 11.9261 121.548 11.9396 121.548 11.9539 121.544 11.9672 121.531 12.0007 121.512 12.0315 121.489 12.0585L120.412 13.0654 120.324 13.1384C120.295 13.1579 120.263 13.1723 120.23 13.181 120.19 13.1933 120.149 13.2014 120.108 13.2054 120.052 13.2088 119.996 13.2088 119.941 13.2054 119.884 13.2112 119.827 13.2112 119.77 13.2054 119.738 13.204 119.708 13.191 119.685 13.1688 119.677 13.1608 119.671 13.1505 119.668 13.1391 119.665 13.1278 119.666 13.116 119.67 13.105 119.681 13.0713 119.698 13.0403 119.722 13.0137L120.619 11.9855zM128.373 19.493C128.376 19.5487 128.364 19.6041 128.34 19.6542 128.319 19.6955 128.292 19.7326 128.258 19.7637 128.224 19.7916 128.184 19.8123 128.142 19.8245 128.1 19.8366 128.057 19.8427 128.014 19.8428H127.743C127.669 19.8434 127.594 19.8353 127.521 19.8185 127.455 19.7983 127.393 19.7652 127.339 19.7211 127.273 19.668 127.216 19.6055 127.169 19.5355 127.101 19.4386 127.04 19.3369 126.986 19.2313L125.109 15.7361C125.012 15.5535 124.911 15.3649 124.805 15.1672 124.698 14.9695 124.61 14.7778 124.525 14.5892 124.525 14.8174 124.525 15.0516 124.54 15.2889 124.555 15.5262 124.54 15.7604 124.54 15.9946V19.7059C124.54 19.7284 124.534 19.7505 124.522 19.7698 124.505 19.7922 124.482 19.8092 124.455 19.8185L124.327 19.8458C124.262 19.8514 124.195 19.8514 124.13 19.8458 124.064 19.8512 123.998 19.8512 123.932 19.8458L123.81 19.8185C123.784 19.8092 123.76 19.7922 123.743 19.7698 123.732 19.7505 123.725 19.7284 123.725 19.7059V14.0356C123.719 13.9852 123.725 13.934 123.744 13.8867 123.762 13.8394 123.793 13.7975 123.831 13.7648 123.899 13.7118 123.983 13.6829 124.069 13.6827H124.47C124.55 13.6816 124.63 13.6898 124.708 13.707 124.769 13.7215 124.827 13.7484 124.878 13.7861 124.935 13.8279 124.985 13.8782 125.027 13.9352 125.081 14.0145 125.131 14.0968 125.176 14.1816L126.618 16.8799 126.873 17.3605 127.114 17.8259 127.339 18.2731 127.564 18.7172C127.564 18.4678 127.564 18.2062 127.564 17.9354 127.564 17.6647 127.564 17.4061 127.564 17.1536V13.8074C127.565 13.7855 127.572 13.7644 127.585 13.7466 127.602 13.7243 127.626 13.7074 127.652 13.6979 127.689 13.6897 127.727 13.6866 127.765 13.6888 127.833 13.685 127.901 13.685 127.969 13.6888 128.032 13.6853 128.096 13.6853 128.16 13.6888 128.203 13.6929 128.246 13.7042 128.285 13.7223 128.311 13.7317 128.333 13.7487 128.349 13.7709 128.363 13.7881 128.37 13.8096 128.37 13.8318L128.373 19.493zM135.151 16.6854C135.157 17.1397 135.098 17.5926 134.974 18.0299 134.874 18.4015 134.698 18.7483 134.457 19.049 134.22 19.3317 133.919 19.553 133.578 19.6939 132.795 19.9892 131.932 19.9957 131.144 19.7122 130.819 19.5822 130.532 19.3731 130.308 19.1038 130.075 18.8162 129.907 18.4822 129.815 18.1242 129.702 17.6852 129.648 17.233 129.654 16.7797 129.648 16.3334 129.708 15.8886 129.83 15.4594 129.933 15.0896 130.112 14.7455 130.357 14.4495 130.596 14.1702 130.897 13.9505 131.236 13.8076 132.012 13.515 132.867 13.5074 133.648 13.7863 133.973 13.9178 134.261 14.1267 134.488 14.3947 134.722 14.6785 134.892 15.0095 134.986 15.3651 135.102 15.7955 135.157 16.2398 135.151 16.6854zM134.287 16.7432C134.289 16.4163 134.258 16.09 134.193 15.7697 134.141 15.4935 134.037 15.2293 133.888 14.991 133.745 14.7713 133.545 14.5939 133.31 14.4769 133.032 14.3442 132.727 14.2805 132.419 14.2913 132.11 14.2816 131.804 14.3496 131.528 14.489 131.293 14.6179 131.092 14.8002 130.941 15.0214 130.785 15.2586 130.676 15.5227 130.618 15.8001 130.553 16.1061 130.52 16.4181 130.521 16.731 130.518 17.0658 130.549 17.4 130.612 17.7288 130.662 18.0084 130.766 18.2758 130.916 18.5167 131.058 18.7352 131.255 18.9117 131.488 19.0277 131.768 19.161 132.076 19.2247 132.386 19.2133 132.702 19.2253 133.016 19.1562 133.298 19.0125 133.535 18.884 133.737 18.6991 133.885 18.4741 134.036 18.2331 134.139 17.9657 134.189 17.6862 134.256 17.3722 134.289 17.052 134.287 16.731V16.7432zM142.062 19.4932C142.066 19.5428 142.066 19.5926 142.062 19.6422 142.058 19.6795 142.046 19.7156 142.029 19.7487 142.015 19.7729 141.997 19.7937 141.974 19.8095 141.953 19.8228 141.929 19.8302 141.904 19.8308H138.953C138.879 19.8291 138.807 19.8023 138.749 19.7548 138.713 19.7227 138.686 19.6826 138.668 19.6376 138.651 19.5926 138.644 19.5442 138.649 19.4962V14.0206C138.644 13.9726 138.651 13.9241 138.668 13.8792 138.686 13.8342 138.713 13.7941 138.749 13.762 138.807 13.7153 138.879 13.6896 138.953 13.689H141.871C141.895 13.6885 141.919 13.6949 141.941 13.7072 141.964 13.7222 141.981 13.7448 141.989 13.7711 142.004 13.8051 142.014 13.8409 142.02 13.8776 142.025 13.9302 142.025 13.9832 142.02 14.0358 142.025 14.0853 142.025 14.1353 142.02 14.1848 142.015 14.2207 142.005 14.2556 141.989 14.2883 141.98 14.3132 141.963 14.3345 141.941 14.3491 141.919 14.3615 141.895 14.3678 141.871 14.3674H139.467V16.296H141.53C141.554 16.2965 141.577 16.3039 141.597 16.3173 141.619 16.3331 141.638 16.3539 141.652 16.3781 141.667 16.4108 141.677 16.4457 141.682 16.4816 141.685 16.5342 141.685 16.5871 141.682 16.6397 141.685 16.6884 141.685 16.7372 141.682 16.7858 141.677 16.8206 141.667 16.8545 141.652 16.8862 141.638 16.9087 141.619 16.9275 141.597 16.9409 141.575 16.9458 141.552 16.9458 141.53 16.9409H139.467V19.1646H141.901C141.926 19.1637 141.951 19.1712 141.971 19.1859 141.994 19.2005 142.012 19.2203 142.026 19.2437 142.043 19.2759 142.054 19.3109 142.059 19.3471 142.063 19.3957 142.064 19.4445 142.062 19.4932zM145.877 19.6877C145.866 19.7194 145.848 19.7484 145.825 19.7729 145.798 19.7967 145.766 19.8143 145.731 19.8246 145.681 19.8385 145.63 19.8477 145.579 19.852H145.348 145.165C145.121 19.8557 145.076 19.8557 145.031 19.852 144.998 19.8476 144.966 19.8405 144.934 19.8307 144.909 19.8248 144.885 19.8145 144.864 19.8002 144.846 19.7882 144.83 19.7727 144.818 19.7546 144.807 19.7339 144.797 19.7126 144.788 19.6907L142.78 13.9809C142.758 13.9275 142.743 13.8711 142.738 13.8135 142.736 13.795 142.739 13.7764 142.746 13.7594 142.754 13.7423 142.765 13.7275 142.78 13.7162 142.82 13.6886 142.868 13.6737 142.917 13.6736 142.98 13.6736 143.065 13.6736 143.173 13.6736 143.243 13.6701 143.315 13.6701 143.385 13.6736 143.426 13.6755 143.467 13.6848 143.504 13.701 143.531 13.7103 143.554 13.7272 143.571 13.7497 143.587 13.7747 143.6 13.8012 143.611 13.8288L145.372 19.0002 147.088 13.8288C147.094 13.7991 147.104 13.7705 147.118 13.7436 147.134 13.7194 147.158 13.7012 147.185 13.6919 147.228 13.6759 147.273 13.6667 147.319 13.6645 147.377 13.6645 147.453 13.6645 147.547 13.6645 147.624 13.6587 147.701 13.6587 147.778 13.6645 147.821 13.6654 147.863 13.6803 147.897 13.7071 147.907 13.721 147.914 13.7368 147.918 13.7535 147.921 13.7703 147.921 13.7876 147.918 13.8044 147.911 13.8627 147.897 13.9199 147.876 13.9748L145.877 19.6877zM153.014 19.7063C153.015 19.7296 153.01 19.7528 152.998 19.7732 152.985 19.7958 152.963 19.8122 152.938 19.8189 152.895 19.8364 152.85 19.8467 152.804 19.8493 152.728 19.8532 152.652 19.8532 152.576 19.8493 152.509 19.853 152.442 19.853 152.375 19.8493 152.332 19.8446 152.29 19.8344 152.25 19.8189 152.22 19.8055 152.194 19.7845 152.174 19.758 152.156 19.7283 152.142 19.6966 152.131 19.6637L151.566 18.2157C151.499 18.0514 151.429 17.9115 151.359 17.7625 151.292 17.6304 151.206 17.5093 151.103 17.4035 151.004 17.304 150.886 17.2254 150.756 17.1723 150.604 17.1139 150.442 17.086 150.279 17.0902H149.731V19.7063C149.732 19.7304 149.725 19.7541 149.71 19.7732 149.692 19.7939 149.669 19.8096 149.643 19.8189L149.521 19.8462C149.456 19.8516 149.389 19.8516 149.324 19.8462 149.258 19.8516 149.192 19.8516 149.126 19.8462L149.001 19.8189C148.975 19.8111 148.951 19.7951 148.934 19.7732 148.922 19.7532 148.915 19.7299 148.916 19.7063V14.0147C148.911 13.967 148.917 13.9187 148.934 13.8737 148.95 13.8288 148.978 13.7885 149.013 13.7561 149.071 13.7099 149.143 13.6842 149.217 13.6831H150.525C150.68 13.6831 150.808 13.6831 150.912 13.6831L151.191 13.7074C151.408 13.7434 151.619 13.8089 151.818 13.9021 151.99 13.9861 152.146 14.1005 152.277 14.2398 152.401 14.3752 152.495 14.5347 152.554 14.7083 152.619 14.895 152.651 15.0916 152.649 15.2893 152.652 15.4771 152.624 15.6641 152.566 15.8429 152.513 16.0001 152.431 16.1464 152.326 16.2749 152.219 16.4029 152.091 16.5128 151.949 16.6004 151.795 16.6977 151.631 16.7763 151.459 16.8346 151.559 16.8765 151.652 16.9329 151.736 17.0019 151.821 17.0759 151.899 17.1585 151.967 17.2483 152.042 17.3516 152.109 17.4604 152.168 17.5738 152.233 17.6976 152.297 17.8375 152.36 17.9936L152.91 19.3473C152.953 19.4599 152.983 19.542 152.995 19.5877 153.007 19.6262 153.013 19.6661 153.014 19.7063zM151.797 15.3897C151.803 15.1756 151.747 14.9643 151.636 14.7813 151.505 14.5993 151.312 14.4715 151.094 14.4223 151.005 14.3986 150.915 14.3823 150.823 14.3736 150.726 14.3736 150.595 14.3736 150.431 14.3736H149.728V16.427H150.525C150.715 16.4303 150.904 16.4036 151.085 16.3479 151.235 16.3024 151.374 16.2257 151.493 16.1228 151.593 16.0309 151.672 15.9176 151.724 15.7912 151.772 15.6629 151.797 15.5268 151.797 15.3897zM159.247 16.6856C159.252 17.1398 159.194 17.5924 159.073 18.0302 158.97 18.4024 158.79 18.7493 158.547 19.0493 158.311 19.3318 158.011 19.5531 157.671 19.6942 156.887 19.9887 156.025 19.9951 155.237 19.7125 154.913 19.5815 154.625 19.3725 154.401 19.104 154.176 18.8177 154.014 18.487 153.926 18.1336 153.811 17.6949 153.757 17.2425 153.765 16.7891 153.76 16.343 153.818 15.8985 153.938 15.4688 154.043 15.0992 154.223 14.7553 154.468 14.4589 154.706 14.1789 155.007 13.9591 155.347 13.817 155.733 13.6615 156.147 13.585 156.564 13.5919 156.967 13.5841 157.369 13.6532 157.747 13.7957 158.071 13.9281 158.358 14.1368 158.583 14.4041 158.823 14.6822 158.998 15.0093 159.098 15.3624 159.207 15.7947 159.257 16.2399 159.247 16.6856zM158.383 16.7434C158.385 16.4167 158.354 16.0906 158.291 15.77 158.239 15.4938 158.136 15.2296 157.987 14.9912 157.845 14.7717 157.646 14.5942 157.412 14.4771 157.134 14.3448 156.829 14.2812 156.521 14.2916 156.212 14.2809 155.905 14.349 155.63 14.4893 155.394 14.6173 155.193 14.7998 155.043 15.0217 154.886 15.2582 154.777 15.5226 154.72 15.8004 154.653 16.1061 154.62 16.4183 154.623 16.7313 154.621 17.0659 154.65 17.4 154.711 17.7291 154.763 18.0083 154.866 18.2754 155.015 18.5169 155.157 18.7348 155.355 18.9112 155.587 19.028 155.872 19.1631 156.185 19.2268 156.5 19.2136 156.816 19.2258 157.13 19.1567 157.412 19.0128 157.65 18.8851 157.852 18.7 157.999 18.4743 158.154 18.2338 158.262 17.9666 158.319 17.6865 158.374 17.3713 158.396 17.051 158.383 16.7313V16.7434zM164.318 15.484C164.322 15.7681 164.27 16.0502 164.166 16.3145 164.068 16.5545 163.92 16.7704 163.731 16.9472 163.533 17.1226 163.303 17.2561 163.052 17.3396 162.735 17.4424 162.403 17.4908 162.07 17.4826H161.373V19.6972C161.373 19.7211 161.365 19.7443 161.352 19.7641 161.334 19.7848 161.311 19.8005 161.285 19.8097L161.16 19.8371C161.094 19.8425 161.028 19.8425 160.962 19.8371 160.898 19.8426 160.832 19.8426 160.768 19.8371L160.64 19.8097C160.614 19.8013 160.59 19.7854 160.573 19.7641 160.561 19.744 160.554 19.7208 160.555 19.6972V14.036C160.55 13.9862 160.556 13.9358 160.573 13.8889 160.591 13.8419 160.619 13.7996 160.655 13.7652 160.717 13.7122 160.796 13.6831 160.877 13.6831H162.194C162.325 13.6831 162.453 13.6831 162.575 13.6983 162.721 13.7142 162.866 13.7386 163.01 13.7713 163.188 13.8129 163.36 13.8816 163.518 13.9751 163.684 14.0707 163.833 14.1954 163.956 14.3432 164.079 14.4924 164.173 14.6638 164.233 14.8482 164.296 15.0539 164.325 15.2688 164.318 15.484zM163.457 15.5509C163.464 15.3336 163.416 15.118 163.317 14.9242 163.237 14.7699 163.117 14.6397 162.97 14.547 162.839 14.467 162.693 14.4142 162.541 14.3919 162.399 14.3689 162.256 14.3577 162.112 14.3584H161.358V16.8225H162.094C162.301 16.8282 162.507 16.7962 162.702 16.7282 162.855 16.6724 162.993 16.5838 163.108 16.4687 163.223 16.3536 163.311 16.2148 163.366 16.062 163.424 15.8979 163.455 15.7252 163.457 15.5509zM168.865 18.1063C168.871 18.3714 168.816 18.6343 168.707 18.8759 168.604 19.0966 168.453 19.2918 168.266 19.4478 168.074 19.6061 167.853 19.7259 167.615 19.8007 167.348 19.8816 167.07 19.9216 166.791 19.9193 166.599 19.9215 166.407 19.9042 166.219 19.8676 166.059 19.8386 165.903 19.7959 165.75 19.7398 165.63 19.6977 165.514 19.6448 165.404 19.5817 165.332 19.5461 165.267 19.5 165.209 19.4448 165.17 19.4037 165.142 19.3535 165.127 19.2987 165.106 19.2224 165.097 19.1435 165.099 19.0645 165.096 19.0068 165.096 18.9489 165.099 18.8911 165.106 18.8528 165.116 18.8151 165.13 18.7786 165.138 18.7556 165.154 18.7359 165.174 18.7223 165.194 18.7086 165.218 18.7017 165.242 18.7025 165.312 18.7119 165.377 18.7403 165.431 18.7846 165.529 18.849 165.631 18.9079 165.735 18.9611 165.883 19.0325 166.037 19.0915 166.195 19.1375 166.392 19.1967 166.597 19.2254 166.803 19.2227 166.974 19.2316 167.146 19.2121 167.311 19.1649 167.45 19.1235 167.579 19.0553 167.691 18.9641 167.796 18.877 167.88 18.7666 167.935 18.6417 167.994 18.5057 168.023 18.3582 168.02 18.2097 168.025 18.0532 167.983 17.8988 167.901 17.7656 167.822 17.6381 167.719 17.5275 167.597 17.4401 167.458 17.3398 167.309 17.2532 167.153 17.1815L166.642 16.9442C166.468 16.8641 166.298 16.7747 166.134 16.6765 165.972 16.5809 165.824 16.4643 165.693 16.3297 165.565 16.1922 165.462 16.0338 165.388 15.8613 165.304 15.6581 165.262 15.4395 165.267 15.2194 165.263 14.9828 165.311 14.7483 165.407 14.5319 165.498 14.3368 165.631 14.1644 165.796 14.0269 165.977 13.8871 166.184 13.7838 166.404 13.7227 166.645 13.6506 166.895 13.6147 167.147 13.6163 167.284 13.6163 167.422 13.6285 167.557 13.6528 167.689 13.6752 167.819 13.7067 167.947 13.7471 168.059 13.7829 168.168 13.8276 168.272 13.8809 168.34 13.9121 168.403 13.9519 168.461 13.9996 168.483 14.0206 168.502 14.044 168.519 14.0695 168.531 14.0901 168.539 14.1128 168.543 14.1364 168.55 14.1685 168.555 14.201 168.558 14.2338 168.558 14.2733 168.558 14.322 168.558 14.3828 168.561 14.4335 168.561 14.4843 168.558 14.5349 168.554 14.572 168.547 14.6086 168.537 14.6445 168.53 14.6698 168.516 14.6928 168.497 14.7114 168.48 14.7254 168.459 14.7329 168.437 14.7327 168.377 14.7235 168.321 14.7006 168.272 14.6658 168.199 14.6232 168.108 14.5715 168.002 14.5167 167.878 14.4559 167.75 14.405 167.618 14.3646 167.457 14.3177 167.29 14.2952 167.122 14.2977 166.971 14.2938 166.819 14.3164 166.675 14.3646 166.563 14.405 166.459 14.467 166.371 14.5471 166.289 14.6218 166.226 14.7145 166.185 14.8179 166.144 14.9244 166.123 15.038 166.125 15.1525 166.121 15.3079 166.162 15.4611 166.243 15.5936 166.324 15.7206 166.427 15.8319 166.547 15.9221 166.688 16.0217 166.838 16.1083 166.995 16.1807 167.162 16.2628 167.332 16.3419 167.509 16.421 167.685 16.5001 167.852 16.5914 168.02 16.6887 168.184 16.7816 168.336 16.8962 168.47 17.0294 168.599 17.165 168.702 17.3227 168.774 17.4948 168.846 17.6902 168.877 17.8984 168.865 18.1063zM174.043 19.6972C174.049 19.7201 174.049 19.7442 174.043 19.7672 174.027 19.7894 174.005 19.8064 173.979 19.8158 173.937 19.8295 173.895 19.8397 173.851 19.8463 173.781 19.8517 173.711 19.8517 173.641 19.8463 173.551 19.8521 173.461 19.8521 173.371 19.8463 173.315 19.8412 173.261 19.8235 173.212 19.7945 173.18 19.7701 173.152 19.7414 173.127 19.7094L170.867 16.6369V19.7094C170.867 19.7349 170.859 19.7598 170.844 19.7802 170.828 19.8005 170.807 19.8152 170.782 19.8219L170.657 19.8493C170.591 19.8547 170.525 19.8547 170.459 19.8493 170.395 19.8546 170.33 19.8546 170.265 19.8493L170.137 19.8219C170.12 19.8208 170.103 19.8158 170.087 19.8074 170.072 19.799 170.059 19.7873 170.049 19.7732 170.036 19.7545 170.029 19.7321 170.03 19.7094V13.8079C170.028 13.7841 170.035 13.7602 170.049 13.7409 170.065 13.7181 170.089 13.7019 170.116 13.6953 170.157 13.6807 170.2 13.6715 170.243 13.6679 170.308 13.6626 170.373 13.6626 170.438 13.6679 170.504 13.6626 170.57 13.6626 170.636 13.6679 170.678 13.6722 170.72 13.6813 170.761 13.6953 170.787 13.7026 170.811 13.7187 170.828 13.7409 170.84 13.7608 170.847 13.7842 170.846 13.8079V16.5457L173.021 13.8079C173.038 13.7794 173.061 13.7546 173.088 13.7348 173.117 13.7149 173.148 13.6995 173.182 13.6892 173.225 13.6783 173.269 13.6701 173.313 13.6649 173.381 13.661 173.449 13.661 173.517 13.6649 173.582 13.6592 173.649 13.6592 173.714 13.6649 173.756 13.668 173.798 13.6783 173.836 13.6953 173.861 13.7028 173.883 13.7189 173.897 13.7409 173.909 13.7601 173.915 13.7822 173.915 13.8048 173.914 13.847 173.903 13.8885 173.885 13.9265 173.851 13.9868 173.811 14.0439 173.766 14.0968L171.728 16.5305 173.93 19.469C173.968 19.5227 174.001 19.5797 174.028 19.6394 174.036 19.6577 174.041 19.6772 174.043 19.6972zM179.783 16.6854C179.789 17.1398 179.73 17.5927 179.607 18.03 179.504 18.402 179.326 18.7489 179.084 19.0491 178.847 19.331 178.547 19.5522 178.207 19.694 177.424 19.9885 176.562 19.9949 175.774 19.7123 175.449 19.5813 175.162 19.3723 174.937 19.1038 174.706 18.8162 174.539 18.4821 174.448 18.1243 174.333 17.6856 174.279 17.2332 174.286 16.7797 174.281 16.3337 174.34 15.8891 174.46 15.4595 174.564 15.0899 174.745 14.746 174.989 14.4496 175.228 14.1696 175.529 13.9497 175.868 13.8077 176.255 13.6522 176.668 13.5757 177.085 13.5826 177.489 13.575 177.89 13.6442 178.268 13.7864 178.592 13.9188 178.879 14.1275 179.105 14.3948 179.34 14.6778 179.511 15.0091 179.604 15.3652 179.724 15.7949 179.785 16.2392 179.783 16.6854zM178.919 16.7432C178.921 16.4165 178.891 16.0904 178.828 15.7698 178.775 15.4939 178.672 15.2301 178.524 14.991 178.381 14.7715 178.183 14.5941 177.949 14.4769 177.667 14.345 177.357 14.2834 177.045 14.2975 176.736 14.2877 176.43 14.3557 176.154 14.4952 175.92 14.6233 175.719 14.8058 175.57 15.0275 175.412 15.2634 175.303 15.5281 175.248 15.8063 175.181 16.112 175.148 16.4242 175.15 16.7372 175.148 17.0718 175.178 17.4058 175.238 17.7349 175.289 18.0145 175.392 18.2819 175.543 18.5228 175.685 18.7407 175.882 18.917 176.115 19.0339 176.399 19.1694 176.712 19.2331 177.027 19.2194 177.344 19.2317 177.658 19.1626 177.94 19.0187 178.177 18.8902 178.378 18.7052 178.527 18.4802 178.681 18.2396 178.789 17.9725 178.846 17.6924 178.903 17.3753 178.925 17.053 178.913 16.7311L178.919 16.7432zM185.691 17.5587C185.697 17.8994 185.641 18.2384 185.527 18.5595 185.427 18.8375 185.268 19.0906 185.061 19.3018 184.852 19.5122 184.598 19.6732 184.319 19.7733 184 19.881 183.664 19.9335 183.327 19.9284 183.017 19.9306 182.709 19.8812 182.415 19.7824 182.147 19.6911 181.902 19.5427 181.697 19.3474 181.491 19.1449 181.334 18.8984 181.237 18.6264 181.123 18.3064 181.069 17.9683 181.076 17.6286V13.8079C181.075 13.7842 181.082 13.7609 181.094 13.7409 181.11 13.7182 181.134 13.702 181.161 13.6953 181.201 13.6813 181.241 13.6721 181.283 13.6679 181.414 13.6517 181.547 13.6517 181.678 13.6679 181.721 13.6711 181.763 13.6803 181.803 13.6953 181.829 13.7026 181.852 13.7187 181.867 13.7409 181.882 13.7598 181.89 13.7837 181.888 13.8079V17.5222C181.883 17.7745 181.918 18.026 181.992 18.2675 182.053 18.4641 182.157 18.6448 182.296 18.7968 182.429 18.937 182.591 19.046 182.771 19.1162 183.178 19.2581 183.622 19.2581 184.03 19.1162 184.209 19.0529 184.37 18.9487 184.501 18.812 184.638 18.6631 184.742 18.4868 184.806 18.2948 184.876 18.0612 184.91 17.818 184.906 17.5739V13.8079C184.905 13.7842 184.911 13.7609 184.924 13.7409 184.93 13.7217 184.941 13.704 184.955 13.6892 184.996 13.6753 185.039 13.6661 185.082 13.6618 185.147 13.6564 185.212 13.6564 185.277 13.6618 185.342 13.6565 185.407 13.6565 185.472 13.6618 185.513 13.6657 185.554 13.6749 185.593 13.6892 185.62 13.6973 185.643 13.7132 185.66 13.7349 185.676 13.7537 185.683 13.7776 185.682 13.8018L185.691 17.5587zM194.133 17.5587C194.138 17.8994 194.083 18.2384 193.968 18.5595 193.868 18.8382 193.708 19.0916 193.5 19.3018 193.292 19.5128 193.039 19.674 192.761 19.7733 192.44 19.8812 192.104 19.9337 191.766 19.9284 191.456 19.9309 191.147 19.8816 190.853 19.7824 190.581 19.6897 190.333 19.538 190.126 19.3383 189.919 19.1366 189.762 18.8898 189.667 18.6173 189.553 18.2973 189.498 17.9592 189.506 17.6195V13.8079C189.505 13.7842 189.511 13.7609 189.524 13.7409 189.54 13.7182 189.564 13.702 189.591 13.6953 189.63 13.681 189.671 13.6718 189.712 13.6679 189.844 13.6517 189.977 13.6517 190.108 13.6679 190.15 13.6715 190.192 13.6807 190.233 13.6953 190.257 13.7025 190.278 13.7173 190.294 13.7375 190.309 13.7578 190.318 13.7825 190.318 13.8079V17.5222C190.313 17.7745 190.348 18.026 190.421 18.2675 190.483 18.4641 190.586 18.6448 190.725 18.7968 190.858 18.9376 191.02 19.0468 191.2 19.1162 191.401 19.1895 191.613 19.2255 191.827 19.2227 192.042 19.2258 192.257 19.1897 192.459 19.1162 192.638 19.0529 192.8 18.9487 192.931 18.812 193.069 18.6639 193.173 18.4874 193.235 18.2948 193.308 18.0617 193.343 17.8182 193.339 17.5739V13.8079C193.338 13.7842 193.344 13.7609 193.357 13.7409 193.373 13.7187 193.397 13.7027 193.424 13.6953 193.464 13.681 193.506 13.6718 193.548 13.6679 193.614 13.6626 193.68 13.6626 193.746 13.6679 193.81 13.6626 193.874 13.6626 193.938 13.6679 193.98 13.6715 194.022 13.6807 194.063 13.6953 194.089 13.7034 194.112 13.7193 194.129 13.7409 194.145 13.7598 194.152 13.7837 194.151 13.8079L194.133 17.5587zM200.399 19.493C200.401 19.5438 200.391 19.5945 200.371 19.6412 200.351 19.688 200.321 19.7299 200.283 19.7637 200.249 19.791 200.21 19.8117 200.168 19.8246 200.126 19.8366 200.083 19.8428 200.04 19.8428H199.769C199.694 19.8435 199.618 19.8353 199.544 19.8185 199.478 19.7989 199.417 19.7658 199.365 19.7212 199.299 19.6674 199.241 19.605 199.191 19.5356 199.123 19.4386 199.062 19.337 199.009 19.2314L197.123 15.7361C197.022 15.5536 196.925 15.365 196.819 15.1673 196.712 14.9695 196.627 14.7779 196.542 14.5893 196.542 14.8174 196.542 15.0517 196.542 15.2889 196.542 15.5262 196.542 15.7604 196.542 15.9947V19.7059C196.542 19.729 196.534 19.7514 196.52 19.7698 196.505 19.7936 196.481 19.8108 196.454 19.8185L196.329 19.8459C196.198 19.8621 196.065 19.8621 195.933 19.8459L195.809 19.8185C195.785 19.8105 195.764 19.7955 195.749 19.7754 195.733 19.7553 195.725 19.7311 195.723 19.7059V14.0356C195.718 13.9849 195.724 13.9336 195.744 13.8863 195.763 13.8389 195.794 13.7972 195.833 13.7649 195.9 13.7121 195.982 13.6832 196.067 13.6827H196.469C196.55 13.6815 196.63 13.6897 196.709 13.7071 196.77 13.7221 196.828 13.749 196.879 13.7862 196.936 13.8271 196.986 13.8775 197.025 13.9352 197.081 14.0139 197.131 14.0962 197.175 14.1816L198.644 16.8799 198.902 17.3605 199.14 17.826C199.217 17.9781 199.293 18.1271 199.368 18.2732L199.59 18.7173C199.59 18.4678 199.59 18.2062 199.59 17.9355 199.59 17.6648 199.59 17.4062 199.59 17.1537V13.8075C199.59 13.7853 199.597 13.7638 199.611 13.7466 199.628 13.7236 199.651 13.7065 199.678 13.698 199.718 13.6799 199.76 13.6686 199.803 13.6645 199.871 13.6607 199.939 13.6607 200.007 13.6645 200.069 13.6609 200.132 13.6609 200.195 13.6645 200.239 13.6682 200.283 13.6796 200.323 13.698 200.348 13.7083 200.37 13.7251 200.387 13.7466 200.4 13.7644 200.407 13.7855 200.408 13.8075L200.399 19.493zM202.848 19.706C202.848 19.7296 202.842 19.7529 202.83 19.7729 202.813 19.7948 202.789 19.8108 202.763 19.8186L202.638 19.8459C202.508 19.8622 202.376 19.8622 202.246 19.8459L202.118 19.8186C202.091 19.8108 202.068 19.7948 202.051 19.7729 202.038 19.7529 202.032 19.7296 202.033 19.706V13.8075C202.031 13.7833 202.039 13.7595 202.054 13.7406 202.071 13.7176 202.096 13.7015 202.124 13.695 202.165 13.681 202.208 13.6719 202.252 13.6676 202.314 13.6624 202.378 13.6624 202.44 13.6676 202.506 13.6622 202.572 13.6622 202.638 13.6676 202.681 13.6715 202.722 13.6807 202.763 13.695 202.79 13.7016 202.814 13.7178 202.83 13.7406 202.842 13.7605 202.849 13.7839 202.848 13.8075V19.706zM205.3 19.7061C205.3 19.7297 205.294 19.753 205.281 19.7731 205.264 19.7944 205.241 19.8103 205.215 19.8187L205.09 19.8461C205.024 19.8514 204.958 19.8514 204.892 19.8461 204.827 19.8514 204.762 19.8514 204.697 19.8461L204.57 19.8187C204.543 19.8109 204.52 19.795 204.503 19.7731 204.49 19.753 204.484 19.7297 204.484 19.7061V13.8077C204.483 13.7835 204.491 13.7596 204.506 13.7407 204.523 13.7178 204.548 13.7016 204.576 13.6951 204.617 13.6812 204.66 13.672 204.703 13.6677 204.766 13.6625 204.829 13.6625 204.892 13.6677 204.958 13.6624 205.024 13.6624 205.09 13.6677 205.132 13.6716 205.174 13.6808 205.215 13.6951 205.241 13.7025 205.265 13.7185 205.281 13.7407 205.294 13.7607 205.301 13.784 205.3 13.8077V19.7061zM205.437 11.9855C205.468 11.9507 205.503 11.9191 205.54 11.8912 205.575 11.8686 205.613 11.8511 205.653 11.8395 205.7 11.8255 205.749 11.8173 205.799 11.8151 205.866 11.8116 205.934 11.8116 206.002 11.8151 206.078 11.8142 206.153 11.8214 206.227 11.8364 206.269 11.8459 206.307 11.8646 206.34 11.8912 206.351 11.9005 206.358 11.9126 206.362 11.9261 206.366 11.9396 206.365 11.9539 206.361 11.9672 206.35 12.0013 206.331 12.0324 206.307 12.0585L205.23 13.0654C205.202 13.0919 205.173 13.1163 205.142 13.1384 205.113 13.1579 205.081 13.1723 205.047 13.181 205.009 13.1932 204.969 13.2014 204.929 13.2053 204.872 13.2087 204.815 13.2087 204.758 13.2053 204.702 13.2112 204.645 13.2112 204.588 13.2053 204.556 13.204 204.526 13.191 204.503 13.1688 204.498 13.159 204.495 13.148 204.495 13.1369 204.495 13.1258 204.498 13.1148 204.503 13.105 204.514 13.0713 204.531 13.0403 204.554 13.0137L205.437 11.9855zM81.0971 33.6083C81.12 33.6626 81.1343 33.72 81.1397 33.7786 81.1408 33.7965 81.1381 33.8144 81.1318 33.8312 81.1255 33.848 81.1158 33.8632 81.1032 33.876 81.066 33.9007 81.0231 33.9154 80.9785 33.9186 80.9177 33.9186 80.8416 33.9186 80.7412 33.9186 80.6408 33.9186 80.5648 33.9186 80.507 33.9186 80.4617 33.9167 80.4168 33.9095 80.3731 33.8973 80.3473 33.888 80.3243 33.8723 80.3062 33.8516 80.2911 33.8284 80.2779 33.804 80.2667 33.7786L79.7404 32.282H77.1851L76.6801 33.7665C76.6717 33.7925 76.6594 33.8171 76.6436 33.8395 76.6257 33.863 76.6014 33.881 76.5737 33.8912 76.5328 33.9082 76.4898 33.9195 76.4459 33.9247 76.374 33.9284 76.3019 33.9284 76.2299 33.9247 76.1549 33.9286 76.0798 33.9286 76.0048 33.9247 75.9598 33.9213 75.9166 33.9055 75.8801 33.879 75.8677 33.8662 75.8583 33.8509 75.8526 33.8341 75.8468 33.8172 75.8448 33.7994 75.8466 33.7817 75.8525 33.7235 75.8658 33.6662 75.8862 33.6113L77.9487 27.9045C77.9596 27.8718 77.9772 27.8418 78.0004 27.8163 78.0253 27.7923 78.0555 27.7746 78.0886 27.7646 78.1381 27.7503 78.1892 27.7422 78.2407 27.7402 78.3046 27.7402 78.3806 27.7402 78.478 27.7402 78.5753 27.7402 78.6605 27.7402 78.7274 27.7402 78.7819 27.7417 78.8361 27.7499 78.8886 27.7646 78.9248 27.7751 78.9582 27.7939 78.986 27.8193 79.0085 27.8453 79.026 27.8752 79.0377 27.9075L81.0971 33.6083zM78.4536 28.5677L77.3889 31.6371H79.5183L78.4536 28.5677zM85.6602 33.5565C85.6639 33.6081 85.6639 33.66 85.6602 33.7116 85.6559 33.7485 85.6457 33.7845 85.6297 33.8181 85.6194 33.8434 85.6013 33.8647 85.578 33.8789 85.5557 33.8913 85.5305 33.8976 85.505 33.8972H81.8637C81.8268 33.8989 81.79 33.893 81.7555 33.8799 81.721 33.8668 81.6895 33.8468 81.663 33.8211 81.6073 33.754 81.58 33.6678 81.5869 33.5808V33.4044C81.5837 33.3659 81.5837 33.3272 81.5869 33.2888 81.5921 33.2511 81.6023 33.2142 81.6173 33.1793 81.6353 33.1326 81.6577 33.0878 81.6843 33.0454 81.7116 32.9967 81.7451 32.9389 81.7877 32.872L84.6228 28.4367H81.8303C81.8016 28.4362 81.7735 28.4289 81.7481 28.4154 81.7248 28.4018 81.7058 28.3817 81.6934 28.3576 81.6784 28.3248 81.6681 28.29 81.663 28.2542 81.6596 28.2036 81.6596 28.1528 81.663 28.1021 81.6594 28.0484 81.6594 27.9946 81.663 27.9409 81.6687 27.9033 81.6789 27.8665 81.6934 27.8314 81.7059 27.8066 81.7248 27.7856 81.7481 27.7705 81.7737 27.7581 81.8018 27.7519 81.8303 27.7523H85.2495C85.3244 27.7486 85.3977 27.7749 85.4533 27.8253 85.4799 27.856 85.5001 27.8918 85.5126 27.9305 85.5251 27.9691 85.5298 28.0099 85.5263 28.0504V28.236C85.5296 28.2815 85.5296 28.3273 85.5263 28.3729 85.519 28.4134 85.5078 28.4531 85.4929 28.4915 85.4741 28.5373 85.4528 28.582 85.429 28.6253 85.4016 28.674 85.3651 28.7288 85.3225 28.7927L82.4995 33.2097H85.4807C85.5065 33.2094 85.5318 33.2167 85.5535 33.2308 85.5751 33.2449 85.5922 33.265 85.6024 33.2888 85.6428 33.3721 85.6626 33.4639 85.6602 33.5565zM88.6047 31.509V33.7662C88.6052 33.7902 88.5977 33.8137 88.5835 33.8331 88.5678 33.8543 88.5452 33.8694 88.5196 33.8757 88.4779 33.8893 88.4352 33.8995 88.3918 33.9061 88.327 33.9098 88.262 33.9098 88.1971 33.9061 88.1323 33.91 88.0673 33.91 88.0024 33.9061 87.9591 33.8995 87.9163 33.8893 87.8747 33.8757 87.8471 33.87 87.8224 33.8549 87.8047 33.8331 87.7927 33.8128 87.7864 33.7897 87.7864 33.7662V31.4998L86.0494 28.0319C86.0209 27.9778 85.9984 27.9207 85.9825 27.8616 85.978 27.8446 85.9778 27.8268 85.9821 27.8098 85.9863 27.7927 85.9949 27.7771 86.0069 27.7642 86.0449 27.739 86.089 27.7243 86.1346 27.7217 86.1985 27.7217 86.2806 27.7217 86.3841 27.7217 86.4611 27.7178 86.5383 27.7178 86.6153 27.7217 86.6626 27.727 86.7094 27.7361 86.7552 27.749 86.7856 27.7575 86.8131 27.7743 86.8343 27.7977 86.8542 27.8205 86.8706 27.8461 86.883 27.8738L87.7347 29.6412C87.8138 29.8115 87.8929 29.9849 87.972 30.1705 88.0511 30.356 88.1302 30.5386 88.2123 30.7241 88.2853 30.5447 88.3583 30.3652 88.4374 30.1857 88.5165 30.0062 88.5926 29.8298 88.6717 29.6564L89.5265 27.8798C89.5346 27.8503 89.548 27.8225 89.566 27.7977 89.5854 27.7764 89.6093 27.7598 89.636 27.749 89.6776 27.7359 89.7204 27.7267 89.7638 27.7217 89.8316 27.7179 89.8997 27.7179 89.9676 27.7217 90.0801 27.7217 90.1714 27.7217 90.2353 27.7217 90.2839 27.7257 90.3309 27.7413 90.3722 27.7673 90.3847 27.7791 90.3937 27.7942 90.398 27.8109 90.4023 27.8276 90.4018 27.8452 90.3965 27.8616 90.3843 27.9204 90.3627 27.9769 90.3326 28.0289L88.6047 31.509zM94.5733 33.5411C94.5768 33.5948 94.5768 33.6487 94.5733 33.7023 94.569 33.7393 94.5588 33.7752 94.5428 33.8088 94.5323 33.8356 94.5143 33.8588 94.4911 33.8757 94.4697 33.8904 94.4441 33.8979 94.4181 33.897H91.7016C91.6264 33.8964 91.5536 33.8707 91.4947 33.824 91.4592 33.7917 91.4319 33.7514 91.415 33.7064 91.3981 33.6615 91.3921 33.6132 91.3974 33.5654V27.8738C91.3973 27.8503 91.4036 27.8272 91.4156 27.8069 91.432 27.785 91.4558 27.7699 91.4826 27.7643 91.524 27.7499 91.5668 27.7398 91.6103 27.7339 91.6752 27.7302 91.7402 27.7302 91.805 27.7339 91.8709 27.73 91.9369 27.73 92.0027 27.7339 92.0452 27.7401 92.087 27.7502 92.1275 27.7643 92.1542 27.7699 92.178 27.785 92.1944 27.8069 92.2064 27.8272 92.2127 27.8503 92.2126 27.8738V33.1913H94.4181C94.4441 33.1904 94.4697 33.1979 94.4911 33.2126 94.5136 33.2278 94.5314 33.2488 94.5428 33.2734 94.5594 33.3067 94.5697 33.3428 94.5733 33.3799 94.5768 33.4336 94.5768 33.4874 94.5733 33.5411zM100.411 30.755C100.416 31.2091 100.358 31.6617 100.238 32.0995 100.133 32.4715 99.9541 32.8182 99.7113 33.1186 99.4757 33.402 99.1751 33.6243 98.8352 33.7666 98.4486 33.9221 98.0349 33.9986 97.6183 33.9917 97.2082 34.0005 96.8003 33.9303 96.4167 33.7848 96.0924 33.6549 95.8058 33.4457 95.5832 33.1764 95.3491 32.8912 95.1808 32.5577 95.0904 32.1999 94.9772 31.7609 94.923 31.3087 94.9292 30.8554 94.9235 30.409 94.9829 29.9643 95.1056 29.5351 95.2083 29.1653 95.3876 28.8212 95.6319 28.5252 95.8706 28.2452 96.1717 28.0254 96.511 27.8833 97.2872 27.5907 98.1421 27.5831 98.9234 27.862 99.2483 27.9941 99.5363 28.2028 99.763 28.4704 99.9973 28.7541 100.167 29.0852 100.262 29.4408 100.371 29.87 100.422 30.3122 100.411 30.755zM99.547 30.8097C99.5491 30.484 99.5185 30.1589 99.4557 29.8393 99.4043 29.5629 99.3011 29.2987 99.1515 29.0606 99.0068 28.8411 98.8077 28.663 98.5735 28.5434 98.2948 28.4136 97.9895 28.3511 97.6822 28.3609 97.3732 28.3502 97.0665 28.4183 96.7909 28.5586 96.5555 28.6866 96.3541 28.8692 96.2038 29.091 96.048 29.3267 95.9386 29.59 95.8813 29.8667 95.816 30.1737 95.7833 30.4867 95.784 30.8006 95.7815 31.1354 95.8121 31.4696 95.8753 31.7984 95.926 32.0779 96.0293 32.3452 96.1795 32.5863 96.3174 32.8022 96.5093 32.9783 96.7362 33.0973 97.0215 33.2299 97.3344 33.2925 97.6488 33.2798 97.9647 33.2915 98.2786 33.2235 98.5614 33.0821 98.8 32.9535 99.0029 32.7674 99.1515 32.5406 99.2999 32.2997 99.4029 32.0337 99.4557 31.7558 99.5195 31.4445 99.5501 31.1274 99.547 30.8097zM104.07 33.7662C104.059 33.7989 104.042 33.8289 104.019 33.8545 103.991 33.8783 103.959 33.8959 103.924 33.9062 103.875 33.9207 103.824 33.9289 103.772 33.9305 103.712 33.9305 103.635 33.9305 103.544 33.9305H103.359 103.225C103.192 33.9262 103.159 33.9191 103.127 33.9092L103.057 33.8788C103.039 33.8668 103.024 33.8513 103.012 33.8332 103.001 33.8125 102.99 33.7911 102.981 33.7693L100.974 28.0594C100.951 28.0052 100.936 27.9477 100.931 27.8891 100.93 27.8706 100.933 27.852 100.94 27.8351 100.948 27.8181 100.959 27.8032 100.974 27.7917 101.015 27.7668 101.062 27.7522 101.111 27.7491 101.173 27.7491 101.259 27.7491 101.366 27.7491 101.437 27.7452 101.508 27.7452 101.579 27.7491 101.621 27.7507 101.662 27.7589 101.701 27.7735 101.726 27.7856 101.748 27.8033 101.765 27.8252 101.78 27.8492 101.794 27.8746 101.804 27.9012L103.565 33.0727 105.281 27.9012C105.288 27.8703 105.299 27.8405 105.315 27.813 105.33 27.7898 105.353 27.7718 105.379 27.7613 105.422 27.7466 105.467 27.7384 105.512 27.737 105.588 27.7332 105.665 27.7332 105.741 27.737 105.819 27.7329 105.897 27.7329 105.975 27.737 106.017 27.7405 106.057 27.7564 106.09 27.7826 106.101 27.7962 106.109 27.8119 106.113 27.8286 106.117 27.8454 106.118 27.8629 106.115 27.8799 106.105 27.938 106.089 27.995 106.069 28.0503L104.07 33.7662zM109.062 31.5091V33.7663C109.062 33.7898 109.056 33.8129 109.044 33.8332 109.027 33.8545 109.004 33.8694 108.977 33.8758 108.936 33.8901 108.893 33.9003 108.849 33.9062 108.72 33.9224 108.589 33.9224 108.46 33.9062 108.417 33.8996 108.374 33.8894 108.332 33.8758 108.306 33.8702 108.282 33.855 108.265 33.8332 108.251 33.8138 108.244 33.7903 108.244 33.7663V31.5L106.507 28.032C106.478 27.9786 106.456 27.9212 106.443 27.8617 106.438 27.8448 106.438 27.8268 106.442 27.8096 106.446 27.7925 106.455 27.7768 106.468 27.7643 106.505 27.7386 106.55 27.7238 106.595 27.7218 106.656 27.7218 106.738 27.7218 106.845 27.7218 106.951 27.7218 107.015 27.7218 107.076 27.7218 107.123 27.7274 107.17 27.7365 107.216 27.7491 107.245 27.7576 107.272 27.7745 107.292 27.7978 107.312 27.8211 107.329 27.8467 107.344 27.8739L108.192 29.6413C108.271 29.8116 108.351 29.985 108.43 30.1706 108.509 30.3562 108.588 30.5387 108.67 30.7242 108.743 30.5448 108.819 30.3653 108.895 30.1858 108.971 30.0063 109.05 29.8299 109.129 29.6565L109.984 27.8799C109.994 27.8509 110.007 27.8233 110.024 27.7978 110.044 27.7759 110.069 27.7592 110.097 27.7491 110.137 27.736 110.179 27.7268 110.221 27.7218 110.289 27.7181 110.357 27.7181 110.425 27.7218 110.541 27.7218 110.629 27.7218 110.696 27.7218 110.744 27.7248 110.79 27.7406 110.83 27.7674 110.842 27.7795 110.851 27.7945 110.856 27.811 110.861 27.8275 110.861 27.8449 110.857 27.8617 110.842 27.9201 110.82 27.9764 110.79 28.029L109.062 31.5091zM109.367 26.0547C109.397 26.0192 109.432 25.9875 109.47 25.9604 109.505 25.9378 109.543 25.9204 109.583 25.9087 109.63 25.895 109.679 25.8858 109.729 25.8813H109.932C110.008 25.8789 110.084 25.886 110.158 25.9026 110.199 25.9121 110.237 25.9308 110.27 25.9574 110.281 25.9664 110.289 25.9786 110.293 25.9921 110.296 26.0057 110.296 26.0201 110.291 26.0334 110.28 26.0674 110.261 26.0986 110.237 26.1247L109.16 27.1316C109.132 27.158 109.103 27.1824 109.072 27.2046 109.042 27.2218 109.01 27.236 108.977 27.2472 108.939 27.2594 108.899 27.2676 108.859 27.2715H108.688C108.632 27.2774 108.575 27.2774 108.518 27.2715 108.486 27.2687 108.457 27.2559 108.433 27.235 108.424 27.227 108.418 27.2167 108.416 27.2053 108.413 27.194 108.414 27.1821 108.418 27.1712 108.428 27.1373 108.445 27.1061 108.469 27.0799L109.367 26.0547zM111.593 33.2188C111.598 33.309 111.598 33.3994 111.593 33.4896 111.584 33.5689 111.568 33.6473 111.545 33.7238 111.522 33.7983 111.492 33.8706 111.456 33.9398 111.42 34.0098 111.374 34.0858 111.323 34.1649L110.672 35.1414C110.657 35.1635 110.638 35.183 110.617 35.1992 110.593 35.2164 110.568 35.2307 110.541 35.2418 110.506 35.2548 110.471 35.264 110.434 35.2692H110.285 110.151C110.124 35.2671 110.097 35.2588 110.072 35.2448 110.058 35.2336 110.048 35.2173 110.045 35.1992 110.046 35.1759 110.053 35.1531 110.063 35.1323L110.696 33.8272V33.2188C110.693 33.15 110.701 33.0812 110.72 33.015 110.735 32.969 110.764 32.9287 110.802 32.8994 110.846 32.8732 110.895 32.8556 110.945 32.8477 111.015 32.8424 111.085 32.8424 111.155 32.8477 111.223 32.8425 111.291 32.8425 111.359 32.8477 111.409 32.8545 111.457 32.8721 111.499 32.8994 111.538 32.9287 111.566 32.969 111.581 33.015 111.595 33.0821 111.599 33.1507 111.593 33.2188zM121.96 33.7661C121.959 33.7899 121.952 33.813 121.939 33.833 121.922 33.8543 121.899 33.8693 121.872 33.8756 121.832 33.889 121.79 33.8991 121.748 33.9061 121.617 33.9223 121.485 33.9223 121.355 33.9061 121.312 33.9002 121.269 33.89 121.227 33.8756 121.201 33.8685 121.178 33.8537 121.16 33.833 121.148 33.8128 121.142 33.7897 121.142 33.7661V28.4213L118.976 33.7996C118.967 33.8202 118.953 33.8388 118.937 33.8543 118.914 33.8721 118.888 33.8865 118.861 33.8969 118.822 33.9079 118.782 33.9151 118.742 33.9182 118.687 33.9216 118.632 33.9216 118.578 33.9182 118.52 33.9218 118.462 33.9218 118.404 33.9182 118.364 33.9119 118.325 33.9027 118.286 33.8908 118.259 33.8815 118.235 33.8682 118.213 33.8513 118.198 33.8364 118.185 33.8188 118.176 33.7996L116.108 28.4213V33.7661C116.109 33.7921 116.101 33.8179 116.085 33.8382 116.069 33.8585 116.045 33.8719 116.019 33.8756 115.978 33.8893 115.935 33.8995 115.892 33.9061 115.825 33.91 115.758 33.91 115.691 33.9061 115.626 33.9099 115.561 33.9099 115.496 33.9061 115.454 33.8999 115.412 33.8897 115.371 33.8756 115.346 33.8694 115.323 33.8543 115.308 33.833 115.296 33.8125 115.291 33.7894 115.292 33.7661V28.1232C115.287 28.0708 115.293 28.0179 115.311 27.9684 115.329 27.9189 115.358 27.874 115.396 27.8372 115.463 27.7822 115.547 27.7521 115.633 27.7521H116.135C116.226 27.7509 116.317 27.7601 116.406 27.7794 116.478 27.796 116.546 27.827 116.607 27.8707 116.666 27.9116 116.715 27.9644 116.753 28.0258 116.795 28.0966 116.829 28.1721 116.853 28.2509L118.611 32.7014H118.636L120.461 28.2631C120.491 28.1794 120.53 28.0989 120.576 28.0228 120.613 27.9621 120.659 27.9077 120.713 27.8616 120.763 27.8231 120.82 27.7942 120.881 27.7764 120.95 27.7596 121.022 27.7514 121.094 27.7521H121.62C121.666 27.7512 121.713 27.7584 121.757 27.7733 121.798 27.786 121.836 27.809 121.866 27.8403 121.9 27.8716 121.926 27.9101 121.942 27.9528 121.963 28.0072 121.973 28.065 121.973 28.1232L121.96 33.7661zM124.419 33.7662C124.419 33.7898 124.412 33.8129 124.4 33.8331 124.384 33.855 124.36 33.8701 124.333 33.8757 124.293 33.8898 124.251 33.9 124.209 33.9061 124.143 33.91 124.077 33.91 124.011 33.9061 123.946 33.9099 123.881 33.9099 123.816 33.9061 123.773 33.9003 123.73 33.8901 123.688 33.8757 123.662 33.8701 123.638 33.855 123.622 33.8331 123.61 33.8129 123.603 33.7898 123.603 33.7662V27.8738C123.603 27.8498 123.61 27.8263 123.625 27.8069 123.642 27.785 123.667 27.77 123.695 27.7643 123.736 27.7507 123.779 27.7405 123.822 27.7339 123.885 27.7303 123.948 27.7303 124.011 27.7339 124.077 27.73 124.143 27.73 124.209 27.7339 124.251 27.7401 124.293 27.7502 124.333 27.7643 124.36 27.7699 124.384 27.785 124.4 27.8069 124.412 27.8272 124.419 27.8503 124.419 27.8738V33.7662zM130.661 28.5948C130.664 28.6485 130.664 28.7023 130.661 28.756 130.656 28.7945 130.647 28.8323 130.633 28.8686 130.624 28.8943 130.607 28.9165 130.585 28.9325 130.567 28.9453 130.546 28.9527 130.524 28.9538 130.454 28.9396 130.388 28.9083 130.332 28.8625 130.219 28.7872 130.1 28.7201 129.976 28.6617 129.805 28.5811 129.627 28.5149 129.444 28.464 129.203 28.399 128.954 28.3682 128.705 28.3727 128.391 28.3683 128.08 28.4316 127.792 28.5583 127.529 28.6777 127.296 28.8532 127.108 29.0724 126.916 29.302 126.77 29.5664 126.679 29.8512 126.475 30.5109 126.48 31.2175 126.694 31.8741 126.79 32.1593 126.944 32.4214 127.147 32.6437 127.338 32.8527 127.574 33.0151 127.838 33.1183 128.118 33.2291 128.416 33.2839 128.717 33.2795 128.912 33.2796 129.106 33.2572 129.295 33.2126 129.485 33.1671 129.668 33.0976 129.84 33.0057V31.214H128.416C128.39 31.214 128.364 31.2062 128.342 31.1916 128.321 31.1769 128.304 31.1561 128.294 31.1318 128.261 31.053 128.247 30.9677 128.252 30.8824 128.246 30.8308 128.246 30.7788 128.252 30.7273 128.255 30.6902 128.265 30.6541 128.282 30.6208 128.293 30.5978 128.31 30.5779 128.331 30.563 128.353 30.5499 128.378 30.5435 128.404 30.5447H130.354C130.39 30.5448 130.426 30.551 130.46 30.563 130.497 30.5761 130.531 30.5975 130.559 30.6253 130.587 30.6532 130.608 30.687 130.621 30.7242 130.638 30.7732 130.646 30.8246 130.646 30.8763V33.2187C130.647 33.2919 130.632 33.3645 130.603 33.4316 130.561 33.5026 130.497 33.5581 130.421 33.5898 130.305 33.6466 130.186 33.6973 130.065 33.7419 129.919 33.7936 129.76 33.8392 129.614 33.8788 129.459 33.9163 129.302 33.9447 129.143 33.964 128.987 33.9821 128.831 33.9912 128.674 33.9913 128.24 33.9987 127.807 33.9244 127.4 33.7723 127.042 33.6345 126.719 33.4195 126.454 33.1426 126.19 32.8609 125.988 32.5273 125.861 32.1631 125.583 31.3184 125.589 30.4059 125.879 29.5652 126.01 29.1893 126.217 28.8445 126.487 28.5522 126.762 28.2676 127.094 28.0438 127.461 27.8951 128.069 27.6659 128.729 27.608 129.368 27.7278 129.553 27.7638 129.736 27.8115 129.916 27.8708 130.056 27.9192 130.191 27.9803 130.32 28.0533 130.401 28.0972 130.477 28.1503 130.545 28.2115 130.586 28.2514 130.616 28.3004 130.633 28.3545 130.653 28.433 130.662 28.5138 130.661 28.5948zM136.282 33.7665C136.282 33.7896 136.277 33.8124 136.267 33.8334 136.253 33.8554 136.232 33.8716 136.206 33.8791 136.163 33.8933 136.118 33.9035 136.073 33.9095 135.997 33.9133 135.92 33.9133 135.844 33.9095 135.777 33.9132 135.708 33.9132 135.641 33.9095 135.598 33.904 135.556 33.8927 135.516 33.876 135.487 33.8638 135.461 33.8438 135.443 33.8182 135.423 33.7893 135.407 33.7575 135.397 33.7239L134.831 32.2729C134.765 32.1086 134.698 31.9687 134.625 31.8196 134.559 31.6891 134.473 31.5691 134.372 31.4637 134.274 31.3633 134.156 31.2845 134.025 31.2325 133.872 31.1719 133.709 31.143 133.545 31.1473H133V33.7665C132.999 33.7918 132.99 33.816 132.974 33.8357 132.958 33.8554 132.936 33.8696 132.912 33.876 132.871 33.8901 132.83 33.9003 132.787 33.9064 132.721 33.9103 132.655 33.9103 132.589 33.9064 132.524 33.9102 132.458 33.9102 132.392 33.9064 132.349 33.9003 132.308 33.8901 132.267 33.876 132.241 33.8697 132.217 33.8547 132.2 33.8334 132.188 33.8132 132.182 33.7901 132.182 33.7665V28.084C132.176 28.0363 132.183 27.988 132.199 27.943 132.216 27.8981 132.244 27.8578 132.279 27.8254 132.338 27.7788 132.411 27.7531 132.486 27.7524H133.791C133.946 27.7524 134.077 27.7524 134.18 27.7524L134.457 27.7768C134.675 27.8128 134.887 27.8783 135.087 27.9715 135.26 28.0534 135.416 28.168 135.546 28.3091 135.669 28.4453 135.763 28.6046 135.823 28.7776 135.886 28.9648 135.917 29.1612 135.914 29.3586 135.917 29.5464 135.889 29.7334 135.832 29.9123 135.78 30.07 135.698 30.2165 135.592 30.3442 135.485 30.4721 135.359 30.582 135.218 30.6697 135.063 30.7653 134.899 30.8438 134.728 30.904 134.827 30.9465 134.919 31.0029 135.002 31.0713 135.089 31.1417 135.167 31.2236 135.233 31.3146 135.31 31.4186 135.378 31.5284 135.437 31.6432 135.498 31.7679 135.562 31.9078 135.625 32.063L136.176 33.4167C136.209 33.4951 136.237 33.5753 136.261 33.657 136.273 33.6925 136.28 33.7293 136.282 33.7665zM135.066 29.456C135.072 29.2418 135.016 29.0303 134.904 28.8476 134.774 28.6655 134.581 28.5378 134.363 28.4886 134.276 28.4632 134.186 28.4469 134.095 28.4399 133.995 28.4399 133.864 28.4399 133.703 28.4399H133.015V30.5085H133.812C134.001 30.513 134.189 30.4873 134.369 30.4325 134.513 30.3858 134.646 30.3113 134.761 30.2134 134.864 30.1228 134.943 30.0092 134.993 29.8819 135.044 29.7459 135.069 29.6013 135.066 29.456zM142.062 33.6083C142.085 33.6626 142.099 33.72 142.105 33.7786 142.106 33.7965 142.103 33.8144 142.097 33.8312 142.091 33.848 142.081 33.8632 142.068 33.876 142.031 33.9007 141.988 33.9154 141.944 33.9186 141.883 33.9186 141.807 33.9186 141.706 33.9186 141.606 33.9186 141.53 33.9186 141.472 33.9186 141.427 33.9167 141.382 33.9095 141.338 33.8973 141.312 33.888 141.289 33.8723 141.271 33.8516 141.256 33.8284 141.243 33.804 141.232 33.7786L140.705 32.282H138.15L137.648 33.7665C137.64 33.7925 137.627 33.8171 137.612 33.8395 137.594 33.863 137.569 33.881 137.542 33.8912 137.501 33.9082 137.458 33.9195 137.414 33.9247 137.342 33.9284 137.27 33.9284 137.198 33.9247 137.123 33.9286 137.048 33.9286 136.973 33.9247 136.928 33.9213 136.885 33.9055 136.848 33.879 136.836 33.8662 136.826 33.8509 136.821 33.8341 136.815 33.8172 136.813 33.7994 136.815 33.7817 136.821 33.7235 136.834 33.6662 136.854 33.6113L138.917 27.9045C138.928 27.8718 138.945 27.8418 138.968 27.8163 138.993 27.7923 139.024 27.7746 139.057 27.7646 139.106 27.7503 139.157 27.7422 139.209 27.7402 139.27 27.7402 139.349 27.7402 139.443 27.7402 139.537 27.7402 139.629 27.7402 139.695 27.7402 139.75 27.7417 139.804 27.7499 139.857 27.7646 139.893 27.7751 139.926 27.7939 139.954 27.8193 139.977 27.8453 139.994 27.8752 140.006 27.9075L142.062 33.6083zM139.419 28.5677L138.357 31.6371H140.486L139.419 28.5677zM147.124 33.0301C147.124 33.0788 147.124 33.1244 147.124 33.1609 147.122 33.195 147.116 33.2287 147.106 33.2613 147.099 33.288 147.089 33.3136 147.075 33.3373 147.057 33.3675 147.034 33.3951 147.009 33.4195 146.947 33.473 146.881 33.5208 146.811 33.5624 146.69 33.6355 146.564 33.6996 146.434 33.7541 146.265 33.82 146.091 33.8718 145.913 33.9092 145.703 33.9534 145.489 33.9748 145.275 33.9731 144.904 33.9755 144.536 33.9052 144.192 33.7663 143.875 33.6367 143.594 33.4345 143.37 33.1761 143.132 32.8947 142.954 32.5676 142.847 32.2148 142.599 31.337 142.604 30.4067 142.862 29.5318 142.978 29.1609 143.166 28.8167 143.416 28.5188 143.647 28.245 143.939 28.0284 144.268 27.886 144.615 27.7365 144.991 27.6619 145.369 27.667 145.542 27.6662 145.716 27.6825 145.886 27.7157 146.044 27.7471 146.199 27.7887 146.351 27.8404 146.484 27.887 146.611 27.9461 146.732 28.0168 146.814 28.0643 146.891 28.1193 146.963 28.1811 146.994 28.2102 147.022 28.2429 147.045 28.2784 147.058 28.3036 147.068 28.3302 147.075 28.3575 147.086 28.3922 147.092 28.4279 147.094 28.464 147.097 28.5126 147.097 28.5614 147.094 28.61 147.097 28.6647 147.097 28.7196 147.094 28.7743 147.087 28.8116 147.076 28.8482 147.063 28.8838 147.054 28.9096 147.038 28.9327 147.018 28.9507 147 28.9655 146.977 28.973 146.954 28.972 146.884 28.961 146.819 28.9292 146.768 28.8808 146.542 28.7065 146.288 28.5709 146.017 28.4792 145.807 28.4139 145.588 28.3831 145.369 28.388 145.11 28.3846 144.854 28.4409 144.621 28.5522 144.393 28.6641 144.196 28.8289 144.046 29.0329 143.871 29.2668 143.74 29.5307 143.659 29.8116 143.568 30.1529 143.524 30.5049 143.528 30.8581 143.523 31.2071 143.566 31.5551 143.656 31.8924 143.727 32.163 143.85 32.4173 144.018 32.6407 144.172 32.8376 144.371 32.9942 144.599 33.097 144.845 33.2038 145.11 33.2567 145.378 33.2522 145.595 33.255 145.81 33.2232 146.017 33.1578 146.179 33.1056 146.336 33.0384 146.485 32.9571 146.613 32.8841 146.72 32.8141 146.79 32.7563 146.845 32.7071 146.914 32.6754 146.987 32.665 147.005 32.6588 147.024 32.6588 147.042 32.665 147.052 32.671 147.061 32.6789 147.067 32.6883 147.074 32.6977 147.079 32.7085 147.082 32.7198 147.092 32.7555 147.099 32.7922 147.103 32.8293 147.114 32.8957 147.121 32.9628 147.124 33.0301zM145.241 27.2715H145.077C145.037 27.2694 144.997 27.2633 144.958 27.2533 144.927 27.2447 144.898 27.2302 144.873 27.2107 144.849 27.1924 144.824 27.1681 144.794 27.1407L143.778 26.0608C143.755 26.0378 143.737 26.0097 143.726 25.9787 143.723 25.9684 143.723 25.9572 143.726 25.9468 143.729 25.9365 143.736 25.9274 143.744 25.9209 143.774 25.9031 143.807 25.8927 143.842 25.8905 143.899 25.8866 143.955 25.8866 144.012 25.8905H144.24L144.377 25.9087C144.406 25.916 144.434 25.9284 144.459 25.9452L144.514 25.9939 145.247 26.8092 146.008 26.0121C146.029 25.9877 146.054 25.9662 146.081 25.9483 146.11 25.9299 146.142 25.9165 146.175 25.9087 146.221 25.8985 146.268 25.8914 146.315 25.8874H146.528C146.59 25.8819 146.652 25.8819 146.713 25.8874 146.747 25.8891 146.778 25.9008 146.805 25.9209 146.81 25.9291 146.813 25.9386 146.813 25.9483 146.813 25.9579 146.81 25.9674 146.805 25.9756 146.793 26.0055 146.776 26.0324 146.753 26.0547L145.713 27.1346C145.69 27.1611 145.663 27.1837 145.634 27.2016 145.603 27.2206 145.571 27.235 145.536 27.2442 145.498 27.2567 145.458 27.2639 145.418 27.2655L145.241 27.2715zM152.855 33.5593C152.856 33.6159 152.845 33.6719 152.822 33.7236 152.802 33.7644 152.774 33.8007 152.74 33.83 152.706 33.8595 152.667 33.8814 152.624 33.8939 152.583 33.906 152.54 33.9121 152.496 33.9122H152.226C152.15 33.9134 152.074 33.9042 152.001 33.8848 151.934 33.8676 151.873 33.8354 151.821 33.7905 151.755 33.7356 151.697 33.6722 151.648 33.6019 151.579 33.5054 151.518 33.4037 151.465 33.2977L149.591 29.8115C149.494 29.6321 149.394 29.4434 149.287 29.2457 149.181 29.048 149.095 28.8533 149.01 28.6677 149.01 28.8959 149.01 29.1271 149.01 29.3674 149.01 29.6077 149.01 29.8389 149.01 30.0731V33.7662C149.01 33.7892 149.003 33.8116 148.989 33.83 148.981 33.8418 148.972 33.8518 148.96 33.8597 148.949 33.8675 148.936 33.873 148.922 33.8757 148.882 33.8897 148.84 33.8999 148.797 33.9061 148.666 33.9223 148.533 33.9223 148.402 33.9061 148.359 33.8999 148.318 33.8897 148.277 33.8757 148.251 33.8695 148.228 33.8531 148.213 33.83 148.201 33.8109 148.194 33.7889 148.192 33.7662V28.1019C148.186 28.0512 148.193 27.9999 148.212 27.9525 148.231 27.9052 148.262 27.8635 148.302 27.8312 148.369 27.7801 148.451 27.7523 148.536 27.7521H148.937C149.018 27.7502 149.099 27.7574 149.178 27.7734 149.239 27.7897 149.296 27.8165 149.348 27.8525 149.405 27.8947 149.454 27.9461 149.494 28.0046 149.55 28.0828 149.6 28.1651 149.643 28.251L151.085 30.9492 151.344 31.4299C151.426 31.5881 151.505 31.7341 151.581 31.8923 151.657 32.0505 151.733 32.1965 151.809 32.3425 151.885 32.4885 151.958 32.6467 152.031 32.7866 152.031 32.5372 152.031 32.2756 152.031 32.0048 152.031 31.7341 152.031 31.4725 152.031 31.223V27.8768C152.031 27.8547 152.038 27.8331 152.052 27.816 152.068 27.792 152.092 27.7738 152.119 27.7643 152.159 27.7488 152.201 27.7385 152.244 27.7338 152.312 27.73 152.38 27.73 152.448 27.7338 152.511 27.7303 152.574 27.7303 152.636 27.7338 152.68 27.7382 152.723 27.7485 152.764 27.7643 152.79 27.7756 152.812 27.7934 152.828 27.816 152.841 27.8337 152.848 27.8549 152.849 27.8768L152.855 33.5593zM155.304 33.7663C155.304 33.7898 155.298 33.813 155.286 33.8332 155.269 33.8551 155.246 33.8702 155.219 33.8758 155.178 33.8899 155.137 33.9001 155.094 33.9062 155.028 33.9101 154.962 33.9101 154.896 33.9062 154.832 33.9099 154.767 33.9099 154.702 33.9062 154.658 33.9004 154.615 33.8902 154.574 33.8758 154.547 33.8702 154.524 33.8551 154.507 33.8332 154.495 33.813 154.489 33.7898 154.489 33.7663V27.8739C154.488 27.8499 154.496 27.8264 154.51 27.807 154.528 27.7851 154.553 27.7701 154.58 27.7644 154.622 27.7508 154.665 27.7406 154.708 27.734 154.771 27.7304 154.834 27.7304 154.896 27.734 154.962 27.7301 155.028 27.7301 155.094 27.734 155.137 27.7402 155.178 27.7503 155.219 27.7644 155.246 27.77 155.269 27.7851 155.286 27.807 155.298 27.8273 155.304 27.8504 155.304 27.8739V33.7663zM155.447 26.0548C155.476 26.0186 155.51 25.9869 155.547 25.9605 155.582 25.9379 155.62 25.9204 155.66 25.9088 155.708 25.8953 155.757 25.8862 155.806 25.8814H156.01C156.086 25.8787 156.161 25.8859 156.235 25.9027 156.276 25.9121 156.315 25.9308 156.348 25.9574 156.359 25.9662 156.367 25.9783 156.371 25.992 156.374 26.0057 156.374 26.0202 156.369 26.0335 156.359 26.0681 156.34 26.0995 156.314 26.1248L155.237 27.1317C155.21 27.1588 155.181 27.1833 155.149 27.2047 155.12 27.2213 155.089 27.2355 155.058 27.2473 155.018 27.2592 154.977 27.2673 154.936 27.2716H154.766C154.709 27.2773 154.652 27.2773 154.595 27.2716 154.564 27.2688 154.534 27.256 154.51 27.2351 154.503 27.2265 154.497 27.2162 154.495 27.205 154.492 27.1939 154.492 27.1823 154.495 27.1712 154.5 27.136 154.513 27.1025 154.534 27.0739L155.447 26.0548zM163.743 33.6084C163.763 33.6632 163.777 33.7204 163.782 33.7787 163.783 33.7966 163.781 33.8145 163.774 33.8313 163.768 33.848 163.758 33.8633 163.746 33.8761 163.709 33.9008 163.666 33.9155 163.621 33.9186 163.56 33.9186 163.484 33.9186 163.384 33.9186 163.283 33.9186 163.207 33.9186 163.149 33.9186 163.104 33.9168 163.059 33.9096 163.016 33.8974 162.991 33.8881 162.969 33.8724 162.952 33.8517 162.934 33.8293 162.92 33.8048 162.909 33.7787L162.383 32.282H159.828L159.323 33.7665C159.314 33.7926 159.302 33.8172 159.286 33.8396 159.268 33.8631 159.244 33.8811 159.216 33.8913 159.175 33.9083 159.132 33.9195 159.088 33.9247 159.016 33.9285 158.944 33.9285 158.872 33.9247 158.797 33.9287 158.722 33.9287 158.647 33.9247 158.602 33.9208 158.559 33.905 158.523 33.8791 158.508 33.8647 158.497 33.8468 158.491 33.8271 158.486 33.8074 158.485 33.7866 158.489 33.7665 158.495 33.7083 158.508 33.6511 158.529 33.5962L160.591 27.8894C160.602 27.8567 160.62 27.8267 160.643 27.8011 160.668 27.7772 160.698 27.7595 160.731 27.7494 160.781 27.7352 160.832 27.727 160.883 27.7251 160.947 27.7251 161.023 27.7251 161.12 27.7251 161.218 27.7251 161.303 27.7251 161.37 27.7251 161.424 27.7266 161.479 27.7348 161.531 27.7494 161.567 27.76 161.601 27.7787 161.628 27.8042 161.651 27.8302 161.669 27.8601 161.68 27.8924L163.743 33.6084zM161.096 28.5677L160.031 31.6371H162.161L161.096 28.5677zM167.783 33.7662C167.783 33.7898 167.776 33.8129 167.764 33.8331 167.748 33.855 167.724 33.8701 167.697 33.8757 167.657 33.8898 167.615 33.9 167.573 33.9061 167.507 33.91 167.441 33.91 167.375 33.9061 167.31 33.9099 167.245 33.9099 167.18 33.9061 167.137 33.9003 167.094 33.8901 167.052 33.8757 167.026 33.8701 167.002 33.855 166.986 33.8331 166.974 33.8129 166.967 33.7898 166.967 33.7662V27.8738C166.967 27.8498 166.974 27.8263 166.989 27.8069 167.006 27.785 167.031 27.77 167.059 27.7643 167.1 27.7507 167.143 27.7405 167.186 27.7339 167.249 27.7303 167.312 27.7303 167.375 27.7339 167.441 27.73 167.507 27.73 167.573 27.7339 167.615 27.7401 167.657 27.7502 167.697 27.7643 167.724 27.7699 167.748 27.785 167.764 27.8069 167.776 27.8272 167.783 27.8503 167.783 27.8738V33.7662zM174.064 33.5593C174.065 33.6159 174.054 33.6719 174.031 33.7236 174.011 33.7644 173.983 33.8007 173.949 33.83 173.915 33.8595 173.876 33.8814 173.833 33.8939 173.791 33.906 173.748 33.9121 173.705 33.9122H173.435C173.359 33.9134 173.283 33.9042 173.209 33.8848 173.143 33.8669 173.082 33.8347 173.03 33.7905 172.964 33.7356 172.906 33.6722 172.857 33.6019 172.788 33.5054 172.727 33.4037 172.674 33.2977L170.8 29.8115C170.703 29.6321 170.602 29.4434 170.496 29.2457 170.389 29.048 170.304 28.8533 170.219 28.6677 170.219 28.8959 170.219 29.1271 170.234 29.3674 170.25 29.6077 170.234 29.8389 170.234 30.0731V33.7662C170.234 33.7892 170.227 33.8116 170.213 33.83 170.206 33.8418 170.196 33.8518 170.184 33.8597 170.173 33.8675 170.16 33.873 170.146 33.8757 170.106 33.8897 170.064 33.8999 170.021 33.9061 169.89 33.9223 169.757 33.9223 169.626 33.9061 169.584 33.9004 169.544 33.8902 169.504 33.8757 169.477 33.8686 169.454 33.8525 169.437 33.83 169.426 33.8107 169.419 33.7887 169.419 33.7662V28.1019C169.413 28.0515 169.419 28.0003 169.438 27.953 169.456 27.9057 169.487 27.8638 169.526 27.8312 169.593 27.7805 169.675 27.7527 169.76 27.7521H170.161C170.242 27.7501 170.323 27.7572 170.402 27.7734 170.463 27.7897 170.52 27.8165 170.572 27.8525 170.629 27.8947 170.678 27.9461 170.718 28.0046 170.774 28.0833 170.825 28.1657 170.87 28.251L172.309 30.9492 172.568 31.4299C172.65 31.5881 172.729 31.7341 172.805 31.8923 172.881 32.0505 172.957 32.1965 173.033 32.3425 173.109 32.4885 173.182 32.6467 173.255 32.7866 173.255 32.5372 173.255 32.2756 173.255 32.0048 173.255 31.7341 173.255 31.4725 173.255 31.223V27.8768C173.255 27.8547 173.262 27.8331 173.276 27.816 173.292 27.792 173.316 27.7738 173.343 27.7643 173.383 27.7488 173.425 27.7385 173.468 27.7338 173.536 27.73 173.604 27.73 173.672 27.7338 173.735 27.7303 173.798 27.7303 173.86 27.7338 173.904 27.7382 173.947 27.7485 173.988 27.7643 174.014 27.7747 174.036 27.7927 174.052 27.816 174.065 27.8337 174.072 27.8549 174.073 27.8768L174.064 33.5593zM179.549 28.1023C179.553 28.155 179.553 28.2078 179.549 28.2605 179.546 28.2975 179.535 28.3336 179.519 28.367 179.506 28.391 179.489 28.4119 179.467 28.4278 179.446 28.4402 179.422 28.4465 179.397 28.446H177.654V33.7665C177.654 33.7901 177.648 33.8132 177.636 33.8335 177.618 33.8541 177.595 33.8689 177.569 33.876 177.527 33.8897 177.484 33.8999 177.441 33.9065 177.375 33.9104 177.309 33.9104 177.243 33.9065 177.178 33.9102 177.113 33.9102 177.049 33.9065 177.005 33.8999 176.962 33.8897 176.921 33.876 176.895 33.8689 176.871 33.8541 176.854 33.8335 176.842 33.8132 176.836 33.7901 176.836 33.7665V28.446H175.108C175.083 28.4465 175.059 28.4402 175.038 28.4278 175.016 28.4125 174.999 28.3914 174.989 28.367 174.973 28.3336 174.962 28.2975 174.959 28.2605 174.954 28.2079 174.954 28.1549 174.959 28.1023 174.954 28.0497 174.954 27.9967 174.959 27.9441 174.963 27.9052 174.973 27.8671 174.989 27.8316 174.998 27.8066 175.015 27.7853 175.038 27.7707 175.059 27.7583 175.083 27.752 175.108 27.7525H179.388C179.412 27.752 179.437 27.7583 179.458 27.7707 179.48 27.7859 179.498 27.8069 179.51 27.8316 179.526 27.8671 179.536 27.9052 179.54 27.9441 179.546 27.9966 179.549 28.0494 179.549 28.1023zM183.857 33.5595C183.86 33.6101 183.86 33.6609 183.857 33.7116 183.853 33.749 183.841 33.7852 183.823 33.818 183.811 33.8429 183.792 33.8639 183.768 33.8789 183.748 33.8913 183.725 33.8977 183.701 33.8971H180.751C180.676 33.896 180.603 33.8704 180.544 33.8241 180.508 33.7918 180.481 33.7515 180.464 33.7065 180.447 33.6616 180.441 33.6133 180.446 33.5655V28.0899C180.441 28.0422 180.447 27.9939 180.464 27.9489 180.481 27.904 180.508 27.8637 180.544 27.8313 180.603 27.7851 180.676 27.7594 180.751 27.7583H183.668C183.692 27.7578 183.715 27.7641 183.735 27.7766 183.758 27.7908 183.776 27.8121 183.787 27.8374 183.801 27.8715 183.811 27.9073 183.817 27.9439 183.822 27.9975 183.822 28.0515 183.817 28.1051 183.822 28.1547 183.822 28.2046 183.817 28.2542 183.812 28.2899 183.802 28.3248 183.787 28.3576 183.776 28.3829 183.758 28.4042 183.735 28.4185 183.715 28.4309 183.692 28.4372 183.668 28.4367H181.265V30.3593H183.327C183.351 30.3588 183.375 30.3663 183.394 30.3806 183.416 30.3952 183.434 30.4151 183.446 30.4384 183.462 30.4717 183.473 30.5078 183.476 30.5448 183.48 30.5965 183.48 30.6483 183.476 30.7 183.48 30.7496 183.48 30.7994 183.476 30.849 183.472 30.884 183.462 30.918 183.446 30.9494 183.434 30.9724 183.416 30.9915 183.394 31.0042 183.372 31.0088 183.349 31.0088 183.327 31.0042H181.265V33.2035H183.698C183.722 33.203 183.745 33.2094 183.765 33.2218 183.789 33.2368 183.808 33.2578 183.82 33.2826 183.839 33.3142 183.85 33.3495 183.853 33.3861 183.859 33.4437 183.86 33.5017 183.857 33.5595zM189.691 28.595C189.695 28.6486 189.695 28.7025 189.691 28.7562 189.687 28.7947 189.677 28.8325 189.664 28.8687 189.653 28.8938 189.636 28.9158 189.615 28.9326 189.597 28.9455 189.576 28.9529 189.554 28.9539 189.484 28.9403 189.418 28.9089 189.363 28.8627 189.249 28.7873 189.13 28.7202 189.007 28.6619 188.834 28.5813 188.655 28.5151 188.471 28.4641 188.231 28.3991 187.984 28.3684 187.735 28.3729 187.421 28.3684 187.11 28.4317 186.822 28.5584 186.559 28.6771 186.325 28.8527 186.138 29.0726 185.944 29.3006 185.798 29.5655 185.709 29.8513 185.498 30.5091 185.498 31.2164 185.709 31.8742 185.807 32.1584 185.962 32.42 186.162 32.6439 186.355 32.8523 186.592 33.0145 186.856 33.1184 187.136 33.2295 187.434 33.2843 187.735 33.2797 187.93 33.2798 188.124 33.2573 188.313 33.2127 188.503 33.1672 188.686 33.0977 188.858 33.0059V31.2141H187.431C187.405 31.2138 187.379 31.2058 187.358 31.1912 187.336 31.1766 187.319 31.1561 187.309 31.132 187.279 31.0525 187.265 30.9676 187.27 30.8826 187.266 30.8309 187.266 30.7791 187.27 30.7274 187.275 30.6907 187.285 30.6549 187.3 30.6209 187.313 30.5984 187.331 30.5787 187.352 30.5631 187.373 30.5503 187.397 30.5439 187.422 30.5449H189.375C189.41 30.5449 189.445 30.5511 189.478 30.5631 189.514 30.5752 189.548 30.595 189.575 30.6209 189.605 30.6505 189.627 30.6857 189.642 30.7244 189.658 30.7736 189.665 30.8249 189.664 30.8765V33.2188C189.666 33.2922 189.652 33.3651 189.621 33.4318 189.581 33.5033 189.518 33.5591 189.442 33.5899 189.326 33.6467 189.207 33.6975 189.086 33.742 188.94 33.7938 188.782 33.8394 188.632 33.8789 188.325 33.9546 188.009 33.9923 187.692 33.9915 187.259 33.9986 186.827 33.9243 186.421 33.7725 186.063 33.6339 185.739 33.4191 185.472 33.1428 185.209 32.8609 185.008 32.5273 184.882 32.1632 184.741 31.7544 184.672 31.3241 184.678 30.8917 184.672 30.4401 184.746 29.9909 184.897 29.5654 185.029 29.1901 185.236 28.8455 185.505 28.5524 185.779 28.2721 186.107 28.0515 186.47 27.9044 187.078 27.6752 187.738 27.6173 188.377 27.7371 188.562 27.773 188.745 27.8208 188.925 27.8801 189.065 27.9285 189.2 27.9896 189.329 28.0626 189.41 28.1065 189.485 28.1596 189.554 28.2208 189.595 28.2596 189.625 28.3091 189.639 28.3638 189.667 28.4382 189.684 28.5159 189.691 28.595zM195.297 33.7665C195.302 33.7886 195.302 33.8114 195.297 33.8334 195.282 33.8555 195.259 33.8715 195.234 33.8791 195.191 33.8934 195.147 33.9036 195.103 33.9095 195.027 33.9133 194.951 33.9133 194.875 33.9095 194.807 33.9132 194.739 33.9132 194.671 33.9095 194.628 33.904 194.586 33.8927 194.546 33.876 194.516 33.8654 194.49 33.8451 194.473 33.8182 194.453 33.7893 194.438 33.7575 194.427 33.7239L193.862 32.2729C193.795 32.1086 193.728 31.9687 193.655 31.8196 193.589 31.6891 193.504 31.5691 193.402 31.4637 193.302 31.3638 193.183 31.2852 193.052 31.2325 192.901 31.1715 192.738 31.1425 192.575 31.1473H192.027V33.7665C192.028 33.7906 192.02 33.8141 192.006 33.8334 191.989 33.8547 191.966 33.8697 191.939 33.876 191.9 33.8905 191.859 33.9007 191.817 33.9064 191.686 33.9227 191.553 33.9227 191.422 33.9064 191.38 33.9003 191.338 33.8901 191.297 33.876 191.271 33.8704 191.247 33.8553 191.23 33.8334 191.218 33.8132 191.212 33.7901 191.212 33.7665V28.084C191.207 28.0363 191.213 27.988 191.23 27.943 191.247 27.8981 191.274 27.8578 191.309 27.8254 191.368 27.7788 191.441 27.7531 191.516 27.7524H192.821C192.976 27.7524 193.104 27.7524 193.208 27.7524L193.487 27.7768C193.705 27.8128 193.917 27.8783 194.117 27.9715 194.29 28.0534 194.445 28.1681 194.573 28.3091 194.697 28.4451 194.792 28.6044 194.853 28.7776 194.916 28.9648 194.947 29.1612 194.945 29.3586 194.947 29.5464 194.92 29.7334 194.862 29.9123 194.809 30.0695 194.727 30.2158 194.622 30.3442 194.515 30.4722 194.387 30.5821 194.245 30.6697 194.092 30.7658 193.929 30.8444 193.758 30.904 193.857 30.9465 193.949 31.0029 194.032 31.0713 194.119 31.1425 194.196 31.2243 194.263 31.3146 194.338 31.4194 194.405 31.5291 194.464 31.6432 194.529 31.7669 194.593 31.9068 194.656 32.063L195.206 33.4167C195.239 33.4951 195.268 33.5753 195.291 33.657 195.298 33.6931 195.3 33.7299 195.297 33.7665zM194.081 29.4468C194.087 29.2327 194.031 29.0212 193.919 28.8384 193.789 28.6564 193.596 28.5287 193.378 28.4795 193.29 28.4541 193.199 28.4378 193.107 28.4308 193.01 28.4308 192.879 28.4308 192.718 28.4308H192.027V30.4994H192.827C193.016 30.5036 193.204 30.4779 193.384 30.4233 193.528 30.3766 193.661 30.3022 193.776 30.2043 193.877 30.1125 193.956 29.9991 194.008 29.8727 194.058 29.7396 194.083 29.5982 194.081 29.456V29.4468zM201.096 33.6083C201.117 33.663 201.131 33.7203 201.138 33.7786 201.139 33.7965 201.137 33.8144 201.13 33.8312 201.124 33.848 201.114 33.8632 201.102 33.876 201.064 33.9007 201.02 33.9154 200.974 33.9186 200.916 33.9186 200.837 33.9186 200.74 33.9186 200.642 33.9186 200.563 33.9186 200.506 33.9186 200.46 33.917 200.415 33.9098 200.372 33.8973 200.346 33.888 200.323 33.8723 200.305 33.8516 200.29 33.8284 200.277 33.804 200.265 33.7786L199.739 32.282H197.184L196.679 33.7665C196.67 33.7925 196.658 33.8171 196.642 33.8395 196.624 33.8623 196.599 33.8801 196.572 33.8912 196.531 33.9082 196.488 33.9195 196.444 33.9247 196.373 33.9284 196.3 33.9284 196.228 33.9247 196.152 33.9286 196.076 33.9286 196 33.9247 195.956 33.9208 195.914 33.905 195.879 33.879 195.866 33.8666 195.856 33.8513 195.85 33.8344 195.844 33.8175 195.843 33.7994 195.845 33.7817 195.85 33.7232 195.863 33.6658 195.885 33.6113L197.947 27.9045C197.957 27.8721 197.974 27.842 197.996 27.8163 198.022 27.793 198.054 27.7754 198.087 27.7646 198.137 27.7503 198.188 27.7422 198.239 27.7402 198.3 27.7402 198.379 27.7402 198.473 27.7402 198.568 27.7402 198.659 27.7402 198.726 27.7402 198.781 27.7417 198.835 27.7499 198.887 27.7646 198.923 27.7745 198.955 27.7933 198.982 27.8193 199.005 27.8454 199.023 27.8752 199.036 27.9075L201.096 33.6083zM198.449 28.5677L197.387 31.6371H199.517L198.449 28.5677zM206.154 33.03C206.154 33.0787 206.154 33.1243 206.154 33.1608 206.152 33.1949 206.146 33.2286 206.136 33.2612 206.128 33.2875 206.118 33.3129 206.106 33.3373 206.087 33.3674 206.065 33.395 206.039 33.4194 205.977 33.4735 205.91 33.5214 205.838 33.5624 205.718 33.6367 205.592 33.7008 205.461 33.754 205.293 33.8203 205.12 33.8722 204.944 33.9092 204.734 33.9533 204.52 33.9747 204.305 33.9731 203.936 33.9779 203.569 33.9107 203.225 33.7753 202.908 33.6466 202.627 33.4443 202.404 33.1852 202.164 32.9045 201.986 32.5772 201.88 32.2239 201.752 31.7968 201.691 31.3525 201.698 30.9067 201.69 30.4437 201.757 29.9825 201.896 29.5408 202.01 29.1695 202.199 28.825 202.449 28.5278 202.681 28.2541 202.972 28.0375 203.301 27.8951 203.812 27.6819 204.375 27.6227 204.919 27.7247 205.077 27.7561 205.233 27.7978 205.385 27.8495 205.516 27.8954 205.643 27.9546 205.762 28.0259 205.845 28.0717 205.923 28.1268 205.993 28.1902 206.024 28.2203 206.053 28.2529 206.078 28.2875 206.091 28.3127 206.102 28.3392 206.109 28.3666 206.109 28.397 206.109 28.4305 206.127 28.4731 206.13 28.5217 206.13 28.5705 206.127 28.6191 206.131 28.6738 206.131 28.7287 206.127 28.7834 206.122 28.8208 206.113 28.8576 206.1 28.8929 206.09 28.9187 206.075 28.9417 206.054 28.9598 206.036 28.9745 206.013 28.9821 205.99 28.9811 205.92 28.9696 205.854 28.9379 205.802 28.8898 205.571 28.7089 205.311 28.5698 205.032 28.4792 204.823 28.4141 204.606 28.3833 204.387 28.3879 204.128 28.3846 203.872 28.4408 203.639 28.5522 203.411 28.664 203.214 28.8289 203.064 29.0328 202.893 29.2677 202.766 29.5315 202.69 29.8116 202.518 30.4945 202.518 31.2094 202.69 31.8923 202.759 32.1635 202.882 32.4179 203.052 32.6406 203.205 32.8382 203.404 32.9949 203.633 33.097 203.878 33.204 204.144 33.2569 204.411 33.2521 204.629 33.2561 204.846 33.2253 205.053 33.1608 205.215 33.1086 205.372 33.0414 205.522 32.9601 205.65 32.887 205.756 32.8171 205.826 32.7593 205.881 32.7108 205.948 32.6791 206.021 32.668 206.039 32.6615 206.06 32.6615 206.078 32.668 206.098 32.6812 206.112 32.7005 206.118 32.7228 206.129 32.7585 206.136 32.7952 206.139 32.8323 206.151 32.8962 206.154 32.957 206.154 33.03zM204.271 27.2715H204.104C204.065 27.2691 204.026 27.263 203.989 27.2532 203.958 27.2446 203.929 27.2302 203.903 27.2106 203.879 27.1924 203.855 27.1681 203.824 27.1407L202.808 26.0608C202.785 26.0377 202.767 26.0096 202.757 25.9786 202.753 25.9683 202.753 25.9572 202.756 25.9468 202.76 25.9364 202.766 25.9273 202.775 25.9208 202.803 25.903 202.836 25.8925 202.869 25.8904 202.927 25.8867 202.985 25.8867 203.042 25.8904H203.271L203.408 25.9087C203.436 25.9153 203.463 25.9277 203.487 25.9452L203.544 25.9938 204.278 26.8091 205.032 26.003C205.055 25.9792 205.081 25.9578 205.108 25.9391 205.137 25.92 205.169 25.9065 205.202 25.8995 205.248 25.8893 205.295 25.8822 205.342 25.8782H205.555C205.616 25.8726 205.677 25.8726 205.738 25.8782 205.772 25.8801 205.804 25.8917 205.832 25.9117 205.837 25.9199 205.84 25.9294 205.84 25.9391 205.84 25.9488 205.837 25.9583 205.832 25.9665 205.821 25.9963 205.803 26.0233 205.78 26.0456L204.728 27.1346C204.705 27.1619 204.677 27.1846 204.646 27.2015 204.617 27.221 204.585 27.2354 204.551 27.2441 204.512 27.2569 204.471 27.2641 204.43 27.2654L204.271 27.2715zM211.883 33.5593C211.885 33.6156 211.874 33.6717 211.852 33.7236 211.832 33.765 211.803 33.8015 211.767 33.83 211.734 33.8595 211.694 33.8814 211.652 33.8939 211.61 33.9059 211.567 33.9121 211.524 33.9122H211.256C211.18 33.9134 211.104 33.9042 211.031 33.8848 210.964 33.867 210.902 33.8348 210.848 33.7905 210.784 33.7347 210.727 33.6713 210.678 33.6019 210.609 33.5054 210.548 33.4037 210.496 33.2977L208.619 29.8115C208.521 29.6321 208.424 29.4434 208.314 29.2457 208.205 29.048 208.123 28.8533 208.038 28.6677 208.038 28.8959 208.038 29.1271 208.038 29.3674 208.038 29.6077 208.038 29.8389 208.038 30.0731V33.7662C208.038 33.7892 208.03 33.8116 208.016 33.83 208.001 33.8532 207.977 33.8696 207.949 33.8757 207.909 33.8894 207.867 33.8995 207.825 33.9061 207.759 33.91 207.693 33.91 207.627 33.9061 207.561 33.9101 207.495 33.9101 207.429 33.9061 207.387 33.9004 207.345 33.8902 207.305 33.8757 207.278 33.8694 207.255 33.8531 207.241 33.83 207.227 33.8116 207.219 33.7892 207.219 33.7662V28.1019C207.213 28.0512 207.22 27.9999 207.239 27.9525 207.259 27.9052 207.289 27.8635 207.329 27.8312 207.396 27.7801 207.478 27.7523 207.563 27.7521H207.965C208.044 27.7502 208.124 27.7573 208.202 27.7734 208.264 27.7897 208.322 27.8164 208.375 27.8525 208.431 27.8963 208.48 27.9475 208.521 28.0046 208.577 28.0828 208.627 28.1651 208.67 28.251L210.112 30.9492C210.201 31.1135 210.286 31.2747 210.371 31.4299 210.456 31.585 210.532 31.7341 210.608 31.8923 210.684 32.0505 210.76 32.1965 210.836 32.3425L211.058 32.7866C211.058 32.5372 211.058 32.2756 211.058 32.0048 211.058 31.7341 211.058 31.4725 211.058 31.223V27.8768C211.058 27.8552 211.065 27.834 211.077 27.816 211.094 27.7934 211.117 27.7756 211.144 27.7643 211.185 27.7492 211.228 27.739 211.271 27.7338 211.339 27.73 211.407 27.73 211.475 27.7338 211.538 27.7303 211.601 27.7303 211.664 27.7338 211.706 27.7382 211.748 27.7484 211.788 27.7643 211.815 27.7756 211.838 27.7934 211.855 27.816 211.867 27.834 211.874 27.8552 211.874 27.8768L211.883 33.5593zM214.335 33.7662C214.335 33.7898 214.328 33.8129 214.316 33.8332 214.299 33.8544 214.276 33.8694 214.249 33.8758 214.209 33.8898 214.167 33.9 214.125 33.9062 213.994 33.9224 213.862 33.9224 213.732 33.9062 213.689 33.9003 213.646 33.8901 213.604 33.8758 213.578 33.8702 213.554 33.855 213.537 33.8332 213.525 33.8132 213.517 33.7901 213.516 33.7662V27.8739C213.517 27.8501 213.525 27.827 213.537 27.8069 213.557 27.7856 213.582 27.7707 213.61 27.7643 213.652 27.7507 213.695 27.7405 213.738 27.7339 213.801 27.7302 213.864 27.7302 213.927 27.7339 213.993 27.7301 214.059 27.7301 214.125 27.7339 214.167 27.7401 214.209 27.7503 214.249 27.7643 214.276 27.7707 214.299 27.7857 214.316 27.8069 214.328 27.8272 214.335 27.8503 214.335 27.8739V33.7662zM214.462 26.0547C214.493 26.0192 214.527 25.9875 214.566 25.9604 214.6 25.9378 214.638 25.9204 214.678 25.9087 214.726 25.895 214.775 25.8858 214.824 25.8813H215.028C215.104 25.8789 215.179 25.886 215.253 25.9026 215.294 25.9121 215.333 25.9308 215.366 25.9574 215.377 25.9664 215.384 25.9786 215.388 25.9921 215.392 26.0057 215.392 26.0201 215.387 26.0334 215.374 26.0668 215.356 26.0977 215.332 26.1247L214.255 27.1316C214.228 27.158 214.198 27.1824 214.167 27.2046 214.137 27.2218 214.106 27.236 214.073 27.2472 214.034 27.2594 213.995 27.2676 213.954 27.2715H213.784C213.727 27.2774 213.67 27.2774 213.614 27.2715 213.582 27.2687 213.552 27.2559 213.528 27.235 213.521 27.2264 213.515 27.2161 213.513 27.205 213.51 27.1939 213.51 27.1822 213.513 27.1712 213.523 27.1373 213.541 27.1061 213.565 27.0799L214.462 26.0547zM221.398 28.1023C221.402 28.1549 221.402 28.2078 221.398 28.2605 221.394 28.2977 221.382 28.3338 221.365 28.3669 221.351 28.3912 221.333 28.412 221.31 28.4278 221.291 28.4394 221.269 28.4457 221.246 28.446H218.995V30.5359H221.124C221.147 30.5358 221.169 30.541 221.188 30.5511 221.211 30.5645 221.23 30.5833 221.243 30.6059 221.262 30.6374 221.273 30.6727 221.277 30.7093 221.28 30.764 221.28 30.8189 221.277 30.8735 221.28 30.9242 221.28 30.975 221.277 31.0256 221.273 31.0632 221.262 31.0995 221.243 31.1321 221.23 31.1563 221.211 31.1772 221.188 31.193 221.17 31.2077 221.148 31.2153 221.124 31.2143H218.995V33.7665C218.995 33.7895 218.988 33.812 218.974 33.8304 218.959 33.8534 218.936 33.8698 218.91 33.876 218.869 33.8897 218.827 33.8999 218.785 33.9064 218.718 33.9104 218.651 33.9104 218.584 33.9064 218.519 33.9101 218.454 33.9101 218.39 33.9064 218.346 33.8998 218.304 33.8897 218.262 33.876 218.235 33.8689 218.211 33.8528 218.195 33.8304 218.183 33.8111 218.177 33.789 218.177 33.7665V28.084C218.171 28.0363 218.177 27.988 218.194 27.943 218.211 27.8981 218.239 27.8578 218.274 27.8254 218.333 27.7788 218.406 27.7531 218.481 27.7524H221.246C221.269 27.7528 221.291 27.7591 221.31 27.7707 221.333 27.7857 221.352 27.8067 221.365 27.8315 221.382 27.8669 221.393 27.905 221.398 27.9441 221.402 27.9968 221.402 28.0496 221.398 28.1023zM227.701 30.7548C227.707 31.2092 227.648 31.662 227.525 32.0994 227.421 32.4711 227.243 32.8179 227.002 33.1185 226.764 33.3995 226.464 33.6204 226.125 33.7634 225.342 34.0578 224.48 34.0643 223.692 33.7816 223.367 33.6518 223.079 33.4426 222.855 33.1732 222.623 32.887 222.456 32.5539 222.366 32.1967 222.251 31.758 222.197 31.3056 222.204 30.8522 222.198 30.4084 222.254 29.966 222.372 29.538 222.476 29.1684 222.657 28.8245 222.901 28.5281 223.139 28.2488 223.439 28.0291 223.777 27.8862 224.554 27.5936 225.41 27.5861 226.192 27.8649 226.517 27.9959 226.804 28.2048 227.029 28.4733 227.268 28.7513 227.444 29.0784 227.543 29.4315 227.657 29.8632 227.71 30.3085 227.701 30.7548zM226.837 30.8096C226.84 30.4837 226.808 30.1584 226.743 29.8392 226.692 29.5627 226.588 29.2985 226.439 29.0604 226.297 28.84 226.098 28.6615 225.864 28.5433 225.585 28.4134 225.28 28.3509 224.973 28.3608 224.663 28.3508 224.355 28.4188 224.078 28.5585 223.844 28.6866 223.643 28.8691 223.494 29.0908 223.337 29.3259 223.228 29.5894 223.172 29.8666 223.105 30.1733 223.072 30.4865 223.074 30.8004 223.072 31.1351 223.102 31.4691 223.163 31.7982 223.213 32.0777 223.317 32.345 223.467 32.5861 223.609 32.804 223.806 32.9803 224.039 33.0972 224.324 33.2298 224.637 33.2923 224.951 33.2797 225.267 33.2913 225.581 33.2233 225.864 33.082 226.102 32.9532 226.303 32.7671 226.451 32.5405 226.6 32.3002 226.704 32.034 226.755 31.7556 226.816 31.4441 226.843 31.1269 226.837 30.8096zM233.627 33.5597C233.628 33.6159 233.617 33.6717 233.597 33.724 233.576 33.7651 233.547 33.8013 233.511 33.8305 233.478 33.86 233.439 33.8818 233.396 33.8944 233.354 33.9064 233.311 33.9125 233.268 33.9126H233.019C232.944 33.9138 232.869 33.9046 232.797 33.8852 232.73 33.8674 232.667 33.8352 232.614 33.7909 232.548 33.7367 232.491 33.6732 232.444 33.6023 232.375 33.5058 232.314 33.4041 232.261 33.2981L230.375 29.812C230.278 29.6325 230.177 29.4439 230.071 29.2461 229.964 29.0484 229.879 28.8537 229.791 28.6682 229.791 28.8963 229.791 29.1275 229.806 29.3678 229.821 29.6081 229.806 29.8393 229.806 30.0736V33.7666C229.806 33.7891 229.8 33.8112 229.788 33.8305 229.772 33.8529 229.748 33.869 229.721 33.8761 229.679 33.8898 229.637 33.8999 229.593 33.9065 229.527 33.9105 229.461 33.9105 229.396 33.9065 229.33 33.9104 229.264 33.9104 229.198 33.9065 229.156 33.9004 229.116 33.8902 229.076 33.8761 229.049 33.869 229.026 33.8529 229.009 33.8305 228.998 33.8112 228.991 33.7891 228.991 33.7666V28.1023C228.987 28.0521 228.994 28.0014 229.012 27.9544 229.031 27.9074 229.06 27.8654 229.097 27.8316 229.166 27.7808 229.249 27.7532 229.335 27.7525H229.736C229.816 27.7506 229.896 27.7578 229.974 27.7738 230.035 27.7896 230.092 27.8164 230.144 27.8529 230.201 27.8958 230.251 27.9471 230.293 28.005 230.348 28.0839 230.398 28.1662 230.442 28.2514L231.884 30.9497 232.14 31.4303 232.38 31.8927 232.605 32.3429C232.681 32.4889 232.754 32.6471 232.83 32.7871 232.83 32.5376 232.83 32.276 232.83 32.0053 232.83 31.7345 232.83 31.4729 232.83 31.2235V27.8772C232.831 27.8553 232.838 27.8342 232.851 27.8164 232.868 27.7932 232.892 27.7752 232.918 27.7647 232.958 27.7495 233 27.7393 233.043 27.7343 233.111 27.7305 233.179 27.7305 233.247 27.7343 233.311 27.7308 233.375 27.7308 233.438 27.7343 233.481 27.739 233.523 27.7492 233.563 27.7647 233.589 27.7751 233.611 27.7932 233.627 27.8164 233.641 27.8335 233.649 27.8551 233.648 27.8772L233.627 33.5597zM240.015 30.7246C240.023 31.1979 239.954 31.6695 239.811 32.1209 239.687 32.4927 239.479 32.831 239.203 33.1095 238.931 33.3758 238.601 33.5756 238.239 33.6936 237.8 33.833 237.342 33.8987 236.882 33.8883H235.58C235.505 33.8876 235.432 33.8619 235.373 33.8153 235.338 33.7829 235.31 33.7426 235.293 33.6977 235.277 33.6527 235.27 33.6044 235.276 33.5567V28.0811C235.27 28.0333 235.277 27.985 235.293 27.9401 235.31 27.8951 235.338 27.8548 235.373 27.8225 235.432 27.7758 235.505 27.7501 235.58 27.7495H236.973C237.431 27.7369 237.888 27.807 238.321 27.9563 238.667 28.087 238.98 28.2951 239.233 28.5647 239.487 28.8333 239.679 29.1527 239.799 29.5017 239.938 29.8946 240.011 30.3078 240.015 30.7246zM239.154 30.758C239.156 30.4497 239.115 30.1426 239.033 29.8454 238.958 29.5729 238.825 29.3198 238.643 29.1032 238.461 28.8805 238.227 28.706 237.962 28.5952 237.631 28.4661 237.277 28.4061 236.922 28.4187H236.091V33.2008H236.931C237.267 33.2094 237.603 33.16 237.922 33.0548 238.182 32.964 238.414 32.8091 238.598 32.6045 238.788 32.3833 238.928 32.1225 239.005 31.841 239.099 31.4909 239.144 31.1296 239.139 30.7672L239.154 30.758zM0 0V47.1513H69.428V0H0zM68.0925 45.7976H1.33545V1.29286H68.0925V45.7976z"/><path d="M33.2919 10.9906L34.7003 9.96243 36.1088 10.9906 35.5734 9.32665 37.0031 8.29845H35.2388L34.7003 6.61621 34.1589 8.30149 32.3975 8.29845 33.8273 9.32665 33.2919 10.9906zM26.0001 12.9467L27.4116 11.9215 28.817 12.9467 28.2816 11.2857 29.7113 10.2575H27.95L27.4085 8.57227 26.8701 10.2606 25.1057 10.2575 26.5355 11.2857 26.0001 12.9467zM22.076 13.9199L21.5376 15.6052 19.7732 15.6022 21.2029 16.6304 20.6675 18.2943 22.076 17.2661 23.4845 18.2943 22.9491 16.6304 24.3788 15.6022H22.6144L22.076 13.9199zM20.1199 24.5459L21.5284 25.5741 20.993 23.9132 22.4228 22.885H20.6584L20.1199 21.1997 19.5785 22.888 17.8171 22.885 19.2469 23.9132 18.7115 25.5741 20.1199 24.5459zM22.6144 30.1857L22.076 28.5034 21.5376 30.1887 19.7732 30.1857 21.2029 31.2139 20.6675 32.8778 22.076 31.8466 23.4845 32.8778 22.9491 31.2139 24.3788 30.1857H22.6144zM27.9592 35.5304L27.4207 33.8481 26.8823 35.5334 25.1179 35.5304 26.5477 36.5586 26.0123 38.2226 27.4207 37.1944 28.8292 38.2226 28.2938 36.5586 29.7235 35.5304H27.9592zM35.2417 37.4685L34.7003 35.7832 34.1618 37.4685H32.3975L33.8272 38.4967 33.2918 40.1576 34.7033 39.1294 36.1087 40.1576 35.5733 38.4967 37.0031 37.4685H35.2417zM42.5214 35.5304L41.983 33.8481 41.4415 35.5334 39.6802 35.5304 41.1099 36.5586 40.5745 38.2226 41.983 37.1944 43.3914 38.2226 42.853 36.5586 44.2858 35.5304H42.5214zM47.8661 30.1857L47.3277 28.5034 46.7862 30.1887 45.0249 30.1857 46.4547 31.2139 45.9162 32.8778 47.3277 31.8466 48.7362 32.8778 48.1977 31.2139 49.6305 30.1857H47.8661zM51.5653 22.8635H49.801L49.2625 21.1782 48.721 22.8665 46.9597 22.8635 48.3895 23.8917 47.8541 25.5557 49.2625 24.5244 50.671 25.5557 50.1356 23.8917 51.5653 22.8635zM45.9162 18.2733L47.3277 17.2451 48.7362 18.2733 48.1977 16.6094 49.6305 15.5842H47.8661L47.3277 13.8989 46.7862 15.5842H45.0249L46.4547 16.6094 45.9162 18.2733zM42.0012 8.5752L41.4627 10.2605 39.7014 10.2574 41.1281 11.2887 40.5927 12.9496 42.0042 11.9214 43.4127 12.9496 42.8773 11.2887 44.307 10.2574H42.5427L42.0012 8.5752z"/></g><defs><clipPath id="clip0_2321_61765"><path fill="#fff" d="M0 0H240V47.16H0z"/></clipPath></defs></svg>
+                </a>
+                <a 
+                    href="https://mv.gov.cz/" 
+                    class="footer__logo"
+                    data-type="hideLinkIcon" 
+                    aria-label="Logo – Ministry of the Interior of the Czech Republic – go to the website"
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 163 45" fill="none"><g clip-path="url(#clip0_2321_61679)" fill="#fff"><path d="M73.9171 23.3333H73.1053V18.94L71.3708 21.1237H71.2232L69.4925 18.94H69.474V23.3333H68.6658V17.6948H69.4223L71.2896 20.0079 73.1643 17.6948H73.9023L73.9171 23.3333zM76.3673 23.3333H75.5555V17.6948H76.3673V23.3333zM83.2387 23.3333H82.5449L78.7771 18.9918V23.3333H78.0169V17.6948H78.6627L82.4785 22.0586V17.6948H83.2387V23.3333zM85.7113 23.3333H84.8995V17.6948H85.7113V23.3333zM90.0438 18.9331C89.6981 18.5703 89.2232 18.3591 88.7227 18.3456 88.2023 18.3456 87.8296 18.619 87.8296 19.0144 87.8296 20.097 90.2652 20.0822 90.2652 21.878 90.2685 22.0837 90.2296 22.2879 90.1509 22.4779 90.0722 22.668 89.9553 22.8399 89.8076 22.9829 89.6599 23.126 89.4845 23.2371 89.2921 23.3096 89.0998 23.382 88.8947 23.4141 88.6894 23.404 88.1193 23.4177 87.5618 23.2351 87.11 22.8867V21.8595C87.2761 22.101 87.4958 22.3008 87.7519 22.4431 88.008 22.5854 88.2935 22.6664 88.5861 22.6798 89.2135 22.6798 89.5013 22.2807 89.5013 21.9703 89.5013 20.8027 87.0694 20.6697 87.0694 19.1215 87.0694 18.2052 87.7447 17.6177 88.778 17.6177 89.2267 17.6221 89.6637 17.7611 90.0327 18.0167L90.0438 18.9331zM95.7968 18.4192H93.8483V23.3335H93.0401V18.4192H91.0916V17.6802H95.7968V18.4192zM100.17 18.419H97.7933V20.1224H100.096V20.8614H97.7933V22.6165H100.255V23.3555H96.9852V17.6948H100.181L100.17 18.419zM102.96 17.6948C104.096 17.6948 104.805 18.2934 104.805 19.2726 104.815 19.5731 104.729 19.8691 104.56 20.1176 104.391 20.3661 104.147 20.5541 103.864 20.6545 104.377 20.9907 104.687 21.5117 105.118 22.2175 105.358 22.5869 105.488 22.7939 105.886 23.3259H104.919L104.181 22.1657C103.443 21.0092 103.1 20.8762 102.687 20.8762H102.347V23.3259H101.539V17.6948H102.96zM102.347 20.1557H102.867C103.735 20.1557 103.974 19.7086 103.974 19.2393 103.974 18.7109 103.65 18.3858 102.867 18.3858H102.347V20.1557zM109.602 18.9331C109.432 18.7528 109.227 18.6081 109 18.5073 108.774 18.4064 108.529 18.3515 108.281 18.3456 107.761 18.3456 107.392 18.619 107.392 19.0144 107.392 20.097 109.828 20.0822 109.828 21.878 109.83 22.0839 109.791 22.2881 109.712 22.4782 109.633 22.6683 109.516 22.8401 109.368 22.9831 109.22 23.1261 109.044 23.2372 108.851 23.3096 108.659 23.382 108.453 23.4141 108.248 23.404 107.679 23.4171 107.123 23.2345 106.672 22.8867V21.8595C106.838 22.101 107.058 22.3008 107.314 22.4431 107.57 22.5854 107.856 22.6664 108.148 22.6798 108.776 22.6798 109.067 22.2807 109.067 21.9703 109.067 20.8027 106.628 20.6697 106.628 19.1215 106.628 18.2052 107.307 17.6177 108.34 17.6177 108.792 17.6204 109.231 17.7595 109.602 18.0167V18.9331zM115.348 18.4192H113.4V23.3335H112.591V18.4192H110.639V17.6802H115.348V18.4192zM118.507 23.3814H118.341L115.905 17.6948H116.714L118.404 21.6521 120.09 17.6948H120.895L118.507 23.3814zM124.364 17.6175C126.209 17.6175 127.393 18.9403 127.393 20.5106 127.393 22.081 126.253 23.4038 124.345 23.4038 123.953 23.4236 123.562 23.3635 123.194 23.227 122.826 23.0906 122.49 22.8807 122.206 22.6101 121.921 22.3395 121.695 22.0138 121.54 21.6529 121.386 21.292 121.306 20.9033 121.306 20.5106 121.306 20.1179 121.386 19.7292 121.54 19.3683 121.695 19.0074 121.921 18.6818 122.206 18.4112 122.49 18.1406 122.826 17.9307 123.194 17.7942 123.562 17.6578 123.953 17.5976 124.345 17.6175H124.364zM124.364 22.6611C124.787 22.6531 125.198 22.5202 125.546 22.2791 125.893 22.038 126.162 21.6994 126.319 21.3058 126.475 20.9122 126.512 20.4812 126.424 20.0667 126.337 19.6523 126.129 19.2729 125.827 18.9762 125.525 18.6795 125.143 18.4787 124.727 18.399 124.312 18.3192 123.882 18.3641 123.492 18.528 123.102 18.6919 122.769 18.9675 122.535 19.3202 122.3 19.6729 122.175 20.087 122.175 20.5106 122.171 20.7978 122.224 21.0829 122.333 21.3486 122.442 21.6143 122.604 21.855 122.808 22.0562 123.013 22.2574 123.256 22.4147 123.524 22.5187 123.791 22.6227 124.077 22.6711 124.364 22.6611zM133.541 23.3814H133.379L130.943 17.6948H131.744L133.442 21.6521 135.128 17.6948H135.929L133.541 23.3814zM142.177 23.3333H141.483L137.715 18.9918V23.3333H136.959V17.6948H137.601L141.416 22.0586V17.6948H142.177V23.3333zM144.66 23.3333H143.852V17.6948H144.66V23.3333zM150.539 18.4192H148.59V23.3335H147.779V18.4192H145.83V17.6802H150.539V18.4192zM153.148 17.6948C154.288 17.6948 154.993 18.2934 154.993 19.2726 155.003 19.5736 154.917 19.8699 154.747 20.1185 154.577 20.367 154.332 20.5548 154.048 20.6545 154.561 20.9907 154.875 21.5117 155.303 22.2175 155.543 22.5869 155.672 22.7939 156.071 23.3259H155.107L154.369 22.1657C153.631 21.0092 153.288 20.8762 152.875 20.8762H152.535V23.3259H151.727V17.6948H153.148zM152.535 20.1557H153.056C153.923 20.1557 154.163 19.7086 154.163 19.2393 154.163 18.7109 153.842 18.3858 153.056 18.3858H152.535V20.1557zM162.005 23.3334H161.178L160.44 21.6707H158.045L157.336 23.3334H156.51L158.931 17.6616H159.499L162.005 23.3334zM158.344 20.9427H160.097L159.189 18.8994 158.344 20.9427zM73.4779 28.876C72.8972 28.5054 72.2253 28.3033 71.5368 28.2922 71.2457 28.2781 70.9548 28.3236 70.6819 28.4259 70.409 28.5282 70.1597 28.6851 69.9494 28.887 69.7391 29.089 69.5721 29.3317 69.4586 29.6005 69.3451 29.8692 69.2875 30.1583 69.2894 30.4501 69.2894 31.7137 70.2156 32.5894 71.57 32.5894 72.2727 32.5695 72.9551 32.349 73.5369 31.9539V32.837C72.9109 33.1763 72.208 33.3481 71.4962 33.3358 71.1106 33.3572 70.7246 33.3007 70.3613 33.1697 69.9979 33.0386 69.6646 32.8357 69.3812 32.573 69.0979 32.3103 68.8702 31.9931 68.7117 31.6405 68.5533 31.2878 68.4674 30.9069 68.459 30.5203 68.459 28.8021 69.7544 27.5643 71.5478 27.5643 72.2159 27.5851 72.8727 27.7422 73.4779 28.0262V28.876zM71.0607 27.3426L70.068 26.3745H70.5662L71.5109 26.8955 72.463 26.3745H72.9575L71.9612 27.3426H71.0607zM78.1387 28.3475H75.7548V30.0509H78.0575V30.7899H75.7548V32.545H78.2125V33.284H74.9429V27.6196H78.1387V28.3475zM82.1648 28.8612C81.8192 28.4984 81.3443 28.2872 80.8437 28.2737 80.3234 28.2737 79.9506 28.5471 79.9506 28.9424 79.9506 30.0251 82.3863 30.0103 82.3863 31.806 82.3894 32.0113 82.3508 32.215 82.2725 32.4047 82.1943 32.5944 82.0782 32.7662 81.9314 32.9094 81.7846 33.0526 81.61 33.1643 81.4186 33.2376 81.2271 33.3109 81.0227 33.3443 80.8179 33.3357 80.2467 33.3485 79.6887 33.1632 79.2384 32.8111V31.7765C79.4051 32.0174 79.625 32.2167 79.8809 32.359 80.1369 32.5012 80.4221 32.5826 80.7145 32.5968 81.3419 32.5968 81.6297 32.1977 81.6297 31.8836 81.6297 30.7197 79.1978 30.5867 79.1978 29.0385 79.1978 28.1222 79.8731 27.5347 80.9064 27.5347 81.355 27.5395 81.792 27.6785 82.1611 27.9337L82.1648 28.8612zM88.4753 33.2544H87.3682L84.5082 30.4721V33.2544H83.6964V27.6196H84.5082V30.2061L86.8774 27.6196H87.8849L85.4197 30.2985 88.4753 33.2544zM92.7154 28.3476H90.3278V30.051H92.6269V30.79H90.3241V32.5451H92.7856V33.2841H89.5159V27.6197H92.7118L92.7154 28.3476zM92.328 26.3819L91.2615 27.3426H90.7817L91.4017 26.3745 92.328 26.3819zM99.4871 27.6196C100.627 27.6196 101.332 28.2256 101.332 29.1974 101.343 29.4981 101.257 29.7943 101.088 30.0429 100.919 30.2915 100.675 30.4795 100.391 30.5793 100.9 30.9192 101.214 31.4402 101.646 32.1423 101.886 32.5339 102.015 32.7224 102.414 33.2507H101.447L100.709 32.0942C99.9705 30.9377 99.631 30.8047 99.2325 30.8047H98.8966V33.2544H98.0848V27.6196H99.4871zM98.8782 30.0842H99.3985C100.266 30.0842 100.506 29.6371 100.506 29.1678 100.506 28.6357 100.185 28.3143 99.3985 28.3143H98.8782V30.0842zM106.65 28.3475H104.266V30.0509H106.569V30.7899H104.266V32.545H106.728V33.284H103.458V27.6196H106.65V28.3475zM109.717 27.6196C110.949 27.6196 111.51 28.3586 111.51 29.2417 111.51 30.1248 110.916 30.8232 109.61 30.8232H108.768V33.2544H107.96V27.6196H109.717zM108.768 30.0916H109.683C110.289 30.0916 110.676 29.7701 110.676 29.2085 110.676 28.7946 110.451 28.3475 109.717 28.3475H108.768V30.0916zM117.352 31.0375C117.352 32.4157 116.525 33.3283 114.85 33.3283 113.662 33.3283 112.507 32.6559 112.507 31.1114V27.6196H113.315V30.9451C113.315 31.5843 113.396 31.8467 113.651 32.1016 113.809 32.2605 113.999 32.3852 114.208 32.4678 114.417 32.5504 114.64 32.5893 114.865 32.582 115.104 32.6006 115.345 32.5717 115.573 32.4968 115.801 32.422 116.012 32.3028 116.193 32.146 116.335 31.9766 116.441 31.7802 116.504 31.5687 116.567 31.3572 116.587 31.135 116.562 30.9155V27.6196H117.352V31.0375zM118.891 27.6196H120.526C121.74 27.6196 122.26 28.3586 122.26 29.0607 122.273 29.3273 122.196 29.5906 122.042 29.8087 121.888 30.0268 121.666 30.1875 121.411 30.2652 122.249 30.4204 122.762 30.9783 122.762 31.7432 122.762 32.4379 122.245 33.247 120.828 33.247H118.898L118.891 27.6196zM119.699 30.0361H120.238C121.039 30.0361 121.426 29.7368 121.426 29.1346 121.426 28.7133 121.186 28.3475 120.445 28.3475H119.706L119.699 30.0361zM119.699 32.5339H120.714C121.666 32.5339 121.924 32.061 121.924 31.6397 121.924 31.1261 121.526 30.764 120.673 30.764H119.699V32.5339zM124.759 32.5339H127.316V33.2729H123.965V27.6196H124.773L124.759 32.5339zM129.235 33.2544H128.423V27.6196H129.231L129.235 33.2544zM135.686 33.2544H134.578L131.711 30.4684V33.2544H130.903V27.6196H131.711V30.2061L134.08 27.6196H135.088L132.63 30.2985 135.686 33.2544zM140.125 27.6196H141.099L139.011 30.2985V33.2544H138.199V30.2763L136.11 27.6196H137.084L138.597 29.5632 140.125 27.6196zM4.3062 2.15786C4.3062 2.5848 4.1797 3.00215 3.94273 3.35708 3.70576 3.71202 3.36895 3.9886 2.97494 4.15181 2.58092 4.31502 2.1474 4.35754 1.72925 4.27398 1.31109 4.19042.927087 3.98453.625833 3.68238.324578 3.38023.119613 2.99539.0368731 2.57657-.0458663 2.15774-.00266045 1.72375.161023 1.32952.324707.935288.601511.598533.956407.36187 1.3113.125207 1.72834-.000727898 2.15474.00000316494 2.72568.000982034 3.2729.228759 3.67627.63333 4.07964 1.0379 4.3062 1.5862 4.3062 2.15786zM57.5689 2.15786C57.5689 2.58448 57.4426 3.00153 57.2059 3.35631 56.9693 3.71109 56.6329 3.98767 56.2393 4.1511 55.8457 4.31453 55.4126 4.35748 54.9946 4.27452 54.5767 4.19155 54.1927 3.9864 53.8911 3.68499 53.5896 3.38358 53.384 2.99943 53.3004 2.58109 53.2169 2.16275 53.259 1.729 53.4216 1.33464 53.5841.940277 53.8598.603011 54.2137.365459 54.5676.127907 54.9839.000730524 55.41 0 55.9819-8.3664e-7 56.5305.227226 56.9353.631797 57.34 1.03637 57.5679 1.58522 57.5689 2.15786zM4.30657 8.82352C4.30366 9.24982 4.17469 9.6657 3.93595 10.0187 3.69721 10.3717 3.3594 10.6459 2.96513 10.8069 2.57087 10.9678 2.13783 11.0083 1.72065 10.923 1.30347 10.8378.920851 10.6308.621072 10.328.321294 10.0253.117789 9.64045.0362393 9.22204-.0453108 8.80362-.00125222 8.37039.162855 7.97702.326963 7.58365.603766 7.24777.958334 7.01175 1.3129 6.77573 1.72935 6.65016 2.15512 6.65088 2.43921 6.65087 2.72049 6.7072 2.98273 6.81661 3.24497 6.92602 3.48296 7.08635 3.68299 7.28834 3.88301 7.49033 4.0411 7.72999 4.14813 7.99348 4.25516 8.25697 4.30901 8.53908 4.30657 8.82352zM10.9639 8.82352C10.961 9.24982 10.832 9.6657 10.5933 10.0187 10.3545 10.3717 10.0167 10.6459 9.62245 10.8069 9.22819 10.9678 8.79515 11.0083 8.37797 10.923 7.96079 10.8378 7.57817 10.6308 7.27839 10.328 6.97861 10.0253 6.77511 9.64045 6.69356 9.22204 6.61201 8.80362 6.65607 8.37039 6.82017 7.97702 6.98428 7.58365 7.26108 7.24777 7.61565 7.01175 7.97022 6.77573 8.38667 6.65016 8.81244 6.65088 9.09653 6.65087 9.37781 6.7072 9.64005 6.81661 9.90229 6.92602 10.1403 7.08635 10.3403 7.28834 10.5403 7.49033 10.6984 7.72999 10.8054 7.99348 10.9125 8.25697 10.9663 8.53908 10.9639 8.82352zM50.9041 8.82352C50.9012 9.24982 50.7723 9.6657 50.5335 10.0187 50.2948 10.3717 49.957 10.6459 49.5627 10.8069 49.1684 10.9678 48.7354 11.0083 48.3182 10.923 47.901 10.8378 47.5184 10.6308 47.2186 10.328 46.9189 10.0253 46.7154 9.64045 46.6338 9.22204 46.5523 8.80362 46.5963 8.37039 46.7604 7.97702 46.9245 7.58365 47.2013 7.24777 47.5559 7.01175 47.9105 6.77573 48.3269 6.65016 48.7527 6.65088 49.0368 6.65087 49.3181 6.7072 49.5803 6.81661 49.8425 6.92602 50.0805 7.08635 50.2806 7.28834 50.4806 7.49033 50.6387 7.72999 50.7457 7.99348 50.8527 8.25697 50.9066 8.53908 50.9041 8.82352zM57.5688 8.82352C57.5659 9.2495 57.4371 9.66509 57.1987 10.0179 56.9603 10.3707 56.6229 10.645 56.2291 10.8062 55.8353 10.9674 55.4026 11.0082 54.9856 10.9236 54.5686 10.839 54.186 10.6327 53.8859 10.3307 53.5859 10.0287 53.3818 9.6445 53.2994 9.22657 53.217 8.80864 53.26 8.37564 53.423 7.98214 53.586 7.58864 53.8616 7.25224 54.2152 7.01534 54.5688 6.77843 54.9845 6.65162 55.41 6.65088 55.6946 6.65039 55.9764 6.70633 56.2393 6.81548 56.5022 6.92462 56.7408 7.08481 56.9415 7.28681 57.1423 7.4888 57.301 7.72859 57.4087 7.99235 57.5163 8.2561 57.5708 8.53859 57.5688 8.82352zM4.30668 15.4894C4.30668 15.9163 4.18019 16.3337 3.94322 16.6886 3.70625 17.0436 3.36944 17.3201 2.97542 17.4834 2.58141 17.6466 2.14789 17.6891 1.72974 17.6055 1.31158 17.522.927576 17.3161.626321 17.0139.325067 16.7118.120101 16.3269.0373614 15.9081-.045378 15.4893-.00217217 15.0553.161511 14.6611.325195 14.2668.601999 13.9301.956896 13.6934 1.31179 13.4567 1.72883 13.3308 2.15523 13.3315 2.72617 13.3325 3.27339 13.5603 3.67676 13.9649 4.08013 14.3694 4.30668 14.9177 4.30668 15.4894zM10.9639 15.4894C10.9639 15.9163 10.8374 16.3337 10.6004 16.6886 10.3635 17.0436 10.0267 17.3201 9.63265 17.4834 9.23864 17.6466 8.80512 17.6891 8.38696 17.6055 7.96881 17.522 7.5848 17.3161 7.28355 17.0139 6.98229 16.7118 6.77733 16.3269 6.69459 15.9081 6.61185 15.4893 6.65505 15.0553 6.81874 14.6611 6.98242 14.2668 7.25923 13.9301 7.61412 13.6934 7.96902 13.4567 8.38606 13.3308 8.81246 13.3315 9.3834 13.3325 9.93062 13.5603 10.334 13.9649 10.7374 14.3694 10.9639 14.9177 10.9639 15.4894zM17.6174 15.4894C17.6167 15.9155 17.4898 16.3317 17.2528 16.6856 17.0158 17.0394 16.6793 17.3149 16.2859 17.4773 15.8925 17.6397 15.4598 17.6816 15.0426 17.5977 14.6254 17.5139 14.2424 17.3081 13.9421 17.0063 13.6417 16.7045 13.4374 16.3203 13.3551 15.9023 13.2728 15.4843 13.3162 15.0513 13.4797 14.6579 13.6432 14.2646 13.9195 13.9286 14.2738 13.6925 14.628 13.4564 15.0441 13.3308 15.4697 13.3315 15.7522 13.332 16.0319 13.3882 16.2927 13.4969 16.5535 13.6056 16.7904 13.7647 16.9899 13.9651 17.1893 14.1655 17.3474 14.4032 17.4551 14.6648 17.5627 14.9263 17.6179 15.2065 17.6174 15.4894zM44.2469 15.4894C44.2469 15.9163 44.1204 16.3337 43.8834 16.6886 43.6464 17.0436 43.3096 17.3201 42.9156 17.4834 42.5216 17.6466 42.0881 17.6891 41.6699 17.6055 41.2518 17.522 40.8678 17.3161 40.5665 17.0139 40.2653 16.7118 40.0603 16.3269 39.9775 15.9081 39.8948 15.4893 39.938 15.0553 40.1017 14.6611 40.2654 14.2668 40.5422 13.9301 40.8971 13.6934 41.252 13.4567 41.669 13.3308 42.0954 13.3315 42.6663 13.3325 43.2136 13.5603 43.6169 13.9649 44.0203 14.3694 44.2469 14.9177 44.2469 15.4894zM50.9041 15.4894C50.9041 15.9163 50.7776 16.3337 50.5406 16.6886 50.3037 17.0436 49.9669 17.3201 49.5728 17.4834 49.1788 17.6466 48.7453 17.6891 48.3272 17.6055 47.909 17.522 47.525 17.3161 47.2237 17.0139 46.9225 16.7118 46.7175 16.3269 46.6348 15.9081 46.552 15.4893 46.5952 15.0553 46.7589 14.6611 46.9226 14.2668 47.1994 13.9301 47.5543 13.6934 47.9092 13.4567 48.3262 13.3308 48.7526 13.3315 49.3236 13.3325 49.8708 13.5603 50.2742 13.9649 50.6776 14.3694 50.9041 14.9177 50.9041 15.4894zM57.5689 15.4894C57.5689 15.9163 57.4424 16.3337 57.2054 16.6886 56.9685 17.0436 56.6316 17.3201 56.2376 17.4834 55.8436 17.6466 55.4101 17.6891 54.9919 17.6055 54.5738 17.522 54.1898 17.3161 53.8885 17.0139 53.5873 16.7118 53.3823 16.3269 53.2996 15.9081 53.2168 15.4893 53.26 15.0553 53.4237 14.6611 53.5874 14.2668 53.8642 13.9301 54.2191 13.6934 54.574 13.4567 54.991 13.3308 55.4174 13.3315 55.9884 13.3325 56.5356 13.5603 56.939 13.9649 57.3423 14.3694 57.5689 14.9177 57.5689 15.4894zM4.30668 22.1696C4.30668 22.5965 4.18019 23.0139 3.94322 23.3688 3.70625 23.7237 3.36944 24.0003 2.97542 24.1635 2.58141 24.3267 2.14789 24.3693 1.72974 24.2857 1.31158 24.2021.927576 23.9963.626321 23.6941.325067 23.3919.120101 23.0071.0373614 22.5883-.045378 22.1695-.00217217 21.7355.161511 21.3412.325195 20.947.601999 20.6103.956896 20.3736 1.31179 20.1369 1.72883 20.011 2.15523 20.0117 2.72617 20.0127 3.27339 20.2405 3.67676 20.645 4.08013 21.0496 4.30668 21.5979 4.30668 22.1696zM10.9639 22.1696C10.9639 22.5965 10.8374 23.0139 10.6004 23.3688 10.3635 23.7237 10.0267 24.0003 9.63265 24.1635 9.23864 24.3267 8.80512 24.3693 8.38696 24.2857 7.96881 24.2021 7.5848 23.9963 7.28355 23.6941 6.98229 23.3919 6.77733 23.0071 6.69459 22.5883 6.61185 22.1695 6.65505 21.7355 6.81874 21.3412 6.98242 20.947 7.25923 20.6103 7.61412 20.3736 7.96902 20.1369 8.38606 20.011 8.81246 20.0117 9.3834 20.0127 9.93062 20.2405 10.334 20.645 10.7374 21.0496 10.9639 21.5979 10.9639 22.1696zM17.6174 22.1696C17.6167 22.5956 17.4898 23.0119 17.2528 23.3657 17.0158 23.7196 16.6793 23.9951 16.2859 24.1575 15.8925 24.3198 15.4598 24.3618 15.0426 24.2779 14.6254 24.1941 14.2424 23.9883 13.9421 23.6865 13.6417 23.3847 13.4374 23.0005 13.3551 22.5825 13.2728 22.1645 13.3162 21.7314 13.4797 21.3381 13.6432 20.9448 13.9195 20.6088 14.2738 20.3727 14.628 20.1366 15.0441 20.011 15.4697 20.0117 15.7522 20.0122 16.0319 20.0684 16.2927 20.1771 16.5535 20.2858 16.7904 20.4449 16.9899 20.6453 17.1893 20.8456 17.3474 21.0834 17.4551 21.3449 17.5627 21.6065 17.6179 21.8867 17.6174 22.1696zM24.2749 22.1698C24.2712 22.5958 24.1415 23.0112 23.902 23.3634 23.6626 23.7156 23.3242 23.9888 22.9297 24.1484 22.5352 24.3081 22.1023 24.347 21.6857 24.2603 21.2691 24.1736 20.8875 23.9652 20.5892 23.6613 20.2909 23.3575 20.0893 22.9719 20.0099 22.5534 19.9304 22.1348 19.9767 21.7021 20.1429 21.3099 20.3091 20.9177 20.5877 20.5836 20.9436 20.3499 21.2994 20.1163 21.7164 19.9935 22.1419 19.9971 22.4244 19.9996 22.7037 20.0577 22.9638 20.1682 23.2239 20.2787 23.4597 20.4394 23.6578 20.6411 23.8559 20.8429 24.0123 21.0817 24.1182 21.344 24.2241 21.6063 24.2773 21.8869 24.2749 22.1698zM37.5895 22.1697C37.5866 22.5955 37.4579 23.011 37.2197 23.3637 36.9814 23.7165 36.6443 23.9908 36.2506 24.152 35.857 24.3133 35.4245 24.3544 35.0077 24.2701 34.5908 24.1857 34.2082 23.9798 33.9079 23.6782 33.6077 23.3765 33.4033 22.9927 33.3205 22.575 33.2377 22.1573 33.2802 21.7245 33.4426 21.3309 33.605 20.9373 33.8801 20.6007 34.2332 20.3633 34.5864 20.126 35.0017 19.9986 35.427 19.9971 35.7119 19.9961 35.9941 20.0517 36.2574 20.1606 36.5207 20.2695 36.7598 20.4297 36.9609 20.6317 37.162 20.8337 37.3211 21.0737 37.429 21.3377 37.5369 21.6017 37.5915 21.8845 37.5895 22.1697zM44.2469 22.1696C44.2469 22.5965 44.1204 23.0139 43.8834 23.3688 43.6464 23.7237 43.3096 24.0003 42.9156 24.1635 42.5216 24.3267 42.0881 24.3693 41.6699 24.2857 41.2518 24.2021 40.8678 23.9963 40.5665 23.6941 40.2653 23.3919 40.0603 23.0071 39.9775 22.5883 39.8948 22.1695 39.938 21.7355 40.1017 21.3412 40.2654 20.947 40.5422 20.6103 40.8971 20.3736 41.252 20.1369 41.669 20.011 42.0954 20.0117 42.6663 20.0127 43.2136 20.2405 43.6169 20.645 44.0203 21.0496 44.2469 21.5979 44.2469 22.1696zM50.9041 22.1696C50.9041 22.5965 50.7776 23.0139 50.5406 23.3688 50.3037 23.7237 49.9669 24.0003 49.5728 24.1635 49.1788 24.3267 48.7453 24.3693 48.3272 24.2857 47.909 24.2021 47.525 23.9963 47.2237 23.6941 46.9225 23.3919 46.7175 23.0071 46.6348 22.5883 46.552 22.1695 46.5952 21.7355 46.7589 21.3412 46.9226 20.947 47.1994 20.6103 47.5543 20.3736 47.9092 20.1369 48.3262 20.011 48.7526 20.0117 49.3236 20.0127 49.8708 20.2405 50.2742 20.645 50.6776 21.0496 50.9041 21.5979 50.9041 22.1696zM57.5689 22.1696C57.5689 22.5965 57.4424 23.0139 57.2054 23.3688 56.9685 23.7237 56.6316 24.0003 56.2376 24.1635 55.8436 24.3267 55.4101 24.3693 54.9919 24.2857 54.5738 24.2021 54.1898 23.9963 53.8885 23.6941 53.5873 23.3919 53.3823 23.0071 53.2996 22.5883 53.2168 22.1695 53.26 21.7355 53.4237 21.3412 53.5874 20.947 53.8642 20.6103 54.2191 20.3736 54.574 20.1369 54.991 20.011 55.4174 20.0117 55.9884 20.0127 56.5356 20.2405 56.939 20.645 57.3423 21.0496 57.5689 21.5979 57.5689 22.1696zM4.30659 28.8207C4.30586 29.2475 4.17875 29.6645 3.94133 30.0189 3.70391 30.3734 3.36685 30.6494 2.97278 30.812 2.5787 30.9747 2.1453 31.0167 1.72738 30.9327 1.30947 30.8487.925813 30.6425.624928 30.3402.324042 30.038.119443 29.6531.0370021 29.2344-.0454386 28.8157-.00201797 28.3819.161773 27.9878.325565 27.5938.60237 27.2573.957186 27.0208 1.312 26.7843 1.72889 26.6585 2.15514 26.6592 2.43815 26.6597 2.71831 26.716 2.97959 26.8249 3.24088 26.9337 3.47819 27.0931 3.67797 27.2938 3.87775 27.4945 4.03609 27.7327 4.14395 27.9947 4.25181 28.2567 4.30707 28.5374 4.30659 28.8207zM10.9639 28.8207C10.9632 29.2475 10.8361 29.6645 10.5987 30.0189 10.3612 30.3734 10.0242 30.6494 9.6301 30.812 9.23602 30.9747 8.80262 31.0167 8.3847 30.9327 7.96679 30.8487 7.58313 30.6425 7.28225 30.3402 6.98136 30.038 6.77676 29.6531 6.69432 29.2344 6.61188 28.8157 6.6553 28.3819 6.81909 27.9878 6.98288 27.5938 7.25969 27.2573 7.6145 27.0208 7.96932 26.7843 8.38621 26.6585 8.81246 26.6592 9.09547 26.6597 9.37562 26.716 9.63691 26.8249 9.8982 26.9337 10.1355 27.0931 10.3353 27.2938 10.5351 27.4945 10.6934 27.7327 10.8013 27.9947 10.9091 28.2567 10.9644 28.5374 10.9639 28.8207zM17.6176 28.8207C17.6161 29.2466 17.4886 29.6625 17.2511 30.0159 17.0137 30.3692 16.6769 30.6442 16.2835 30.806 15.89 30.9678 15.4575 31.0092 15.0405 30.9249 14.6236 30.8407 14.2409 30.6346 13.9409 30.3326 13.6409 30.0307 13.437 29.6465 13.355 29.2286 13.273 28.8107 13.3166 28.3778 13.4802 27.9847 13.6438 27.5916 13.9202 27.2559 14.2743 27.0199 14.6284 26.784 15.0444 26.6585 15.4698 26.6592 15.7526 26.6597 16.0326 26.716 16.2937 26.8249 16.5548 26.9339 16.7918 27.0933 16.9913 27.294 17.1908 27.4948 17.3488 27.733 17.4563 27.995 17.5637 28.2569 17.6185 28.5375 17.6176 28.8207zM24.2749 28.8208C24.2734 29.2473 24.1455 29.6638 23.9074 30.0175 23.6693 30.3711 23.3317 30.6461 22.9373 30.8074 22.543 30.9688 22.1097 31.0093 21.6924 30.9238 21.275 30.8384 20.8924 30.6308 20.593 30.3274 20.2936 30.024 20.0909 29.6384 20.0106 29.2195 19.9303 28.8006 19.9759 28.3673 20.1418 27.9745 20.3077 27.5816 20.5863 27.2469 20.9424 27.0128 21.2984 26.7786 21.7159 26.6556 22.1419 26.6593 22.7106 26.6641 23.2542 26.8943 23.6539 27.2993 24.0536 27.7044 24.2768 28.2514 24.2749 28.8208zM30.9322 28.8207C30.9315 29.2477 30.8043 29.6648 30.5667 30.0193 30.3291 30.3739 29.9918 30.6499 29.5975 30.8124 29.2032 30.9749 28.7696 31.0167 28.3516 30.9324 27.9336 30.8481 27.55 30.6416 27.2492 30.3389 26.9485 30.0363 26.7442 29.6511 26.6622 29.2321 26.5801 28.8131 26.6241 28.3792 26.7884 27.9853 26.9528 27.5913 27.2302 27.2551 27.5855 27.019 27.9408 26.783 28.358 26.6577 28.7844 26.6592 29.3554 26.6611 29.9022 26.8899 30.3049 27.2951 30.7076 27.7004 30.9332 28.2491 30.9322 28.8207zM37.5894 28.8207C37.5887 29.247 37.4618 29.6636 37.2249 30.0178 36.988 30.372 36.6516 30.648 36.2581 30.811 35.8647 30.974 35.4319 31.0166 35.0143 30.9335 34.5966 30.8504 34.213 30.6454 33.9116 30.3442 33.6103 30.043 33.4048 29.6592 33.3212 29.2412 33.2375 28.8232 33.2793 28.3897 33.4414 27.9955 33.6035 27.6013 33.8786 27.264 34.2319 27.0262 34.5853 26.7884 35.0011 26.6607 35.4269 26.6592 35.7108 26.6582 35.9922 26.7134 36.2547 26.8217 36.5173 26.9299 36.7559 27.089 36.9569 27.2899 37.1578 27.4908 37.3171 27.7294 37.4257 27.9921 37.5342 28.2548 37.5899 28.5364 37.5894 28.8207zM44.2468 28.8207C44.2461 29.2475 44.119 29.6645 43.8816 30.0189 43.6442 30.3734 43.3071 30.6494 42.913 30.812 42.5189 30.9747 42.0855 31.0167 41.6676 30.9327 41.2497 30.8487 40.8661 30.6425 40.5652 30.3402 40.2643 30.038 40.0597 29.6531 39.9772 29.2344 39.8948 28.8157 39.9382 28.3819 40.102 27.9878 40.2658 27.5938 40.5426 27.2573 40.8974 27.0208 41.2522 26.7843 41.6691 26.6585 42.0954 26.6592 42.3784 26.6597 42.6585 26.716 42.9198 26.8249 43.1811 26.9337 43.4184 27.0931 43.6182 27.2938 43.818 27.4945 43.9763 27.7327 44.0842 27.9947 44.192 28.2567 44.2473 28.5374 44.2468 28.8207zM50.9042 28.8207C50.9035 29.2475 50.7763 29.6645 50.5389 30.0189 50.3015 30.3734 49.9645 30.6494 49.5704 30.812 49.1763 30.9747 48.7429 31.0167 48.325 30.9327 47.9071 30.8487 47.5234 30.6425 47.2225 30.3402 46.9216 30.038 46.717 29.6531 46.6346 29.2344 46.5522 28.8157 46.5956 28.3819 46.7594 27.9878 46.9232 27.5938 47.2 27.2573 47.5548 27.0208 47.9096 26.7843 48.3265 26.6585 48.7527 26.6592 49.0358 26.6597 49.3159 26.716 49.5772 26.8249 49.8385 26.9337 50.0758 27.0931 50.2756 27.2938 50.4753 27.4945 50.6337 27.7327 50.7415 27.9947 50.8494 28.2567 50.9047 28.5374 50.9042 28.8207zM57.5689 28.8207C57.5681 29.2475 57.441 29.6645 57.2036 30.0189 56.9662 30.3734 56.6291 30.6494 56.235 30.812 55.841 30.9747 55.4076 31.0167 54.9897 30.9327 54.5717 30.8487 54.1881 30.6425 53.8872 30.3402 53.5863 30.038 53.3817 29.6531 53.2993 29.2344 53.2168 28.8157 53.2602 28.3819 53.424 27.9878 53.5878 27.5938 53.8646 27.2573 54.2195 27.0208 54.5743 26.7843 54.9912 26.6585 55.4174 26.6592 55.7004 26.6597 55.9806 26.716 56.2419 26.8249 56.5032 26.9337 56.7405 27.0931 56.9402 27.2938 57.14 27.4945 57.2984 27.7327 57.4062 27.9947 57.5141 28.2567 57.5693 28.5374 57.5689 28.8207zM4.30668 35.4718C4.30668 35.8988 4.18019 36.3161 3.94322 36.6711 3.70625 37.026 3.36944 37.3026 2.97542 37.4658 2.58141 37.629 2.14789 37.6715 1.72974 37.5879 1.31158 37.5044.927576 37.2985.626321 36.9964.325067 36.6942.120101 36.3094.0373614 35.8905-.045378 35.4717-.00217217 35.0377.161511 34.6435.325195 34.2493.601999 33.9125.956896 33.6758 1.31179 33.4392 1.72883 33.3132 2.15523 33.314 2.72617 33.3149 3.27339 33.5427 3.67676 33.9473 4.08013 34.3519 4.30668 34.9002 4.30668 35.4718zM10.9639 35.4718C10.9639 35.8988 10.8374 36.3161 10.6004 36.6711 10.3635 37.026 10.0267 37.3026 9.63265 37.4658 9.23864 37.629 8.80512 37.6715 8.38696 37.5879 7.96881 37.5044 7.5848 37.2985 7.28355 36.9964 6.98229 36.6942 6.77733 36.3094 6.69459 35.8905 6.61185 35.4717 6.65505 35.0377 6.81874 34.6435 6.98242 34.2493 7.25923 33.9125 7.61412 33.6758 7.96902 33.4392 8.38606 33.3132 8.81246 33.314 9.3834 33.3149 9.93062 33.5427 10.334 33.9473 10.7374 34.3519 10.9639 34.9002 10.9639 35.4718zM17.6174 35.4718C17.6167 35.8979 17.4898 36.3141 17.2528 36.668 17.0158 37.0218 16.6793 37.2974 16.2859 37.4597 15.8925 37.6221 15.4598 37.664 15.0426 37.5802 14.6254 37.4963 14.2424 37.2905 13.9421 36.9887 13.6417 36.687 13.4374 36.3028 13.3551 35.8848 13.2728 35.4667 13.3162 35.0337 13.4797 34.6404 13.6432 34.247 13.9195 33.9111 14.2738 33.675 14.628 33.4389 15.0441 33.3132 15.4697 33.314 15.7522 33.3145 16.0319 33.3706 16.2927 33.4794 16.5535 33.5881 16.7904 33.7471 16.9899 33.9475 17.1893 34.1479 17.3474 34.3856 17.4551 34.6472 17.5627 34.9087 17.6179 35.1889 17.6174 35.4718zM24.2749 35.4716C24.2763 35.8987 24.1509 36.3166 23.9146 36.6722 23.6782 37.0279 23.3416 37.3051 22.9476 37.4687 22.5535 37.6323 22.1197 37.675 21.7014 37.5912 21.2831 37.5074 20.8991 37.301 20.5982 36.9981 20.2973 36.6953 20.0931 36.3098 20.0116 35.8905 19.9301 35.4712 19.9749 35.0371 20.1404 34.6434 20.3058 34.2497 20.5845 33.9141 20.9408 33.6793 21.2972 33.4445 21.7153 33.3211 22.1419 33.3248 22.708 33.3296 23.2494 33.5577 23.6487 33.9596 24.048 34.3615 24.273 34.9047 24.2749 35.4716zM30.9321 35.4715C30.9343 35.899 30.8096 36.3176 30.5738 36.6741 30.338 37.0306 30.0018 37.3089 29.6077 37.4737 29.2137 37.6385 28.7796 37.6824 28.3607 37.5998 27.9417 37.5172 27.5566 37.3118 27.2544 37.0097 26.9522 36.7076 26.7464 36.3225 26.6632 35.9031 26.58 35.4837 26.6231 35.0491 26.787 34.6542 26.9509 34.2594 27.2283 33.9223 27.5839 33.6856 27.9395 33.4489 28.3573 33.3233 28.7844 33.3247 29.3528 33.3267 29.8974 33.5533 30.2996 33.9554 30.7019 34.3575 30.9292 34.9024 30.9321 35.4715zM37.5896 35.4715C37.5918 35.8984 37.4674 36.3164 37.2323 36.6726 36.9972 37.0287 36.6618 37.307 36.2686 37.4722 35.8754 37.6375 35.4421 37.6822 35.0236 37.6008 34.605 37.5194 34.2199 37.3155 33.9171 37.0149 33.6143 36.7143 33.4074 36.3305 33.3225 35.9122 33.2376 35.4938 33.2786 35.0596 33.4402 34.6645 33.6019 34.2694 33.877 33.9312 34.2306 33.6928 34.5843 33.4543 35.0007 33.3262 35.4271 33.3247 35.998 33.3228 36.5464 33.5477 36.9519 33.9502 37.3573 34.3527 37.5867 34.8998 37.5896 35.4715zM44.2469 35.4718C44.2469 35.8988 44.1204 36.3161 43.8834 36.6711 43.6464 37.026 43.3096 37.3026 42.9156 37.4658 42.5216 37.629 42.0881 37.6715 41.6699 37.5879 41.2518 37.5044 40.8678 37.2985 40.5665 36.9964 40.2653 36.6942 40.0603 36.3094 39.9775 35.8905 39.8948 35.4717 39.938 35.0377 40.1017 34.6435 40.2654 34.2493 40.5422 33.9125 40.8971 33.6758 41.252 33.4392 41.669 33.3132 42.0954 33.314 42.666 33.3159 43.2127 33.544 43.6159 33.9484 44.019 34.3527 44.2459 34.9005 44.2469 35.4718zM50.9041 35.4718C50.9041 35.8988 50.7776 36.3161 50.5406 36.6711 50.3037 37.026 49.9669 37.3026 49.5728 37.4658 49.1788 37.629 48.7453 37.6715 48.3272 37.5879 47.909 37.5044 47.525 37.2985 47.2237 36.9964 46.9225 36.6942 46.7175 36.3094 46.6348 35.8905 46.552 35.4717 46.5952 35.0377 46.7589 34.6435 46.9226 34.2493 47.1994 33.9125 47.5543 33.6758 47.9092 33.4392 48.3262 33.3132 48.7526 33.314 49.3236 33.3149 49.8708 33.5427 50.2742 33.9473 50.6776 34.3519 50.9041 34.9002 50.9041 35.4718zM57.5689 35.4718C57.5689 35.8988 57.4424 36.3161 57.2054 36.6711 56.9685 37.026 56.6316 37.3026 56.2376 37.4658 55.8436 37.629 55.4101 37.6715 54.9919 37.5879 54.5738 37.5044 54.1898 37.2985 53.8885 36.9964 53.5873 36.6942 53.3823 36.3094 53.2996 35.8905 53.2168 35.4717 53.26 35.0377 53.4237 34.6435 53.5874 34.2493 53.8642 33.9125 54.2191 33.6758 54.574 33.4392 54.991 33.3132 55.4174 33.314 55.9881 33.3159 56.5347 33.544 56.9379 33.9484 57.3411 34.3527 57.5679 34.9005 57.5689 35.4718zM4.30668 42.1486C4.30668 42.5755 4.18019 42.9929 3.94322 43.3478 3.70625 43.7027 3.36944 43.9793 2.97542 44.1425 2.58141 44.3057 2.14789 44.3483 1.72974 44.2647 1.31158 44.1811.927576 43.9753.626321 43.6731.325067 43.371.120101 42.9861.0373614 42.5673-.045378 42.1485-.00217217 41.7145.161511 41.3202.325195 40.926.601999 40.5893.956896 40.3526 1.31179 40.1159 1.72883 39.99 2.15523 39.9907 2.72617 39.9917 3.27339 40.2195 3.67676 40.6241 4.08013 41.0286 4.30668 41.5769 4.30668 42.1486zM10.9639 42.1486C10.9639 42.5755 10.8374 42.9929 10.6004 43.3478 10.3635 43.7027 10.0267 43.9793 9.63265 44.1425 9.23864 44.3057 8.80512 44.3483 8.38696 44.2647 7.96881 44.1811 7.5848 43.9753 7.28355 43.6731 6.98229 43.371 6.77733 42.9861 6.69459 42.5673 6.61185 42.1485 6.65505 41.7145 6.81874 41.3202 6.98242 40.926 7.25923 40.5893 7.61412 40.3526 7.96902 40.1159 8.38606 39.99 8.81246 39.9907 9.3834 39.9917 9.93062 40.2195 10.334 40.6241 10.7374 41.0286 10.9639 41.5769 10.9639 42.1486zM17.6174 42.1486C17.6167 42.5746 17.4898 42.9909 17.2528 43.3447 17.0158 43.6986 16.6793 43.9741 16.2859 44.1365 15.8925 44.2988 15.4598 44.3408 15.0426 44.2569 14.6254 44.1731 14.2424 43.9673 13.9421 43.6655 13.6417 43.3637 13.4374 42.9795 13.3551 42.5615 13.2728 42.1435 13.3162 41.7105 13.4797 41.3171 13.6432 40.9238 13.9195 40.5878 14.2738 40.3517 14.628 40.1156 15.0441 39.99 15.4697 39.9907 15.7522 39.9912 16.0319 40.0474 16.2927 40.1561 16.5535 40.2648 16.7904 40.4239 16.9899 40.6243 17.1893 40.8247 17.3474 41.0624 17.4551 41.3239 17.5627 41.5855 17.6179 41.8657 17.6174 42.1486zM24.2749 42.1482C24.2741 42.5749 24.1469 42.9917 23.9092 43.3458 23.6715 43.7 23.3341 43.9755 22.9399 44.1374 22.5456 44.2993 22.1122 44.3404 21.6946 44.2553 21.277 44.1703 20.8941 43.963 20.5943 43.6597 20.2945 43.3565 20.0915 42.9709 20.0108 42.5519 19.9302 42.133 19.9757 41.6995 20.1415 41.3064 20.3072 40.9133 20.5859 40.5784 20.942 40.3441 21.2981 40.1098 21.7158 39.9867 22.1419 39.9903 22.7099 39.9952 23.253 40.2248 23.6526 40.6291 24.0522 41.0333 24.2759 41.5794 24.2749 42.1482zM30.9322 42.1486C30.9322 42.5757 30.8056 42.9932 30.5684 43.3482 30.3313 43.7032 29.9943 43.9798 29.6001 44.1429 29.2058 44.306 28.7721 44.3483 28.3539 44.2644 27.9356 44.1806 27.5516 43.9743 27.2505 43.6718 26.9494 43.3693 26.7447 42.9841 26.6624 42.565 26.5801 42.146 26.6238 41.7118 26.7881 41.3177 26.9523 40.9235 27.2297 40.587 27.5851 40.3508 27.9405 40.1146 28.3579 39.9893 28.7844 39.9907 29.3547 39.9927 29.901 40.2209 30.3036 40.6254 30.7061 41.0298 30.9322 41.5776 30.9322 42.1486zM37.5894 42.1486C37.5894 42.5751 37.4632 42.992 37.2267 43.3467 36.9902 43.7014 36.6541 43.9779 36.2607 44.1415 35.8673 44.305 35.4344 44.3482 35.0165 44.2655 34.5987 44.1828 34.2146 43.9781 33.9129 43.677 33.6113 43.376 33.4054 42.9922 33.3214 42.5741 33.2374 42.156 33.2791 41.7223 33.4411 41.3279 33.603 40.9335 33.8781 40.596 34.2316 40.358 34.585 40.12 35.0009 39.9922 35.4269 39.9907 35.7105 39.9898 35.9915 40.0449 36.2539 40.1529 36.5162 40.2609 36.7547 40.4197 36.9556 40.6201 37.1565 40.8206 37.3159 41.0588 37.4246 41.3211 37.5334 41.5834 37.5894 41.8646 37.5894 42.1486zM44.2469 42.1486C44.2469 42.5755 44.1204 42.9929 43.8834 43.3478 43.6464 43.7027 43.3096 43.9793 42.9156 44.1425 42.5216 44.3057 42.0881 44.3483 41.6699 44.2647 41.2518 44.1811 40.8678 43.9753 40.5665 43.6731 40.2653 43.371 40.0603 42.9861 39.9775 42.5673 39.8948 42.1485 39.938 41.7145 40.1017 41.3202 40.2654 40.926 40.5422 40.5893 40.8971 40.3526 41.252 40.1159 41.669 39.99 42.0954 39.9907 42.6663 39.9917 43.2136 40.2195 43.6169 40.6241 44.0203 41.0286 44.2469 41.5769 44.2469 42.1486zM50.9041 42.1486C50.9041 42.5755 50.7776 42.9929 50.5406 43.3478 50.3037 43.7027 49.9669 43.9793 49.5728 44.1425 49.1788 44.3057 48.7453 44.3483 48.3272 44.2647 47.909 44.1811 47.525 43.9753 47.2237 43.6731 46.9225 43.371 46.7175 42.9861 46.6348 42.5673 46.552 42.1485 46.5952 41.7145 46.7589 41.3202 46.9226 40.926 47.1994 40.5893 47.5543 40.3526 47.9092 40.1159 48.3262 39.99 48.7526 39.9907 49.3236 39.9917 49.8708 40.2195 50.2742 40.6241 50.6776 41.0286 50.9041 41.5769 50.9041 42.1486zM57.5689 42.1486C57.5689 42.5755 57.4424 42.9929 57.2054 43.3478 56.9685 43.7027 56.6316 43.9793 56.2376 44.1425 55.8436 44.3057 55.4101 44.3483 54.9919 44.2647 54.5738 44.1811 54.1898 43.9753 53.8885 43.6731 53.5873 43.371 53.3823 42.9861 53.2996 42.5673 53.2168 42.1485 53.26 41.7145 53.4237 41.3202 53.5874 40.926 53.8642 40.5893 54.2191 40.3526 54.574 40.1159 54.991 39.99 55.4174 39.9907 55.9884 39.9917 56.5356 40.2195 56.939 40.6241 57.3423 41.0286 57.5689 41.5769 57.5689 42.1486z"/></g><defs><clipPath id="clip0_2321_61679"><path fill="#fff" d="M0 0H163V44.303H0z"/></clipPath></defs></svg>
+                </a>
+                <a 
+                    href="https://www.facebook.com/oampMV.IPC/" 
+                    class="footer__logo"
+                    data-type="hideLinkIcon"
+                    aria-label="Facebook of the Integration Portal for Foreigners"
+                >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 933.333 933.333"><defs><clipPath clipPathUnits="userSpaceOnUse" id="a"><path d="M 0,700 H 700 V 0 H 0 Z"/></clipPath></defs><g clip-path="url(#a)" transform="matrix(1.33333 0 0 -1.33333 0 933.333)"><path d="m 0,0 c 0,138.071 -111.929,250 -250,250 -138.071,0 -250,-111.929 -250,-250 0,-117.245 80.715,-215.622 189.606,-242.638 v 166.242 h -51.552 V 0 h 51.552 v 32.919 c 0,85.092 38.508,124.532 122.048,124.532 15.838,0 43.167,-3.105 54.347,-6.211 V 81.986 c -5.901,0.621 -16.149,0.932 -28.882,0.932 -40.993,0 -56.832,-15.528 -56.832,-55.9 V 0 h 81.659 l -14.028,-76.396 h -67.631 V -248.169 C -95.927,-233.218 0,-127.818 0,0" fill="#fff" transform="translate(600 350)"/></g></svg>
+                </a>
+            </div>
+            <nav class="footer__menu-wrapper" aria-label="Menu patička">
+                    <ul class="footer__menu">
+                        <li class="footer__menu-item">
+                            <a href="https://ipc.gov.cz/en/about-us/" class="footer__menu-link">
+                                About us
+                            </a>
+                        </li>
+                        <li class="footer__menu-item">
+                            <a href="https://ipc.gov.cz/en/glossary/" class="footer__menu-link">
+                                Glossary
+                            </a>
+                        </li>
+                        <li class="footer__menu-item">
+                            <a href="https://ipc.gov.cz/en/contacts/#4" class="footer__menu-link">
+                                Assistance
+                            </a>
+                        </li>
+                        <li class="footer__menu-item">
+                            <a href="https://ipc.gov.cz/en/contacts/" class="footer__menu-link">
+                                Contacts
+                            </a>
+                        </li>
+                        <li class="footer__menu-item">
+                            <a href="https://ipc.gov.cz/en/need-advice/" class="footer__menu-link">
+                                FAQ
+                            </a>
+                        </li>
+                    </ul>
+                    <ul class="footer__menu">
+                        <li class="footer__menu-item">
+                            <a href="https://ipc.gov.cz/en/administrative-proceedings/" class="footer__menu-link">
+                                Administrative Proceedings
+                            </a>
+                        </li>
+                        <li class="footer__menu-item">
+                            <a href="https://ipc.gov.cz/en/life-in-the-eu/" class="footer__menu-link">
+                                Life in the EU
+                            </a>
+                        </li>
+                        <li class="footer__menu-item">
+                            <a href="https://ipc.gov.cz/en/life-in-the-czech-republic/" class="footer__menu-link">
+                                Life in Czechia
+                            </a>
+                        </li>
+                        <li class="footer__menu-item">
+                            <a href="https://mv.gov.cz/migrace/clanek/nase-hlavni-temata-mezinarodni-ochrana-mezinarodni-ochrana.aspx" class="footer__menu-link">
+                                International Protection
+                            </a>
+                        </li>
+                    </ul>
+                    <ul class="footer__menu">
+                        <li class="footer__menu-item">
+                            <a href="https://ipc.gov.cz/en/for-employers/" class="footer__menu-link">
+                                Employers
+                            </a>
+                        </li>
+                        <li class="footer__menu-item">
+                            <a href="https://ipc.gov.cz/en/educational-institutions/" class="footer__menu-link">
+                                Educational Institutions
+                            </a>
+                        </li>
+                        <li class="footer__menu-item">
+                            <a href="https://ipc.gov.cz/en/accommodation-providers/" class="footer__menu-link">
+                                Accommodation Providers
+                            </a>
+                        </li>
+                        <li class="footer__menu-item">
+                            <a href="https://ipc.gov.cz/en/rules-for-making-appointments-via-the-information-portal-for-foreigners/" class="footer__menu-link">
+                                IPC rules
+                            </a>
+                        </li>
+                    </ul>
+            </nav>
+            <button class="footer__scroll-top button__outline-light-inverse icon__only icon--20x20 icon--arrow-up smoothscroll" data-selector="0" aria-label="Go to the top of the page"></button>
+        </div>
+        <div class="footer__additional">
+            Disclaimer: This website is being continuously updated. The information available here is not intended to be comprehensive and many details which are relevant to particular circumstances may have been omitted. Hence it cannot be regarded as the full extent of the Act on the Residence of Foreign Nationals in the Czech Republic.
+            <br>
+            <br>
+            The project Use of intercultural workers at workplaces where foreigners stay and improvement of the quality of information provision to foreigners from third countries (VIP), year no. AMIF/21/01 is financed within the framework of the national program of the Asylum, Migration and Integration Fund and the budget of the Ministry of the Interior of the Czech Republic.
+        </div>
+        <hr class="footer__divider">
+        <div class="footer__additional">
+            <div>
+                &copy;2026 Ministry of the interior of the Czech republic, all rights reserved
+            </div>
+            <nav>
+                <ul class="footer__bottom-menu">
+                            <li class="footer__bottom-menu-item">
+                                <a href="https://ipc.gov.cz/en/gdpr-2/" class="footer__bottom-menu-link">GDPR</a>
+                            </li>
+                            <li class="footer__bottom-menu-item">
+                                <a href="https://ipc.gov.cz/en/accessibility-statement/" class="footer__bottom-menu-link">Accessibility Statement</a>
+                            </li>
+                    <li class="footer__bottom-menu-item" data-cookies-edit="footer__bottom-menu-link">
+                        <button type="button"  class="footer__bottom-menu-link">
+                            Cookie settings
+                        </button>
+                    </li>
+                </ul>
+            </nav>
+        </div>
+    </div>
+</footer>
+        </div>
+
+
+<script type='text/javascript' id='iq-26.c851eb21021055033b2d-js-extra'>
+/* <![CDATA[ */
+var SITE_PARAMS = {"site_url":"https:\/\/ipc.gov.cz","home_url":"https:\/\/ipc.gov.cz\/en\/","theme_url":"https:\/\/ipc.gov.cz\/wp-content\/themes\/iq-theme","tooltip_translation":"","tooltip_help":"","forms_web_filler":"https:\/\/ipc.gov.cz\/forms-web-filler\/","isds_login_url":"https:\/\/www.mojedatovaschranka.cz\/as\/login?atsId=293ccef8b8944289","translation_version":"9y3dfspzIoN2Qs\/dPJa94jM2","cookie_name":"cookie-consent-46ee6946-968c-4d8c-9d9b-7319579eda0b"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/26.c851eb21021055033b2d.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-26.c851eb21021055033b2d-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/36.edf6111c33a61801b59f.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-36.edf6111c33a61801b59f-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/33.3d97c7dd270e406050a4.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-33.3d97c7dd270e406050a4-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/25.5d017c2fc816138e4fcf.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-25.5d017c2fc816138e4fcf-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/24.6f6da2cb9428e0141a0c.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-24.6f6da2cb9428e0141a0c-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/32.c38f272395eafb9d0c6c.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-32.c38f272395eafb9d0c6c-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/28.2a186028dbe4bf605bbb.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-28.2a186028dbe4bf605bbb-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/23.b1a2db0d7b37f3f12c95.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-23.b1a2db0d7b37f3f12c95-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/35.4b767ba170445a73f31c.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-35.4b767ba170445a73f31c-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/40.503015d08f13a135d293.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-40.503015d08f13a135d293-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/22.61640ddab95dfec3cf67.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-22.61640ddab95dfec3cf67-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/27.476505b13ed0bec3238e.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-27.476505b13ed0bec3238e-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/34.52794fc67527b82d2759.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-34.52794fc67527b82d2759-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/37.71fac33e96d2b54b7e0b.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-37.71fac33e96d2b54b7e0b-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/30.1f698d8425b323e18b07.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-30.1f698d8425b323e18b07-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/29.c3d20b4a5cbd34112c77.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-29.c3d20b4a5cbd34112c77-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/39.fb5237af63010761b7a1.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-39.fb5237af63010761b7a1-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/31.bb69757425fb67469d37.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-31.bb69757425fb67469d37-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/38.9bab160dbe840a11a4f6.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-38.9bab160dbe840a11a4f6-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/20.2e4c2db156d0137569ce.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-20.2e4c2db156d0137569ce-js'></script>
+<script type='text/javascript' src='https://ipc.gov.cz/wp-content/themes/iq-theme/dist/js/client~e36e0bff.e9ffc1dceee07be5267f.js?ver=81beeff896c5ccb9c6e6d1649961c583' id='iq-client~e36e0bff.e9ffc1dceee07be5267f-js'></script>
+    </body>
+</html>

--- a/sources/CZ_IPC_INSURANCE_2026-06-10.html.meta.json
+++ b/sources/CZ_IPC_INSURANCE_2026-06-10.html.meta.json
@@ -1,0 +1,7 @@
+{
+  "source_id": "CZ_IPC_INSURANCE_2026",
+  "url": "https://ipc.gov.cz/en/forms-and-documents/documents/medical-insurance/",
+  "retrieved_at": "2026-06-10T00:00:00Z",
+  "sha256": "9ddbe03ceba165c54745267b9c3ca926e6f24a89d4af205ba79df6e6b08e7592",
+  "local_path": "sources/CZ_IPC_INSURANCE_2026-06-10.html"
+}

--- a/tools/build_content_hubs.py
+++ b/tools/build_content_hubs.py
@@ -153,6 +153,20 @@ VISA_FAQS = {
             "answer": "No. Digital Nomad visa holders are not enrolled in Japan's national health insurance, so private coverage meeting the JPY 10 million threshold is required.",
         },
     ],
+    "CZ_LONGTERM_BUSINESS_IPC_2026": [
+        {
+            "question": "How much insurance coverage does the Czech long-term business visa require?",
+            "answer": "The Official Information Portal for Foreigners states the coverage amount must be at least EUR 400,000 per insured event, with no cost sharing by the insured person.",
+        },
+        {
+            "question": "Why do SafetyWing, World Nomads and Genki Traveler show RED?",
+            "answer": "Their documented limits convert to below EUR 400,000, and a deductible (cost sharing) conflicts with the no-cost-sharing rule, so the engine marks them RED rather than accepting them.",
+        },
+        {
+            "question": "Why are the Spanish health policies UNKNOWN rather than GREEN?",
+            "answer": "Their policy documents do not state an overall coverage limit to compare against the EUR 400,000 threshold, so the engine records UNKNOWN instead of assuming they clear it.",
+        },
+    ],
     "CO_DNV_CANCILLERIA_2026": [
         {
             "question": "What insurance does the Colombia Digital Nomad Visa require?",
@@ -218,6 +232,11 @@ RELATED_POSTS = {
         ("/posts/colombia-dnv-insurance/", "Colombia Digital Nomad Visa insurance requirements"),
         ("/posts/digital-nomad-insurance-americas/", "Digital nomad insurance in the Americas"),
         ("/guides/how-to-read-results/", "How to read compliance results"),
+    ],
+    "CZ_LONGTERM_BUSINESS_IPC_2026": [
+        ("/posts/czech-business-visa-insurance/", "Czech long-term business visa insurance requirements"),
+        ("/guides/schengen-30000-insurance/", "Schengen 30,000 EUR insurance rule"),
+        ("/posts/digital-nomad-insurance-europe/", "Digital nomad insurance in Europe"),
     ],
 }
 

--- a/tools/editorial_targets.json
+++ b/tools/editorial_targets.json
@@ -138,5 +138,13 @@
   "content/posts/colombia-dnv-insurance.md": [
     450,
     950
+  ],
+  "content/visas/czech-republic/long-term-business-visa/doing-business-ipc/index.md": [
+    900,
+    1300
+  ],
+  "content/posts/czech-business-visa-insurance.md": [
+    450,
+    1050
   ]
 }


### PR DESCRIPTION
## Summary
Adds the **Czech long-term visa for the purpose of doing business** — first of two routes from OMP's Stage-1 research (Czech, then Croatia).

Source: official **IPC (Ministry of the Interior) Medical Insurance page** (`ipc.gov.cz`), byte-exact, sha256-validated. Verbatim: *"The insurance coverage amount (the agreed limit per insured event) must be at least EUR 400,000, with no cost sharing by the insured person."*

## Requirements
insurance mandatory · min coverage **≥ EUR 400,000** (currency-aware) · no deductible (no cost sharing)

## Compliance results (verified = OMP's Stage-1 prediction)
| Product | Status |
|---|---|
| Genki Traveler / SafetyWing / World Nomads | **RED** — limits convert below €400k and/or carry a deductible |
| ASISA / DKV / Sanitas / GenericInsurer / Genki Native | UNKNOWN — no documented overall limit |

A strict **differentiation route**: it honestly shows the three most common nomad products fail the Czech €400k / no-cost-sharing rule. No GREEN product → no affiliate (deferred). The "authorised in the Czech Republic" clause is left unmodeled (no engine rule); it produces no false GREEN here.

## Gates (all green locally)
validate · lint · editorial · internal links · SEO audit · Hugo build · ui-compliance

🤖 Generated with [Claude Code](https://claude.com/claude-code)