### PR TITLE
🎨 Palette: Accessibility improvements for form labels and mobile menu

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-10 - Form Label and Mobile Menu Accessibility Improvements
+**Learning:** In responsive forms using flex-col layouts (like VisaFact's), visual proximity does not guarantee accessible label associations. Custom icon-only mobile menus often miss crucial ARIA state attributes (`aria-expanded`, `aria-controls`), which prevents screen readers from understanding the menu's state and purpose.
+**Action:** Always verify that `<label>` elements have a matching `for` attribute referencing their target input's `id`, and ensure `<select>` elements use `aria-describedby` when helper text is present. For custom toggle buttons, dynamically manage `aria-expanded` in the event handler and explicitly link to the controlled element via `aria-controls`.

--- a/ui/index.html
+++ b/ui/index.html
@@ -111,7 +111,9 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+        aria-label="Toggle menu"
+        aria-expanded="false"
+        aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -183,12 +185,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -200,12 +202,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select an insurance product</option>
             </select>
@@ -1179,6 +1181,7 @@
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
+      btn.setAttribute("aria-expanded", String(!isOpen));
     });
 
     init().catch(err => {


### PR DESCRIPTION
💡 What: Added `for` attributes to labels linking them to their corresponding `<select>` elements. Added `aria-describedby` to `<select>` elements to link them to helper text. Added `aria-expanded` and `aria-controls` to the mobile menu toggle button, dynamically updating `aria-expanded` in the JavaScript toggle handler. Logged a journal entry.
🎯 Why: In responsive flex-col layouts, visual proximity between labels and inputs does not guarantee accessible associations for screen readers. Explicit `for` attributes are necessary. Custom toggle buttons need `aria-expanded` and `aria-controls` to clearly communicate their state and purpose to screen reader users.
📸 Before/After: Visuals are unchanged (verified via UI testing), ensuring the UX improvements are seamless and accessible to assistive technologies.
♿ Accessibility: Ensures that screen readers can correctly associate labels with inputs, announce helper text, and correctly identify the state of the mobile menu.

---
*PR created automatically by Jules for task [5827375498707597037](https://jules.google.com/task/5827375498707597037) started by @W73QB*