### PR TITLE
🎨 Palette: Add dynamic aria-expanded state to mobile menu button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-11 - Dynamic ARIA attributes for mobile menus
+**Learning:** Icon-only toggle buttons like `#mobileMenuBtn` not only need an `aria-label`, but they MUST explicitly manage their `aria-expanded` and `aria-controls` state dynamically in JS, so screen readers announce when the targeted component (#mobileMenu) opens or closes.
+**Action:** Always add `aria-expanded="false"` and `aria-controls="targetID"` to toggle buttons, and update the `aria-expanded` attribute within the click handler to `String(!isOpen)` or the equivalent boolean expression reflecting the NEW state.

--- a/ui/index.html
+++ b/ui/index.html
@@ -108,10 +108,9 @@
       <div class="flex items-center gap-2.5 hover:opacity-80 transition-opacity cursor-pointer">
         <span class="material-symbols-outlined text-primary text-3xl icon-filled">verified_user</span>
         <span class="text-text-primary dark:text-white text-xl font-bold tracking-tight">VisaFact</span>
-      </div>
-      <button id="mobileMenuBtn"
+      </div>      <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+        aria-label="Toggle menu" aria-expanded="false" aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -1170,16 +1169,17 @@
         return;
       }
       $("loadingState").classList.add("hidden");
+    }    // Mobile menu toggle
+    const _mobileMenuBtn = document.getElementById("mobileMenuBtn");
+    const _mobileMenu = document.getElementById("mobileMenu");
+    if (_mobileMenuBtn && _mobileMenu) {
+      _mobileMenuBtn.addEventListener("click", () => {
+        const isOpen = !_mobileMenu.classList.contains("hidden");
+        _mobileMenu.classList.toggle("hidden");
+        _mobileMenuBtn.querySelector("span").textContent = isOpen ? "menu" : "close";
+        _mobileMenuBtn.setAttribute("aria-expanded", String(!isOpen));
+      });
     }
-
-    // Mobile menu toggle
-    $("mobileMenuBtn")?.addEventListener("click", () => {
-      const menu = $("mobileMenu");
-      const btn = $("mobileMenuBtn");
-      const isOpen = !menu.classList.contains("hidden");
-      menu.classList.toggle("hidden");
-      btn.querySelector("span").textContent = isOpen ? "menu" : "close";
-    });
 
     init().catch(err => {
       console.error(err);


### PR DESCRIPTION
💡 What: Added explicitly dynamic `aria-expanded` and `aria-controls` attributes to the `#mobileMenuBtn` mobile menu toggle in `ui/index.html`.
🎯 Why: Icon-only menu buttons must explicitly convey their opened/closed state to screen readers to be accessible. This enhances structural accessibility.
♿ Accessibility: Ensures users relying on assistive technologies are notified whenever the target mobile menu component opens or closes.

---
*PR created automatically by Jules for task [2620745536988332436](https://jules.google.com/task/2620745536988332436) started by @W73QB*