### PR TITLE
fix(content): un-future-date Czech & Croatia posts

### DIFF
--- a/content/posts/croatia-dnv-insurance.md
+++ b/content/posts/croatia-dnv-insurance.md
@@ -1,6 +1,6 @@
 ---
 title: "Croatia digital nomad stay insurance requirements (evidence-based)"
-date: 2026-06-10
+date: 2026-06-09
 description: "Evidence-based summary of the health insurance requirement for Croatia's temporary stay for digital nomads, based on the Ministry of the Interior (MUP)."
 tags: ["croatia", "dnv", "digital-nomad", "insurance", "compliance"]
 faq:

--- a/content/posts/czech-business-visa-insurance.md
+++ b/content/posts/czech-business-visa-insurance.md
@@ -1,6 +1,6 @@
 ---
 title: "Czech long-term business visa insurance requirements (evidence-based)"
-date: 2026-06-10
+date: 2026-06-09
 description: "Evidence-based summary of the medical insurance requirement for the Czech long-term visa for the purpose of doing business, based on the Official Information Portal for Foreigners."
 tags: ["czech-republic", "business-visa", "freelance", "insurance", "compliance"]
 faq:


### PR DESCRIPTION
The Czech and Croatia blog posts were dated 2026-06-10. The deploy runner is on UTC (still 2026-06-09), so Hugo (`buildFuture=false`) skipped them as future-dated → 404 in prod (the visa hubs + ui_index were live, only the posts were missing). Set publish date to 2026-06-09. Verified Hugo builds both locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)