### PR TITLE
feat(route): add Poland National Visa (Type D) route (evidence-based)

### DIFF
--- a/content/posts/poland-national-d-insurance.md
+++ b/content/posts/poland-national-d-insurance.md
@@ -1,0 +1,112 @@
+---
+title: "Poland National Visa (Type D) insurance requirements (evidence-based)"
+date: 2026-06-12
+description: "Evidence-based summary of the travel medical insurance requirement for Poland's National Visa (Type D): 30,000 EUR minimum coverage, valid for the entire visa period, per gov.pl consular checklists."
+tags: ["poland", "national-visa", "type-d", "insurance", "compliance"]
+faq:
+  - question: "How much coverage does the Poland National Visa (Type D) require?"
+    answer: "The gov.pl consular checklist requires travel medical insurance with minimum coverage of 30,000 EUR, valid for the entire period of the requested national visa."
+  - question: "Is this the same as the Schengen 30,000 EUR rule?"
+    answer: "No. The Schengen rule covers short stays (C visas). Poland applies a separate national-visa insurance regime under the Act of 12 December 2013 on Foreigners, which also sets a 30,000 EUR floor plus insurer conduct conditions."
+  - question: "Why is a monthly subscription marked YELLOW?"
+    answer: "The policy must be valid for the entire period of the requested visa. A month-to-month policy that can lapse does not assure full-period validity, so it is YELLOW; a full-period policy with a documented limit of at least 30,000 EUR is GREEN."
+---
+
+## Short answer
+
+Poland's National Visa (Type D) requires travel medical insurance with a minimum coverage of 30,000 EUR, valid for the entire period of the requested national visa, covering urgent medical assistance, emergency hospital treatment and repatriation for medical reasons (Source: `PL_NATD_NICOSIA_2026`, gov.pl consular checklist; verified 2026-06-13). The engine models three rules from this source: insurance is mandatory, minimum coverage of 30,000 EUR, and full-period validity.
+
+## Key findings at a glance
+
+| Item | Value |
+|---|---|
+| Route | Poland National Visa (Type D), long stay |
+| Authority | Embassy of the Republic of Poland in Nicosia (gov.pl) |
+| Evidence verified | 2026-06-13 |
+| Snapshot | 2026-06-13 |
+| Modeled rules | Insurance mandatory; minimum coverage 30,000 EUR; policy valid for the entire visa period |
+
+## What the authority requires
+
+- Travel medical insurance is a required document for the D-type national visa. (Source: `PL_NATD_NICOSIA_2026`; verified 2026-06-13)
+- Minimum coverage of 30,000 EUR. (Source: `PL_NATD_NICOSIA_2026`; verified 2026-06-13)
+- The policy must be valid for the entire period of the requested national visa. (Source: `PL_NATD_NICOSIA_2026`; verified 2026-06-13)
+- Coverage scope: "covering all costs which may arise during the stay, related to any urgent medical assistance, emergency hospital treatment or repatriation for medical reasons as well as, in case of death, repatriation of the deceased." (Source: `PL_NATD_NICOSIA_2026`)
+- The embassy announcement adds insurer conduct conditions effective 1 December 2020: the insurer settles health-service costs directly with the treating entity on an invoice basis and provides a 24/7 assistance centre. (Source: `PL_NATD_SG_2026`; verified 2026-06-13)
+
+Normalized requirements table:
+
+| Requirement | Source URL | Locator | Verified date |
+|---|---|---|---|
+| Insurance is mandatory | https://www.gov.pl/web/cyprus/d-type-national-visa | Documents checklist, travel medical insurance item | 2026-06-13 |
+| Minimum coverage 30,000 EUR | https://www.gov.pl/web/cyprus/d-type-national-visa | Documents checklist, travel medical insurance item | 2026-06-13 |
+| Valid for the entire visa period | https://www.gov.pl/web/cyprus/d-type-national-visa | Documents checklist, travel medical insurance item | 2026-06-13 |
+| Insurer direct settlement + 24/7 assistance | https://www.gov.pl/web/singapore/announcement-regarding-travel-medical-insurance-for-foreigners-applying-for-a-national-visa | Announcement, requirement list | 2026-06-13 |
+
+## Verified requirements (PASS/FAIL/UNKNOWN)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Insurance is mandatory | PASS | gov.pl consular checklist |
+| Minimum coverage 30,000 EUR | PASS for products with a documented limit of 30,000 EUR or more; UNKNOWN where no limit is documented | Checklist: "minimum coverage of 30 000 EUR" |
+| Valid for the entire visa period | PASS for full-period policies; YELLOW for monthly subscriptions | Checklist: "valid for the entire period of the requested national visa" |
+| Insurer direct settlement + 24/7 assistance | NOT MODELED | Announcement `PL_NATD_SG_2026`; see below |
+
+## How we evaluate
+
+The checker compares each modeled requirement against product evidence. Three rules are encoded from the gov.pl consular checklist: insurance is mandatory, the documented coverage limit must be at least 30,000 EUR (currency-aware: limits in other currencies are converted before comparison), and the policy must be valid for the entire period of the requested visa. A monthly subscription that can lapse mid-stay does not assure full-period validity, so it is YELLOW; a full-period policy with a documented limit at or above the threshold is GREEN; a product whose documents state no overall limit stays UNKNOWN rather than being assumed to clear the floor.
+
+Two clauses are deliberately NOT modeled, following the UNKNOWN > Wrong principle: the insurer must settle costs directly with the treating provider and run a 24/7 assistance centre, and Poland's MFA publishes an information list of insurers meeting the statutory conditions of the Act of 12 December 2013 on Foreigners. The engine has no per-product evidence for these conduct clauses, so a GREEN result here still requires you to confirm the insurer against the MFA information list before buying. See /methodology/ for the full logic.
+
+This is also not the Schengen short-stay rule: Poland's national-visa regime sets its own 30,000 EUR floor for D visas, separate from the C-visa Schengen requirement.
+
+## Proof package checklist
+
+- An insurance certificate stating a coverage limit of at least 30,000 EUR.
+- Policy dates spanning the entire period of the requested national visa, not a month-to-month subscription.
+- Confirmation that the insurer settles costs directly with providers and operates 24/7 assistance, per the embassy announcement.
+- A check of the insurer against the MFA information list referenced in the gov.pl checklist.
+
+## FAQ
+
+**Q: How much coverage is required?**
+**A:** At least 30,000 EUR, valid for the entire visa period (Source: `PL_NATD_NICOSIA_2026`; verified 2026-06-13).
+
+**Q: Is this the Schengen 30,000 EUR rule?**
+**A:** No. It is Poland's own national-visa requirement under the Act on Foreigners; the figure matches but the regime and conditions differ.
+
+**Q: Why is a monthly subscription YELLOW?**
+**A:** It can lapse before the visa period ends, so it does not assure full-period validity; a full-period policy with a documented 30,000 EUR limit is GREEN.
+
+## Check in the engine
+
+Use [the compliance checker](/ui/) with the current snapshot for this route:
+
+{{< checker_cta visa="PL_NATD_NICOSIA_2026" product="GENKI_TRAVELER_2026" snapshot="2026-06-13" >}}
+
+## Related reading
+
+- [Poland National Visa requirements (route page)](/visas/poland/national-visa-type-d/d-type-national-visa-gov-pl-nicosia/)
+- [Schengen 30,000 EUR insurance rule](/guides/schengen-30000-insurance/)
+- [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
+
+## Where to find compliant insurance for the Poland National Visa
+
+In the current snapshot, Genki Traveler, Genki Native and World Nomads Explorer show GREEN: each documents a coverage limit at or above 30,000 EUR and a policy term that can span the full visa period. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the visa period ends. Whatever you pick, confirm the insurer against the MFA information list noted above, since the engine does not model the direct-settlement and assistance-centre clauses.
+
+- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+
+> Use the compliance checker to confirm the current GREEN products for this route before you buy.
+
+## Disclaimer + Affiliate disclosure
+
+Not legal advice. Compliance results are evidence-based snapshots.
+
+If an affiliate link is present, it appears only after results and does not change the compliance outcome. The Genki link above is a paid affiliate link.
+
+Last updated: 2026-06-13
+
+## Evidence log
+
+- Source: PL_NATD_NICOSIA_2026
+- Source: PL_NATD_SG_2026

--- a/content/visas/poland/national-visa-type-d/_index.md
+++ b/content/visas/poland/national-visa-type-d/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Poland National Visa (Type D)"
+visa_group: "poland-national-visa-type-d"
+description: "Insurance requirements for Poland National Visa (Type D) - evidence-based compliance checker"
+---
+
+## Poland National Visa (Type D) Requirements
+
+All requirements below are derived from official sources. Missing evidence means UNKNOWN.
+
+## Routes
+
+| Authority | Route | Last Verified | Details |
+| --- | --- | --- | --- |
+| Embassy of the Republic of Poland in Nicosia (gov.pl) | D-Type national visa (gov.pl Nicosia) | 2026-06-13 | [View requirements](/visas/poland/national-visa-type-d/d-type-national-visa-gov-pl-nicosia/) |
+
+## What the authority requires
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+## How we evaluate
+
+We compare these official requirements against insurance product specifications using our automated rule engine. Each requirement is matched to a product fact with evidence.
+
+## Check in the engine
+
+Try the compliance checker: [Open Checker](/ui/?visa=PL_NATD_NICOSIA_2026&snapshot=2026-06-13)
+
+## Disclaimer
+
+This is not legal advice. VisaFact provides evidence-based compliance checking only. Final visa decisions are made by government authorities. A GREEN result does not ensure visa approval.
+
+## Affiliate disclosure
+
+If affiliate links appear, they are shown only after compliance results and do not influence the compliance evaluation in any way.
+
+## Evidence log
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+
+{{< checker_cta visa="PL_NATD_NICOSIA_2026" snapshot="2026-06-13" >}}

--- a/content/visas/poland/national-visa-type-d/d-type-national-visa-gov-pl-nicosia/index.md
+++ b/content/visas/poland/national-visa-type-d/d-type-national-visa-gov-pl-nicosia/index.md
@@ -1,0 +1,109 @@
+---
+title: "Poland National Visa (Type D) - D-Type national visa (gov.pl Nicosia)"
+visa_id: "PL_NATD_NICOSIA_2026"
+last_verified: "2026-06-13"
+source_ids: ["PL_NATD_NICOSIA_2026", "PL_NATD_SG_2026"]
+description: "Official insurance requirements for Poland National Visa (Type D) via D-Type national visa (gov.pl Nicosia)"
+faq:
+  - question: "What insurance does the Poland National Visa (Type D) require?"
+    answer: "The gov.pl consular checklist requires travel medical insurance with minimum coverage of 30,000 EUR, valid for the entire period of the requested national visa, covering urgent medical assistance, emergency hospital treatment and medical repatriation."
+  - question: "Why is SafetyWing YELLOW for this route?"
+    answer: "The policy must be valid for the entire period of the requested visa. A month-to-month subscription that can lapse does not assure full-period validity, so the engine marks it YELLOW; full-period policies with a documented limit of 30,000 EUR or more are GREEN."
+  - question: "Are there insurer conditions the engine does not model?"
+    answer: "Yes. The announcement also requires the insurer to settle costs directly with the treating provider and to run a 24/7 assistance centre, and Poland's MFA publishes a list of insurers meeting the statutory conditions. The engine does not model these clauses, so check the MFA list before buying."
+---
+
+## Poland National Visa (Type D)
+
+**Route:** D-Type national visa (gov.pl Nicosia)  
+**Authority:** Embassy of the Republic of Poland in Nicosia (gov.pl)  
+**Last Verified:** 2026-06-13
+
+## Requirements
+
+| Requirement | Operator | Value | Evidence |
+| --- | --- | --- | --- |
+| `insurance.mandatory` | `==` | Yes | *D-Type national visa, What documents do I submit, travel medical insurance item*: "Travel medical insurance with minimum coverage of 30 000 EUR, valid for the enti..." ([source](/sources/PL_NATD_NICOSIA_2026-06-13.html)) *Announcement regarding travel medical insurance for foreigners applying for a national visa (04.12.2020)*: "since 1 December 2020, the conditions that must be met by travel medical insuran..." ([source](/sources/PL_NATD_SG_2026-06-13.html)) |
+| `insurance.min_coverage` | `>=` | 30000 | *D-Type national visa, What documents do I submit, travel medical insurance item*: "Travel medical insurance with minimum coverage of 30 000 EUR..." ([source](/sources/PL_NATD_NICOSIA_2026-06-13.html)) *Announcement regarding travel medical insurance, requirement list*: "provides for the insurer's liability for the amount of insurance of at least 30 ..." ([source](/sources/PL_NATD_SG_2026-06-13.html)) |
+| `insurance.must_cover_full_period` | `==` | Yes | *D-Type national visa, What documents do I submit, travel medical insurance item*: "valid for the entire period of the requested national visa..." ([source](/sources/PL_NATD_NICOSIA_2026-06-13.html)) *Announcement regarding travel medical insurance, requirement list*: "is valid for the entire period of the planned stay of the foreigner in the terri..." ([source](/sources/PL_NATD_SG_2026-06-13.html)) |
+
+## Source Documents
+
+- **PL_NATD_NICOSIA_2026**: [Local copy](/sources/PL_NATD_NICOSIA_2026-06-13.html) | [Original](https://www.gov.pl/web/cyprus/d-type-national-visa) | Retrieved: 2026-06-13
+- **PL_NATD_SG_2026**: [Local copy](/sources/PL_NATD_SG_2026-06-13.html) | [Original](https://www.gov.pl/web/singapore/announcement-regarding-travel-medical-insurance-for-foreigners-applying-for-a-national-visa) | Retrieved: 2026-06-13
+
+## Related reading
+
+- [Poland National Visa (Type D) insurance requirements](/posts/poland-national-d-insurance/)
+- [Schengen 30,000 EUR insurance rule](/guides/schengen-30000-insurance/)
+- [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
+
+## What the authority requires
+
+The points below are taken directly from the official source for the Poland National Visa (Type D) (D-Type national visa (gov.pl Nicosia)) route. Each one is recorded with a source identifier and a locator so it can be traced back to the original document. Where the source is silent on a point, the engine records UNKNOWN instead of inferring an answer.
+
+- The authority requires that insurance is mandatory.
+- The authority requires that the medical coverage meets the stated minimum of at least 30000.
+- The authority requires that the policy covers the full authorized stay.
+
+## How we evaluate
+
+Every requirement is compared against the documented specification of each insurance product using an automated rule engine. A product is marked GREEN for a requirement only when product evidence explicitly satisfies it; a conflict produces RED; and absent evidence produces UNKNOWN rather than a guess. The route status is the combination of its per-requirement outcomes.
+
+- Rule `insurance.mandatory == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+- Rule `insurance.min_coverage >= 30000` GREEN at or above the threshold, RED below it, UNKNOWN if unstated.
+- Rule `insurance.must_cover_full_period == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+
+## How each compliance status is decided for this route
+
+GREEN means every recorded requirement is satisfied by product evidence. RED means at least one requirement is contradicted by the product evidence. YELLOW means the evidence is partial: some requirements are met while others lack full proof. UNKNOWN means a requirement exists but the product evidence does not address it, so no claim is made. NOT_REQUIRED means the authority does not impose an insurance requirement for the route, which is itself an evidence-based finding drawn from the official document. A GREEN result reflects the evidence on the snapshot date and is not an assurance of a visa outcome, which always rests with the issuing authority.
+
+## Reading the evidence and snapshots
+
+Each requirement above links to a primary source through a source identifier and a locator (for example a page number, article, or section). The underlying documents are listed under Source Documents and are stored alongside this dataset so the wording can be checked directly. Results are tied to a dated snapshot (`2026-06-13`): a deep link to a past snapshot returns the same verdict even if the authority later changes its rules, which keeps every decision reproducible and auditable.
+
+## Proof package checklist
+
+Before applying for this route, prepare the following so the policy can be checked against each requirement:
+
+- A policy certificate that states the coverage limits, any deductible or co-payment, and the covered period.
+- Written confirmation of the insurer's status where the route requires authorization in a specific country.
+- Documentation that the coverage spans the full authorized stay rather than a partial term.
+- The official source wording for the route, so each clause can be matched to the requirements above.
+
+## Common questions
+
+**What insurance does the Poland National Visa (Type D) require?**  
+The gov.pl consular checklist requires travel medical insurance with minimum coverage of 30,000 EUR, valid for the entire period of the requested national visa, covering urgent medical assistance, emergency hospital treatment and medical repatriation.
+
+**Why is SafetyWing YELLOW for this route?**  
+The policy must be valid for the entire period of the requested visa. A month-to-month subscription that can lapse does not assure full-period validity, so the engine marks it YELLOW; full-period policies with a documented limit of 30,000 EUR or more are GREEN.
+
+**Are there insurer conditions the engine does not model?**  
+Yes. The announcement also requires the insurer to settle costs directly with the treating provider and to run a 24/7 assistance centre, and Poland's MFA publishes a list of insurers meeting the statutory conditions. The engine does not model these clauses, so check the MFA list before buying.
+
+## Check in the engine
+
+Run a specific product against this route in the compliance checker: [Open Checker](/ui/?visa=PL_NATD_NICOSIA_2026&snapshot=2026-06-13). The checker shows the per-requirement outcome and the evidence behind each one.
+
+## Disclaimer
+
+This page is not legal advice. VisaFact provides evidence-based compliance checking only, and final visa decisions are made by government authorities. A GREEN result reflects documented evidence on the snapshot date; it does not ensure that a visa application will succeed. Always confirm the current requirements with the issuing authority before submitting an application.
+
+## Affiliate disclosure
+
+If affiliate links appear on related pages, they are shown only after the compliance result and never change the evaluation, which is generated independently from the official evidence.
+
+## Evidence log
+
+Each entry pairs a requirement with the source identifier and locator it was drawn from:
+
+- `insurance.mandatory` <- PL_NATD_NICOSIA_2026 (D-Type national visa, What documents do I submit, travel medical insurance item): "Travel medical insurance with minimum coverage of 30 000 EUR, valid for the entire period of the req"
+- `insurance.mandatory` <- PL_NATD_SG_2026 (Announcement regarding travel medical insurance for foreigners applying for a national visa (04.12.2020)): "since 1 December 2020, the conditions that must be met by travel medical insurance for foreigners ap"
+- `insurance.min_coverage` <- PL_NATD_NICOSIA_2026 (D-Type national visa, What documents do I submit, travel medical insurance item): "Travel medical insurance with minimum coverage of 30 000 EUR"
+- `insurance.min_coverage` <- PL_NATD_SG_2026 (Announcement regarding travel medical insurance, requirement list): "provides for the insurer's liability for the amount of insurance of at least 30 000 EUR"
+- `insurance.must_cover_full_period` <- PL_NATD_NICOSIA_2026 (D-Type national visa, What documents do I submit, travel medical insurance item): "valid for the entire period of the requested national visa"
+- `insurance.must_cover_full_period` <- PL_NATD_SG_2026 (Announcement regarding travel medical insurance, requirement list): "is valid for the entire period of the planned stay of the foreigner in the territory of the Republic"
+
+
+{{< checker_cta visa="PL_NATD_NICOSIA_2026" snapshot="2026-06-13" >}}

--- a/data/mappings/PL_NATD_NICOSIA_2026__ASISA_HEALTH_RESIDENTS_2026.json
+++ b/data/mappings/PL_NATD_NICOSIA_2026__ASISA_HEALTH_RESIDENTS_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "PL_NATD_NICOSIA_2026",
+  "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/PL_NATD_NICOSIA_2026__DKV_VISADO_2026.json
+++ b/data/mappings/PL_NATD_NICOSIA_2026__DKV_VISADO_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "PL_NATD_NICOSIA_2026",
+  "product_id": "DKV_VISADO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/PL_NATD_NICOSIA_2026__GENERIC_EXPAT_COMPLETE_2026.json
+++ b/data/mappings/PL_NATD_NICOSIA_2026__GENERIC_EXPAT_COMPLETE_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "PL_NATD_NICOSIA_2026",
+  "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/PL_NATD_NICOSIA_2026__GENKI_NATIVE_2026.json
+++ b/data/mappings/PL_NATD_NICOSIA_2026__GENKI_NATIVE_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "PL_NATD_NICOSIA_2026",
+  "product_id": "GENKI_NATIVE_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/PL_NATD_NICOSIA_2026__GENKI_TRAVELER_2026.json
+++ b/data/mappings/PL_NATD_NICOSIA_2026__GENKI_TRAVELER_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "PL_NATD_NICOSIA_2026",
+  "product_id": "GENKI_TRAVELER_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/PL_NATD_NICOSIA_2026__SAFETYWING_NOMAD_2026.json
+++ b/data/mappings/PL_NATD_NICOSIA_2026__SAFETYWING_NOMAD_2026.json
@@ -1,0 +1,23 @@
+{
+  "visa_id": "PL_NATD_NICOSIA_2026",
+  "product_id": "SAFETYWING_NOMAD_2026",
+  "status": "YELLOW",
+  "reasons": [
+    {
+      "text": "Visa requires coverage for full legal stay, monthly subscriptions can be cancelled",
+      "evidence": [
+        {
+          "source_id": "PL_NATD_NICOSIA_2026",
+          "locator": "D-Type national visa, What documents do I submit, travel medical insurance item",
+          "excerpt": "valid for the entire period of the requested national visa"
+        },
+        {
+          "source_id": "PL_NATD_SG_2026",
+          "locator": "Announcement regarding travel medical insurance, requirement list",
+          "excerpt": "is valid for the entire period of the planned stay of the foreigner in the territory of the Republic of Poland"
+        }
+      ]
+    }
+  ],
+  "missing": []
+}

--- a/data/mappings/PL_NATD_NICOSIA_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
+++ b/data/mappings/PL_NATD_NICOSIA_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "PL_NATD_NICOSIA_2026",
+  "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/PL_NATD_NICOSIA_2026__WORLDNOMADS_EXPLORER_2026.json
+++ b/data/mappings/PL_NATD_NICOSIA_2026__WORLDNOMADS_EXPLORER_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "PL_NATD_NICOSIA_2026",
+  "product_id": "WORLDNOMADS_EXPLORER_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/ui_index.json
+++ b/data/ui_index.json
@@ -1,6 +1,6 @@
 {
-  "built_at": "2026-06-10T12:08:43.682768+00:00",
-  "snapshot_id": "2026-06-10",
+  "built_at": "2026-06-13T00:06:12.902482+00:00",
+  "snapshot_id": "2026-06-13",
   "visas": [
     {
       "id": "AL_LEJE_UNIKE_MB_2026",
@@ -830,6 +830,84 @@
       ]
     },
     {
+      "id": "PL_NATD_NICOSIA_2026",
+      "country": "Poland",
+      "visa_name": "National Visa (Type D)",
+      "route": "D-Type national visa (gov.pl Nicosia)",
+      "authority": "Embassy of the Republic of Poland in Nicosia (gov.pl)",
+      "last_verified": "2026-06-13",
+      "sources": [
+        {
+          "source_id": "PL_NATD_NICOSIA_2026",
+          "url": "https://www.gov.pl/web/cyprus/d-type-national-visa",
+          "retrieved_at": "2026-06-13T00:00:00Z",
+          "sha256": "e997d4757b16df2c6177497452d7be0230065125d77315f5fed7a08cba9c5cba",
+          "local_path": "sources/PL_NATD_NICOSIA_2026-06-13.html"
+        },
+        {
+          "source_id": "PL_NATD_SG_2026",
+          "url": "https://www.gov.pl/web/singapore/announcement-regarding-travel-medical-insurance-for-foreigners-applying-for-a-national-visa",
+          "retrieved_at": "2026-06-13T00:00:00Z",
+          "sha256": "0f0fdf9637bd6cc74fc1e4cffcb3c271493c8f7a4b38e9f793f7bca79d961580",
+          "local_path": "sources/PL_NATD_SG_2026-06-13.html"
+        }
+      ],
+      "requirements": [
+        {
+          "key": "insurance.mandatory",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "PL_NATD_NICOSIA_2026",
+              "locator": "D-Type national visa, What documents do I submit, travel medical insurance item",
+              "excerpt": "Travel medical insurance with minimum coverage of 30 000 EUR, valid for the entire period of the requested national visa, covering all costs which may arise during the stay, related to any urgent medical assistance, emergency hospital treatment or repatriation for medical reasons as well as, in case of death, repatriation of the deceased."
+            },
+            {
+              "source_id": "PL_NATD_SG_2026",
+              "locator": "Announcement regarding travel medical insurance for foreigners applying for a national visa (04.12.2020)",
+              "excerpt": "since 1 December 2020, the conditions that must be met by travel medical insurance for foreigners applying for a national visa have changed. Travel medical insurance must meet the following requirements"
+            }
+          ]
+        },
+        {
+          "key": "insurance.min_coverage",
+          "op": ">=",
+          "value": 30000,
+          "currency": "EUR",
+          "evidence": [
+            {
+              "source_id": "PL_NATD_NICOSIA_2026",
+              "locator": "D-Type national visa, What documents do I submit, travel medical insurance item",
+              "excerpt": "Travel medical insurance with minimum coverage of 30 000 EUR"
+            },
+            {
+              "source_id": "PL_NATD_SG_2026",
+              "locator": "Announcement regarding travel medical insurance, requirement list",
+              "excerpt": "provides for the insurer's liability for the amount of insurance of at least 30 000 EUR"
+            }
+          ]
+        },
+        {
+          "key": "insurance.must_cover_full_period",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "PL_NATD_NICOSIA_2026",
+              "locator": "D-Type national visa, What documents do I submit, travel medical insurance item",
+              "excerpt": "valid for the entire period of the requested national visa"
+            },
+            {
+              "source_id": "PL_NATD_SG_2026",
+              "locator": "Announcement regarding travel medical insurance, requirement list",
+              "excerpt": "is valid for the entire period of the planned stay of the foreigner in the territory of the Republic of Poland"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "PT_D7_VISTOS_2026",
       "country": "Portugal",
       "visa_name": "D7 Visa (Passive Income)",
@@ -1325,7 +1403,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-10"
     },
     {
       "visa_id": "AL_LEJE_UNIKE_MB_2026",
@@ -1333,7 +1411,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-10"
     },
     {
       "visa_id": "AL_LEJE_UNIKE_MB_2026",
@@ -1341,7 +1419,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-10"
     },
     {
       "visa_id": "AL_LEJE_UNIKE_MB_2026",
@@ -1349,7 +1427,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-10"
     },
     {
       "visa_id": "AL_LEJE_UNIKE_MB_2026",
@@ -1357,7 +1435,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-10"
     },
     {
       "visa_id": "AL_LEJE_UNIKE_MB_2026",
@@ -1376,7 +1454,7 @@
         }
       ],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-10"
     },
     {
       "visa_id": "AL_LEJE_UNIKE_MB_2026",
@@ -1384,7 +1462,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-10"
     },
     {
       "visa_id": "AL_LEJE_UNIKE_MB_2026",
@@ -1392,7 +1470,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-10"
     },
     {
       "visa_id": "CO_DNV_CANCILLERIA_2026",
@@ -2732,6 +2810,94 @@
       "last_verified": "2026-01-15"
     },
     {
+      "visa_id": "PL_NATD_NICOSIA_2026",
+      "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "PL_NATD_NICOSIA_2026",
+      "product_id": "DKV_VISADO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "PL_NATD_NICOSIA_2026",
+      "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "PL_NATD_NICOSIA_2026",
+      "product_id": "GENKI_NATIVE_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "PL_NATD_NICOSIA_2026",
+      "product_id": "GENKI_TRAVELER_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "PL_NATD_NICOSIA_2026",
+      "product_id": "SAFETYWING_NOMAD_2026",
+      "status": "YELLOW",
+      "reasons": [
+        {
+          "text": "Visa requires coverage for full legal stay, monthly subscriptions can be cancelled",
+          "evidence": [
+            {
+              "source_id": "PL_NATD_NICOSIA_2026",
+              "locator": "D-Type national visa, What documents do I submit, travel medical insurance item",
+              "excerpt": "valid for the entire period of the requested national visa"
+            },
+            {
+              "source_id": "PL_NATD_SG_2026",
+              "locator": "Announcement regarding travel medical insurance, requirement list",
+              "excerpt": "is valid for the entire period of the planned stay of the foreigner in the territory of the Republic of Poland"
+            }
+          ]
+        }
+      ],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "PL_NATD_NICOSIA_2026",
+      "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "PL_NATD_NICOSIA_2026",
+      "product_id": "WORLDNOMADS_EXPLORER_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
       "visa_id": "PT_D7_VISTOS_2026",
       "product_id": "ASISA_HEALTH_RESIDENTS_2026",
       "status": "GREEN",
@@ -3283,6 +3449,20 @@
       "sha256": "0f18ac432310a6af5e29ff42cfc7d5ebeb4eba69c02f1bc29a63c69545f4336f",
       "local_path": "sources/MT_NOMAD_RESIDENCY_FAQ_2026-01-12.md",
       "note": "Official FAQ explicitly states monthly payment insurance policies are NOT acceptable - annual payment required"
+    },
+    "PL_NATD_NICOSIA_2026": {
+      "source_id": "PL_NATD_NICOSIA_2026",
+      "url": "https://www.gov.pl/web/cyprus/d-type-national-visa",
+      "retrieved_at": "2026-06-13T00:00:00Z",
+      "sha256": "e997d4757b16df2c6177497452d7be0230065125d77315f5fed7a08cba9c5cba",
+      "local_path": "sources/PL_NATD_NICOSIA_2026-06-13.html"
+    },
+    "PL_NATD_SG_2026": {
+      "source_id": "PL_NATD_SG_2026",
+      "url": "https://www.gov.pl/web/singapore/announcement-regarding-travel-medical-insurance-for-foreigners-applying-for-a-national-visa",
+      "retrieved_at": "2026-06-13T00:00:00Z",
+      "sha256": "0f0fdf9637bd6cc74fc1e4cffcb3c271493c8f7a4b38e9f793f7bca79d961580",
+      "local_path": "sources/PL_NATD_SG_2026-06-13.html"
     },
     "PT_D7_VISTOS_2026": {
       "source_id": "PT_D7_VISTOS_2026",

--- a/data/visas/PL/NATD/consulate-nicosia/2026-06-13/visa_facts.json
+++ b/data/visas/PL/NATD/consulate-nicosia/2026-06-13/visa_facts.json
@@ -1,0 +1,78 @@
+{
+  "id": "PL_NATD_NICOSIA_2026",
+  "country": "Poland",
+  "visa_name": "National Visa (Type D)",
+  "route": "D-Type national visa (gov.pl Nicosia)",
+  "authority": "Embassy of the Republic of Poland in Nicosia (gov.pl)",
+  "last_verified": "2026-06-13",
+  "sources": [
+    {
+      "source_id": "PL_NATD_NICOSIA_2026",
+      "url": "https://www.gov.pl/web/cyprus/d-type-national-visa",
+      "retrieved_at": "2026-06-13T00:00:00Z",
+      "sha256": "e997d4757b16df2c6177497452d7be0230065125d77315f5fed7a08cba9c5cba",
+      "local_path": "sources/PL_NATD_NICOSIA_2026-06-13.html"
+    },
+    {
+      "source_id": "PL_NATD_SG_2026",
+      "url": "https://www.gov.pl/web/singapore/announcement-regarding-travel-medical-insurance-for-foreigners-applying-for-a-national-visa",
+      "retrieved_at": "2026-06-13T00:00:00Z",
+      "sha256": "0f0fdf9637bd6cc74fc1e4cffcb3c271493c8f7a4b38e9f793f7bca79d961580",
+      "local_path": "sources/PL_NATD_SG_2026-06-13.html"
+    }
+  ],
+  "requirements": [
+    {
+      "key": "insurance.mandatory",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "PL_NATD_NICOSIA_2026",
+          "locator": "D-Type national visa, What documents do I submit, travel medical insurance item",
+          "excerpt": "Travel medical insurance with minimum coverage of 30 000 EUR, valid for the entire period of the requested national visa, covering all costs which may arise during the stay, related to any urgent medical assistance, emergency hospital treatment or repatriation for medical reasons as well as, in case of death, repatriation of the deceased."
+        },
+        {
+          "source_id": "PL_NATD_SG_2026",
+          "locator": "Announcement regarding travel medical insurance for foreigners applying for a national visa (04.12.2020)",
+          "excerpt": "since 1 December 2020, the conditions that must be met by travel medical insurance for foreigners applying for a national visa have changed. Travel medical insurance must meet the following requirements"
+        }
+      ]
+    },
+    {
+      "key": "insurance.min_coverage",
+      "op": ">=",
+      "value": 30000,
+      "currency": "EUR",
+      "evidence": [
+        {
+          "source_id": "PL_NATD_NICOSIA_2026",
+          "locator": "D-Type national visa, What documents do I submit, travel medical insurance item",
+          "excerpt": "Travel medical insurance with minimum coverage of 30 000 EUR"
+        },
+        {
+          "source_id": "PL_NATD_SG_2026",
+          "locator": "Announcement regarding travel medical insurance, requirement list",
+          "excerpt": "provides for the insurer's liability for the amount of insurance of at least 30 000 EUR"
+        }
+      ]
+    },
+    {
+      "key": "insurance.must_cover_full_period",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "PL_NATD_NICOSIA_2026",
+          "locator": "D-Type national visa, What documents do I submit, travel medical insurance item",
+          "excerpt": "valid for the entire period of the requested national visa"
+        },
+        {
+          "source_id": "PL_NATD_SG_2026",
+          "locator": "Announcement regarding travel medical insurance, requirement list",
+          "excerpt": "is valid for the entire period of the planned stay of the foreigner in the territory of the Republic of Poland"
+        }
+      ]
+    }
+  ]
+}

--- a/sources/PL_NATD_NICOSIA_2026-06-13.html
+++ b/sources/PL_NATD_NICOSIA_2026-06-13.html
@@ -1,0 +1,522 @@
+<!DOCTYPE html>
+<html lang="en-GB" class="no-js ">
+<head>
+<title>D-Type national visa - Poland in Cyprus - Gov.pl website</title>
+<meta charset="utf-8"/>
+<meta content="initial-scale=1.0, width=device-width" name="viewport">
+<meta property="govpl:site_published" content="true"/>
+<meta name="msvalidate.01" content="D55ECD200B1844DB56EFBA4DA551CF8D"/>
+<meta property="og:site_name" content="Poland in Cyprus"/>
+<meta property="og:url" content="https://www.gov.pl/web/cyprus/d-type-national-visa"/>
+<meta property="og:title"
+content="D-Type national visa - Poland in Cyprus - Gov.pl website"/>
+<meta property="og:type" content="website"/>
+<meta property="og:image" content="https://www.gov.pl/img/fb_share_ogp.jpg"/>
+<meta property="og:description" content=""/>
+<meta name="twitter:description" content=""/>
+<meta name="twitter:image" content="https://www.gov.pl/img/fb_share_ogp.jpg"/>
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title"
+content="D-Type national visa - Poland in Cyprus - Gov.pl website"/>
+<meta property="govpl:site_hash" content="09e287fc-436a-38d9-ce33-bf6dd13084d1"/>
+<meta property="govpl:site_path" content="/web/cyprus"/>
+<meta property="govpl:active_menu_item" content=""/>
+<meta property="govpl:search_scope" content="cyprus"/>
+<link rel="icon" type="image/png" href="/img/icons/favicon-16x16.png"
+sizes="16x16">
+<link rel="icon" type="image/png" href="/img/icons/favicon-32x32.png"
+sizes="32x32">
+<link rel="icon" type="image/png" href="/img/icons/favicon-96x96.png"
+sizes="96x96">
+<link rel="stylesheet" type="text/css" href="/fonts/font-awesome.min.css">
+<link rel="stylesheet" type="text/css" href="/css/vendors/jquery-ui-1.13.2-smoothness.min.css">
+<link rel="stylesheet" type="text/css" href="/css/vendors/modaal.min.css">
+<link rel="stylesheet" type="text/css" href="/css/vendors/vue-select-3.20.4.css">
+<link rel="stylesheet" type="text/css" href="/css/govpl_template.css">
+<link rel="stylesheet" type="text/css" href="/css/main-0af4bd33467.css">
+<!--[if lt IE 9]>
+<script src="/scripts/polyfills/html5shiv-3.7.3.min.js"></script>
+<![endif]-->
+<script src="/scripts/polyfills/modernizr-custom.js"></script>
+<script src="/scripts/polyfills/polyfills.js"></script>
+<script src="/scripts/vendors/jquery-3.7.1.min.js"></script>
+<script src="/scripts/vendors/jquery-ui-1.13.2.min.js"></script>
+<script src="/scripts/vendors/modaal.min.js"></script>
+<script src="/scripts/vendors/b_util.js"></script>
+<script src="/scripts/vendors/b_tab_orginal.js"></script>
+<script src="/scripts/vendors/validate.min.js"></script>
+<script src="/scripts/gov_context.js?locale=en_GB"></script>
+<script src="/scripts/accordion.js"></script>
+<script src="/scripts/govpl.js"></script>
+<script src="/scripts/bundle-c53fc2f030e.js"></script>
+<script src="/scripts/utils.js"></script>
+<!-- Matomo Tag Manager -->
+<script>
+var _mtm = window._mtm = window._mtm || [];
+_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+g.async=true; g.src='https://matomo.www.gov.pl/analytics/js/container_68lYTZ79.js';
+s.parentNode.insertBefore(g,s);
+</script>
+<!-- End Matomo Tag Manager -->
+</head>
+<body id="body"
+class="">
+<nav class="quick-access-nav" aria-label="Szybki dostęp">
+<ul>
+<li><a href="#main-content">Skip to content</a></li>
+<li><a href="#footer-links">Go to the Footer section</a></li>
+</ul>
+</nav>
+<header class="govpl">
+<nav id="gov-menu-nav" aria-label="Menu główne">
+<button class="govpl__menu-opener" aria-controls="gov-menu" aria-expanded="false" aria-label="GOV.pl hamburger menu. Show navigation.">
+<span class="govpl__menu-opener__hamburger">
+<span></span>
+<span></span>
+<span></span>
+</span>
+</button>
+<div id="gov-menu" class="govpl-menu">
+<div class="govpl-menu__container" tabindex="-1">
+<div class="govpl-menu__section hide-desk">
+<ul>
+<li>
+<a href="https://www.gov.pl/"
+id="govpl-i-my_gov"
+>
+<i class="gov-icon gov-icon--account"></i>
+<span class="sr-only">Log in to the panel</span>My Gov
+</a>
+</li>
+</ul>
+</div>
+<div class="govpl-menu__section ">
+<ul>
+<li>
+<a href="https://www.gov.pl/"
+id="govpl-i-gov_home"
+>
+Home
+</a>
+</li>
+<li>
+<a href="/web/gov/rada-ministrow"
+id="govpl-i-council_of_ministers"
+>
+Council of Ministers
+</a>
+</li>
+<li>
+<a href="https://www.gov.pl/web/primeminister"
+id="govpl-i-prime_minister"
+>
+The Chancellery of the Prime Minister
+</a>
+</li>
+<li>
+<a href="/web/gov/ministerstwa"
+id="govpl-i-ministries"
+>
+Ministries
+</a>
+</li>
+<li>
+<a href="/web/gov/katalog-jednostek"
+id="govpl-i-units_catalog"
+>
+Offices, institutions </br>and offices of the RP
+</a>
+</li>
+</ul>
+</div>
+<div class="govpl-menu__section ">
+<ul>
+<li>
+<a href="/web/gov/uslugi-dla-obywatela"
+aria-label="See all services for citizens"
+id="govpl-i-services_for_citizens"
+>
+<i class="gov-icon gov-icon--citizen"></i>
+Services for citizens
+</a>
+</li>
+<li>
+<a href="/web/gov/uslugi-dla-przedsiebiorcy"
+aria-label="See all services for entrepreneurs"
+id="govpl-i-services_for_business"
+>
+<i class="gov-icon gov-icon--business"></i>
+Services for business
+</a>
+</li>
+<li>
+<a href="/web/gov/uslugi-dla-urzednika"
+aria-label="See all services for officials"
+id="govpl-i-services_for_officials"
+>
+<i class="gov-icon gov-icon--official"></i>
+Services for officials
+</a>
+</li>
+<li>
+<a href="/web/gov/uslugi-dla-rolnika"
+aria-label="See all services for farmers"
+id="govpl-i-services_for_farmers"
+>
+<i class="gov-icon gov-icon--citizen"></i>
+Services for farmers
+</a>
+</li>
+</ul>
+</div>
+<div class="govpl-menu__section govpl-menu__section--secondary">
+<ul>
+<li>
+<a href="https://www.gov.pl/web/profilzaufany"
+id="govpl-i-profil_zaufany"
+>
+Trusted profile
+</a>
+</li>
+<li>
+<a href="/web/baza-wiedzy"
+id="govpl-i-baza_wiedzy"
+>
+Knowledge base
+</a>
+</li>
+<li>
+<a href="https://www.gov.pl/web/civilservice"
+id="govpl-i-civil_service"
+>
+Civil service
+</a>
+</li>
+<li>
+<a href="Сайт для громадян України – Service for Ukrainian citizens"
+id="govpl-i-ukraina"
+>
+<a href="https://www.gov.pl/ua"><img alt="flaga" height="16" src="/photo/a6631d28-8291-4474-b530-32864664800e" width="24" />&nbsp;Сайт для громадян України &ndash; Service for Ukrainian citizens</a>
+</a>
+</li>
+</ul>
+</div>
+<button class="govpl-menu__close">Close the GOV.pl menu</button>
+</div></div>
+</nav>
+<nav id="top-bar-nav" class="govpl__top-bar" aria-label="Menu nagłówka strony">
+<div class="govpl__header">
+<a class="govpl__logotype govpl-logo" href="https://www.gov.pl/" aria-label="Gov.pl home page">
+<span class="govpl__portal-short-name ">gov.pl</span>
+</a>
+<span class="govpl__portal-name ">
+<h1 class="">
+<span class="sr-only">gov.pl</span>
+Website of the Republic of Poland
+</h1>
+</span>
+</div>
+<form class="govpl__search search-form--strong-focus form govpl__search--search-right-button"
+action="https://www.gov.pl/web/gov/szukaj"
+method="GET">
+<input type="hidden" name="scope" value="cyprus"/>
+<div class="search-right-button">
+<input id="gov-query"
+name="query"
+placeholder="Search for services, information, news"
+autocomplete="off"
+aria-label="Search in"
+class="search-right-button__input"
+type="text">
+<button type="submit" class="search-right-button__submit btn btn-primary">
+Search
+</button>
+</div>
+</form>
+<a class="govpl__search-link" href="https://www.gov.pl/web/gov/szukaj"><span class="loupe"></span><span class="sr-only">go to search</span></a>
+<a class="govpl__panel-login btn btn-secondary" href="https://www.mobywatel.gov.pl/mObywatel">
+<span class="sr-only">Log in to the panel</span>My Gov
+</a>
+<span class="govpl__separator"></span>
+<img src="/img/icons/eu/eu-center-en.svg" class="govpl__eu-logo" alt="The European Union Logo - a circle of 12 yellow stars formed on a dark blue background, with writing below: European Union">
+</nav>
+</header>
+<div class="govpl-spacer"></div>
+<header class="page-header">
+<div class="main-container">
+<div>
+<div class="header-links">
+<div class="icons">
+</div>
+<div class="lang-links unit-list-item">
+<a href="#" aria-haspopup="true" aria-expanded="false" data-gov-toggle="#lang-links-expand" class="unit-submenu-toggle">
+<span class="sr-only">Change language</span>
+<span class="menu-open">EN</span>
+</a>
+<ul id="lang-links-expand">
+<li><a href="/web/cypr" lang="pl">PL - polski</a></li>
+</ul>
+</div>
+</div>
+<h1 class="unit-h1">
+<a href="/web/cyprus">Poland in Cyprus</a>
+</h1>
+<nav id="unit-menu" aria-label="Menu główne">
+<button id="unit-menu-toggle" aria-haspopup="true" aria-expanded="false">MENU<i></i></button>
+<ul id="unit-menu-list">
+<li id="unit-submenu-0" class="has-child unit-list-item">
+<a href="/web/cyprus/embassy-rp" class="unit-submenu-desktop" >
+Embassy
+</a>
+<button class="unit-submenu-mobile unit-submenu-toggle " aria-haspopup="true" aria-expanded="false">
+<span class="menu-open">Embassy</span>
+</button>
+<ul id="unit-submenu-list-0" class="unit-submenu-list">
+<li>
+<a href="/web/cyprus/embassy"
+>Embassy</a>
+</li>
+<li>
+<a href="/web/cyprus/ambassador"
+>Ambassador</a>
+</li>
+<li>
+<a href="/web/cyprus/honorary-consulates"
+>Honorary consulates</a>
+</li>
+<li>
+<a href="/web/cyprus/our-staff"
+>Our staff</a>
+</li>
+<li>
+<a href="/web/cyprus/internship"
+>Internship</a>
+</li>
+</ul>
+</li>
+<li>
+<a href="/web/cyprus/bilateral-relations-"
+>Bilateral relations</a>
+</li>
+<li>
+<a href="/web/cyprus/consular-information"
+class="active" aria-current="page">Consular information</a>
+</li>
+<li>
+<a href="/web/cyprus/news"
+>News</a>
+</li>
+<li id="unit-menu-lang" class="unit-list-item">
+<button aria-haspopup="true" aria-expanded="false" class="unit-submenu-toggle">
+<span class="sr-only">Change language</span>
+<span class="menu-open">EN</span>
+</button>
+<ul id="unit-menu-lang-list" class="unit-submenu-list">
+<li><a href="/web/cypr" lang="pl">PL - POLSKI</a></li>
+</ul>
+</li>
+<li id="menu-close"><button>Close the menu</button></li>
+</ul>
+</nav>
+</div>
+</div>
+</header>
+<main>
+<nav class="breadcrumbs main-container" aria-label="Breadcrumb trail"><ul>
+<li><a class="home" href="https://www.gov.pl/" aria-label="Gov.pl home page"></a></li>
+<li>
+<a href="/web/cyprus">Poland in Cyprus</a>
+</li>
+<li>
+<a href="/web/cyprus/consular-information">Consular information</a>
+</li>
+<li>
+<a href="/web/cyprus/visas">Visas</a>
+</li>
+<li>
+D-Type national visa
+</li>
+</ul></nav>
+<div class="article-area main-container ">
+<aside class="relative-articles">
+<ul class="relative-articles__siblings">
+<li>
+<a href="/web/cyprus/visas---general-information">Visas - general information</a>
+</li>
+<li>
+<a href="/web/cyprus/c-type-schengen-visa">C-Type Schengen Visa</a>
+</li>
+<li>
+<a class="current" aria-current="true" href="/web/cyprus/d-type-national-visa">D-Type national visa</a>
+</li>
+<li>
+<a href="/web/cyprus/a-type-airport-transit-visa">A-Type airport transit visa</a>
+</li>
+<li>
+<a href="/web/cyprus/information-about-refunding-student-fees-in-case-of-receiving-a-visa-refusal2">Information about refunding student fees in case of receiving a visa refusal.</a>
+</li>
+<li>
+<a href="/web/cyprus/information-on-the-principles-of-applying-for-visas-by-foreigners-intending-to-practice-as-a-doctor-dentist-nurse-obstetrician-or-paramedic-in-the-territory-of-the-republic-of-poland">Information on the principles of applying for visas by foreigners intending to practice as a doctor, dentist, nurse, obstetrician or paramedic in the territory of the Republic of Poland</a>
+</li>
+<li>
+<a href="/web/cyprus/insurance--national-visa">Insurance- national visa</a>
+</li>
+</ul>
+</aside>
+<article class="article-area__article " id="main-content">
+<h2>D-Type national visa</h2>
+<div class="editor-content">
+<div><details><summary>Where to apply?</summary>
+<p>You can apply for a visa at the Consular Section of the Embassy of Poland in Nicosia.</p>
+<p>We can accept your application only if you present a&nbsp;document confirming that you legally reside in the Republic of Cyprus (such as a residence permit).&nbsp;<span style="color:#000000"><span style="font-size:12pt"><span style="background-color:white"><span dir="ltr" lang="EN-US" style="font-size:11.0pt"><span style="background-color:white"><u><ins>Please note that residence permit application or renewal receipts are not accepted.</ins></u></span></span></span></span></span></p>
+</details>
+<details><summary>Do I have to apply in person?</summary>
+<p>The visa application must be submitted in person. We do not accept applications sent via fax, regular mail or e-mail.</p>
+</details>
+<details><summary>How to book an appointment?</summary>
+<p><span style="font-size:14px">In order to apply for a national visa, please book your appointment via the <a href="https://secure.e-konsulat.gov.pl/" style="color:blue; text-decoration:underline">e-konsulat system</a>. Remember to apply for a visa no later than 15 calendar days before the planned departure.</span></p>
+<p><span style="font-size:14px">NOTE - When registering, enter precisely requested data contained in the documents you intend to submit. Data entered in the application need to be consistent with the data contained in the documents (also in terms of spelling).</span></p>
+<p><span style="font-size:14px">In order to book an appointment:</span></p>
+<p style="margin-left:19px"><span style="font-size:14px">1.&nbsp; go to the <a href="https://secure.e-konsulat.gov.pl/" style="color:blue; text-decoration:underline">e-konsulat system</a>;</span></p>
+<p style="margin-left:19px"><span style="font-size:14px">2.&nbsp; in the &ldquo;Menu&rdquo; select &quot;National visa - register form&quot;, then select your option (application for a work visa or application for another type of national visa) and confirm that you accept the rules for submitting the application:</span></p>
+<p style="margin-left:47px"><span style="font-size:14px">-&nbsp;&nbsp;&nbsp; if you select &quot;National visa - work&quot;, fill in the provisionary visa application containing your basic data and the details of your work permit in Poland. If the details entered are correct, you will receive an email with a link to complete the visa application (you will have 48 hours to do it). Complete the application, save it and print it. If the data are not positively verified or the application is not completed within 48 hours, the registration will be canceled;</span></p>
+<p style="margin-left:47px"><span style="font-size:14px">-&nbsp;&nbsp;&nbsp; if you select &quot;National visa - others&quot;, choose the date of your visit, complete the visa application, save it and print it.</span></p>
+<p style="margin-left:19px"><span style="font-size:14px">3.&nbsp; If the number of applicants is greater than the number of available places, appointments will be made by electronic drawing. The appointment dates for visa cases are drawn by the e-konsulat system every Saturday. Employees of consular offices cannot interfere with this process. </span>&nbsp;After booking the appointment , we will send information about the date of the visit to the e-mail address provided by you. Other applications will take part in booking the appointments until they are booked or until the expiry date of the document entitling you to work in Poland.</p>
+<p><span style="font-size:14px">All information, confirmation and links are automatically sent to the e-mail address you&rsquo;ve given at the beginning.</span></p>
+<p><span style="font-size:14px">On the agreed date you shall come to the consular office with a printed and signed visa application form, original work permit and a complete set of necessary documents.</span></p>
+</details>
+<details><summary>What documents do I need to submit?&nbsp;</summary>
+<ol>
+<li><span style="font-size:11pt"><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">Visa application form registered through the </span><a href="https://www.e-konsulat.gov.pl/" style="color:blue; text-decoration:underline"><span dir="ltr" lang="EN-US" style="color:#0563c1">e-konsulat</span></a><span dir="ltr" lang="EN-US" style="color:#1b1b1b"> system, printed and signed.</span></span></span></li>
+<li><span style="font-size:11pt"><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">3.5 x 4.5 cm colour photo. The photo must be: sharp, taken against white background and printed on a quality paper; newer than 6 months; taken en face, clearly showing the eyes and face from both sides from the top of the head to the top of the shoulders with the face covering 70-80% of the photo. The photo must be taken without any headwear.</span></span></span></li>
+<li><span style="font-size:11pt"><span style="background-color:white"><span style="background-color:white"><span style="color:#1b1b1b">Passport issued within last ten years, valid for at least three months from the expected return date, with at least two blank pages for visas. If&nbsp;you have another valid passport, you should attach it to the visa application form.</span></span></span></span></li>
+<li><span style="font-size:11pt"><span style="background-color:white"><span style="background-color:white"><span style="color:#1b1b1b">Copy of the passport personal data page.&nbsp;</span></span></span></span></li>
+<li><span style="font-size:11pt"><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">Document confirming the applicant legally resides in the Republic of Cyprus (such as a residence permit) with a copy.&nbsp;</span></span></span><span style="color:#000000"><span style="font-size:12pt"><span style="background-color:white"><span dir="ltr" lang="EN-US" style="font-size:11.0pt"><span style="background-color:white"><u><ins>Please note that residence permit application or renewal receipts are not accepted.</ins></u></span></span></span></span></span></li>
+<li><span style="font-size:11pt"><span style="background-color:white"><span style="background-color:white"><span style="color:#1b1b1b">Documents confirming the purpose and conditions of the intended stay in Poland (such as a work permit; university acceptance letter with confirmation of payment of fees and high school or lower level university diploma, invitation).</span></span></span></span></li>
+<li><span style="font-size:11pt"><span style="background-color:white"><span style="color:#1b1b1b">Flight booking.</span></span></span></li>
+<li><span style="font-size:11pt"><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">Travel medical insurance with </span><span style="background-color:white"><span style="color:#1b1b1b">minimum coverage of 30&nbsp;000 EUR​, valid for the entire period of the requested national visa, covering all costs&nbsp;which may arise during the stay, related to any urgent medical assistance, emergency hospital treatment or repatriation for medical reasons as well as, in case of death, repatriation of the deceased. The insurer&nbsp;has to provide 24/7 Assistance Provision Centre (Call Centre)&nbsp;and undertakes to cover the costs of health services directly to the entity providing these services, on the basis of an invoice issued by this entity.&nbsp;More information:&nbsp;</span></span><a href="https://www.gov.pl/web/dyplomacja/wizy" style="color:blue; text-decoration:underline"><span style="background-color:white"><span style="color:#0563c1">https://www.gov.pl/web/dyplomacja/wizy</span></span></a><span style="background-color:white"><span style="color:#1b1b1b">&nbsp;under tab &bdquo;Information of the Minister of Foreign Affairs about the insurers and the insurances that they offer, which meet the necessary conditions referred to in Article 25 (1) (2) (a) and Article 25 (1b) of the Act of 12 December 2013 on Foreigners&ldquo;.</span></span></span></span></li>
+<li><span style="font-size:11pt"><span style="background-color:white"><span style="background-color:white"><span style="color:#1b1b1b">Proof of accommodation in Poland (such as invitation registered with the <em>voivdeship office,</em> proof of apartment rental, hotel booking).</span></span></span></span></li>
+<li><span style="font-size:11pt"><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">Proof of financial means. The financial means must be sufficient to cover living expenses (min. 776 PLN per month) and accomodation for the entire period of the requested visa, as well as cost of return flight ticket (min. 2500 PLN). Possession of financial means may be demonstrated by: a) an account statement from a bank with a registered seat in Poland or the European Union; b) a confirmation of a credit card account with information about the available credit limit; c) traveller&rsquo;s cheques; d) proof of employment with sufficient salary or scholarship.</span></span></span></li>
+<li><span style="font-size:11pt"><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">(Optional) sponsorship letter with the sponsored signature certified by a notary public.</span></span></span></li>
+<li><span style="font-size:11pt"><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">(Optional) relevant civil registry certificates (such as marriage or birth certificate).</span></span></span></li>
+<li><span style="font-size:11pt"><span style="background-color:white"><span style="color:#1b1b1b">(Optional) school/university diplomas.</span></span></span></li>
+</ol>
+<p>&nbsp;</p>
+<p><span style="background-color:white"><strong><span style="color:#1b1b1b">Additional documents for minors</span></strong></span></p>
+<ol start="14">
+<li><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">Birth certificate.</span></span></li>
+<li><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">Copies of parents&rsquo; passports or national IDs.</span></span></li>
+<li><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">In case the parent(s)s is/are not present at the time of submitting the visa application, a </span><span dir="ltr" lang="EN-US" style="color:#1b1b1b">written consent of the minor&rsquo;s parent(s), certified by a notary is required. If there is only one guardian, it should be confirmed by a birth certificate, a court decision on exclusive parental custody or a death certificate of the other parent.</span></span></li>
+</ol>
+<p style="margin-left:24px"><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">If a child is entered in their parent&#39;s or a legal guardian&rsquo;s passport, please submit a separate visa application. The visa will be pasted into the parent&#39;s or the legal guardian&#39;s passport.</span></span></p>
+<p>&nbsp;</p>
+<p><span style="background-color:white"><strong><span style="color:#1b1b1b">Remember:</span></strong></span></p>
+<ul>
+<li><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:black">All supporting documents, especially civil registry documents, certificates, invitations, etc., should be submitted as originals. If you would like for the original to be returned to you, please submit it along with a copy.</span></span></li>
+<li><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:black">Official documents, such as civil registry certificates, diplomas, etc., issued in third countries outside the European Union, require an apostille or legalization.</span></span></li>
+<li><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:black">Official documents in languages other than Polish, Greek and English require also a sworn translation by translator from the list kept by the Minister of Justice of the Republic of Poland.</span></span></li>
+<li><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">Usually, the above documents are sufficient to issue a decision, however the consul may require additional documents.</span></span></li>
+<li><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">You must apply at the diplomatic mission accredited for your place of residence.</span></span></li>
+<li><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">Apply for a visa not earlier than 6 months and not later than 15 days before your planned journey. The consul may agree to accept your application later than 15 days before your planned trip only in urgent, justified cases.</span></span></li>
+<li><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">The consul may, but does not have to, invite the applicant for an interview.</span></span></li>
+<li><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">You may be banned from entering any of the Schengen States if you present forged documents or provide false information.</span></span></li>
+<li><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">Receiving the visa does not guarantee that you will enter the Schengen area - the final decision is always made by the authorities of the country where you intend to cross the Schengen area border.</span></span></li>
+<li><span style="background-color:white"><span dir="ltr" lang="EN-US" style="color:#1b1b1b">The Visa Information System (VIS) is designed to exchange data on visa applications and related decisions between Member States. Due to the fact that he has achieved full operational efficiency, the travel document of a foreigner applying for a Schengen visa is not stamped with a stamp confirming the admissibility of the application referred to in art. 20 of Regulation (EC) No 810/2009 of the European Parliament and of the Council of 13 July 2009 establishing a Community Code on Visas (Visa Code).</span></span></li>
+</ul>
+</details>
+<details><summary>How much does it cost?&nbsp;</summary>
+<p>The visa fee is <strong>200,00</strong> EUR.</p>
+<p>The fees must be paid at the office counter when submitting the application.</p>
+<p>Accepted forms of payment: cash.</p>
+<p>The visa application fee is non-returnable, whatever the consul&#39;s decision.</p>
+</details>
+<details><summary>What is the waiting time?</summary>
+<p>The decision on the issue of a visa is made within 15 working days from the payment date of application fee. If the documents need to be examined in more detail, the consideration period may be extended to 30 days. In urgent and justified cases, the decision can be made in three working days.</p>
+</details>
+<details><summary>How to collect the documents?</summary>
+<p>Our consular staff will inform you about the collection date during your first appointment. The collection of visa decisions does not require booking an appointment.</p>
+<p>If you miss your collection date, you can come later, any Monday at 14:00-15:00.</p>
+</details>
+<details><summary>How to appeal?</summary>
+<p>In case of a negative decision, you will be informed in writing. The document will include the reasons for the refusal.</p>
+<p>If you received a visa refusal, you have the right to apply for a reconsideration of the visa application&nbsp;within 14 days from the date when you received the refusal decision.</p>
+<p>To apply for a reconsideration, you do not need to register for an appointment in our online system. Simply come to the Embassy on Monday&nbsp;between 11:00 and 12:00 and submit your documents. If you cannot come on this day, please send&nbsp;us an email and we will offer you an alternative date.&nbsp;</p>
+<p>The application fee in this case is 200 EUR.</p>
+</details>
+<details><summary>Frequently asked questions</summary>
+<p>&nbsp;</p>
+</details>
+</div>
+</div>
+<div class="legal-basis">
+<h3>Legal basis</h3>
+<p class="title">Rozporządzenie Parlamentu Europejskiego i Rady (WE) nr 810/2009 z dnia 13 lipca 2009 r. ustanawiające Wspólnotowy Kodeks Wizowy (kodeks wizowy) </p>
+<p class="title">Ustawa z dnia 12 grudnia 2013 r. o cudzoziemcach (Dz. U. z dnia 30 grudnia 2013 r. poz. 1650 z późn. zm.) </p>
+<p class="title">Ustawa z dnia 25 czerwca 2015 r. Prawo konsularne (Dz. U. z dnia 31 sierpnia 2015 r. poz. 1274) </p>
+<p class="title">[ewentualna umowa dwustronna o ułatwieniach wizowych] </p>
+</div>
+</article>
+</div>
+<pre id="pageMetadata" class="hide">{"register":{"columns":[]}}</pre>
+</main>
+<footer class="footer">
+<div class="main-container">
+<h2 class="sr-only">footer gov.pl</h2>
+<div class="links" id="footer-links">
+<a href="https://www.gov.pl/" class="logo">
+<img src="/img/icons/godlo-12.svg" alt="Godło Polski" width="30" aria-hidden="true">
+<span class="sr-only">Main site</span> gov.pl
+</a>
+<ul>
+<li><a href="https://www.gov.pl/web/gov/polityka-dotyczaca-cookies">Cookie policy</a></li>
+<li><a href="https://www.gov.pl/web/civilservice">Civil service</a></li>
+<li><a href="https://www.gov.pl/web/profilzaufany">Trusted profile</a></li>
+<li><a href="https://www.bip.gov.pl/">Public Information Bulletin</a></li>
+<li><a href="https://www.premier.gov.pl/prawa-autorskie.html">Copyrights</a></li>
+<li><a href="/web/gov/deklaracja-dostepnosci-serwisu-govpl">Gov.pl accessibility declaration</a></li>
+<li><a href="#" id="manage-consent">Ustawienia prywatności</a></li>
+</ul>
+</div>
+<div class="creative-commons">
+<div class="emails">Pages available in the www.gov.pl domain may contain e-mail addresses. By clicking an e-mail address provided as a link, you consent to the processing of your data (e-mail address and other data provided on a voluntary basis in the message) in order for the recipient to send a response to the submitted questions. The details concerning processing of personal data by each unit can be found in their respective policies concerning the processing of personal data.</div>
+<div class="icons">
+<span class="license-cc" aria-hidden="true"></span>
+<span class="license-by" aria-hidden="true"></span>
+</div>
+<div class="text">All content published on this website is covered by a <a target="_blank" href="https://creativecommons.org/licenses/by/3.0/pl/">Creative Commons Attribution 3.0 PL</a> license, unless stated otherwise.</div>
+</div>
+<div class="eu-logotypes eu-logotypes--footer">
+<img src="/img/icons/eu/fe-pc-left-en.svg" alt="Fundusze Europejskie Logotyp:
+Na granatowym tle częściowo widoczne trzy gwiazdki
+żółta, biała i czerwona obok napis
+European, funds digital of Poland." class="eu-funds-logo">
+<img src="/img/icons/eu/rp-left-en.svg" alt="biało-czerwona flaga polska obok napis Rzeczpospolita Polska Logotyp" class="rp-logo">
+<img src="/img/icons/eu/eu-efrp-left-en.svg" alt="z lewej strony napis Unia Europejska Logotyp. Europejski Fundusz Rozwoju Regionalnego. po prawej strony na granatowym tle 12 żółtych gwiazdek tworzących okrąg flaga Unii Europejskiej" class="eu-logo-left">
+<img src="/img/icons/eu/eu-efrp-right-en.svg" alt="z lewej strony napis Unia Europejska Logotyp. Europejski Fundusz Rozwoju Regionalnego. po prawej strony na granatowym tle 12 żółtych gwiazdek tworzących okrąg flaga Unii Europejskiej" class="eu-logo-right">
+</div>
+</div>
+</footer>
+<script src="/scripts/body_end.js"></script>
+<script src="/scripts/register_metadata.js"></script>
+<script src="/scripts/zawbi_banner.js"></script>
+<link rel="stylesheet" type="text/css" href="/css/zawbi_banner.css">
+<script>
+MatomoConsentSDK.init({
+policyUrl: '/web/gov/polityka-dotyczaca-cookies',
+cookieTableEnabled: false,
+});
+if (!window.location.pathname.includes('/web/gov/polityka-dotyczaca-cookies')) {
+MatomoConsentSDK.showBanner();
+}
+document.getElementById('manage-consent').addEventListener('click', function(e){
+e.preventDefault();
+if (typeof showMatomoConsentBanner === 'function') {
+showMatomoConsentBanner({ forceShow: true, forceCookiePanel: true });
+} else if (typeof MatomoConsentSDK !== 'undefined') {
+MatomoConsentSDK.showBanner({ forceShow: true, forceCookiePanel: true });
+}
+});
+</script>
+</body>
+</html>

--- a/sources/PL_NATD_NICOSIA_2026-06-13.html.meta.json
+++ b/sources/PL_NATD_NICOSIA_2026-06-13.html.meta.json
@@ -1,0 +1,7 @@
+{
+  "source_id": "PL_NATD_NICOSIA_2026",
+  "url": "https://www.gov.pl/web/cyprus/d-type-national-visa",
+  "retrieved_at": "2026-06-13T00:00:00Z",
+  "sha256": "e997d4757b16df2c6177497452d7be0230065125d77315f5fed7a08cba9c5cba",
+  "local_path": "sources/PL_NATD_NICOSIA_2026-06-13.html"
+}

--- a/sources/PL_NATD_SG_2026-06-13.html
+++ b/sources/PL_NATD_SG_2026-06-13.html
@@ -1,0 +1,458 @@
+<!DOCTYPE html>
+<html lang="en-GB" class="no-js ">
+<head>
+<title>Announcement regarding travel medical insurance for foreigners applying for a national visa - Poland in Singapore - Gov.pl website</title>
+<meta charset="utf-8"/>
+<meta content="initial-scale=1.0, width=device-width" name="viewport">
+<meta property="govpl:site_published" content="true"/>
+<meta name="msvalidate.01" content="D55ECD200B1844DB56EFBA4DA551CF8D"/>
+<meta property="og:site_name" content="Poland in Singapore"/>
+<meta property="og:url" content="https://www.gov.pl/web/singapore/announcement-regarding-travel-medical-insurance-for-foreigners-applying-for-a-national-visa"/>
+<meta property="og:title"
+content="Announcement regarding travel medical insurance for foreigners applying for a national visa - Poland in Singapore - Gov.pl website"/>
+<meta property="og:type" content="website"/>
+<meta property="og:image" content="https://www.gov.pl/photo/format/129d7e6c-35ea-47cc-9d60-bb59ad534d19/resolution/1328x560"/>
+<meta property="og:description" content=""/>
+<meta name="twitter:description" content=""/>
+<meta name="twitter:image" content="https://www.gov.pl/photo/format/129d7e6c-35ea-47cc-9d60-bb59ad534d19/resolution/1328x560"/>
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title"
+content="Announcement regarding travel medical insurance for foreigners applying for a national visa - Poland in Singapore - Gov.pl website"/>
+<meta property="govpl:site_hash" content="32fe8766-09cd-3d49-25bc-a612ce9db047"/>
+<meta property="govpl:site_path" content="/web/singapore"/>
+<meta property="govpl:active_menu_item" content=""/>
+<meta property="govpl:search_scope" content="singapore"/>
+<link rel="icon" type="image/png" href="/img/icons/favicon-16x16.png"
+sizes="16x16">
+<link rel="icon" type="image/png" href="/img/icons/favicon-32x32.png"
+sizes="32x32">
+<link rel="icon" type="image/png" href="/img/icons/favicon-96x96.png"
+sizes="96x96">
+<link rel="stylesheet" type="text/css" href="/fonts/font-awesome.min.css">
+<link rel="stylesheet" type="text/css" href="/css/vendors/jquery-ui-1.13.2-smoothness.min.css">
+<link rel="stylesheet" type="text/css" href="/css/vendors/modaal.min.css">
+<link rel="stylesheet" type="text/css" href="/css/vendors/vue-select-3.20.4.css">
+<link rel="stylesheet" type="text/css" href="/css/govpl_template.css">
+<link rel="stylesheet" type="text/css" href="/css/main-0af4bd33467.css">
+<!--[if lt IE 9]>
+<script src="/scripts/polyfills/html5shiv-3.7.3.min.js"></script>
+<![endif]-->
+<script src="/scripts/polyfills/modernizr-custom.js"></script>
+<script src="/scripts/polyfills/polyfills.js"></script>
+<script src="/scripts/vendors/jquery-3.7.1.min.js"></script>
+<script src="/scripts/vendors/jquery-ui-1.13.2.min.js"></script>
+<script src="/scripts/vendors/modaal.min.js"></script>
+<script src="/scripts/vendors/b_util.js"></script>
+<script src="/scripts/vendors/b_tab_orginal.js"></script>
+<script src="/scripts/vendors/validate.min.js"></script>
+<script src="/scripts/gov_context.js?locale=en_GB"></script>
+<script src="/scripts/accordion.js"></script>
+<script src="/scripts/govpl.js"></script>
+<script src="/scripts/bundle-c53fc2f030e.js"></script>
+<script src="/scripts/utils.js"></script>
+<!-- Matomo Tag Manager -->
+<script>
+var _mtm = window._mtm = window._mtm || [];
+_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+g.async=true; g.src='https://matomo.www.gov.pl/analytics/js/container_68lYTZ79.js';
+s.parentNode.insertBefore(g,s);
+</script>
+<!-- End Matomo Tag Manager -->
+</head>
+<body id="body"
+class="">
+<nav class="quick-access-nav" aria-label="Szybki dostęp">
+<ul>
+<li><a href="#main-content">Skip to content</a></li>
+<li><a href="#footer-links">Go to the Footer section</a></li>
+</ul>
+</nav>
+<header class="govpl">
+<nav id="gov-menu-nav" aria-label="Menu główne">
+<button class="govpl__menu-opener" aria-controls="gov-menu" aria-expanded="false" aria-label="GOV.pl hamburger menu. Show navigation.">
+<span class="govpl__menu-opener__hamburger">
+<span></span>
+<span></span>
+<span></span>
+</span>
+</button>
+<div id="gov-menu" class="govpl-menu">
+<div class="govpl-menu__container" tabindex="-1">
+<div class="govpl-menu__section hide-desk">
+<ul>
+<li>
+<a href="https://www.gov.pl/"
+id="govpl-i-my_gov"
+>
+<i class="gov-icon gov-icon--account"></i>
+<span class="sr-only">Log in to the panel</span>My Gov
+</a>
+</li>
+</ul>
+</div>
+<div class="govpl-menu__section ">
+<ul>
+<li>
+<a href="https://www.gov.pl/"
+id="govpl-i-gov_home"
+>
+Home
+</a>
+</li>
+<li>
+<a href="/web/gov/rada-ministrow"
+id="govpl-i-council_of_ministers"
+>
+Council of Ministers
+</a>
+</li>
+<li>
+<a href="https://www.gov.pl/web/primeminister"
+id="govpl-i-prime_minister"
+>
+The Chancellery of the Prime Minister
+</a>
+</li>
+<li>
+<a href="/web/gov/ministerstwa"
+id="govpl-i-ministries"
+>
+Ministries
+</a>
+</li>
+<li>
+<a href="/web/gov/katalog-jednostek"
+id="govpl-i-units_catalog"
+>
+Offices, institutions </br>and offices of the RP
+</a>
+</li>
+</ul>
+</div>
+<div class="govpl-menu__section ">
+<ul>
+<li>
+<a href="/web/gov/uslugi-dla-obywatela"
+aria-label="See all services for citizens"
+id="govpl-i-services_for_citizens"
+>
+<i class="gov-icon gov-icon--citizen"></i>
+Services for citizens
+</a>
+</li>
+<li>
+<a href="/web/gov/uslugi-dla-przedsiebiorcy"
+aria-label="See all services for entrepreneurs"
+id="govpl-i-services_for_business"
+>
+<i class="gov-icon gov-icon--business"></i>
+Services for business
+</a>
+</li>
+<li>
+<a href="/web/gov/uslugi-dla-urzednika"
+aria-label="See all services for officials"
+id="govpl-i-services_for_officials"
+>
+<i class="gov-icon gov-icon--official"></i>
+Services for officials
+</a>
+</li>
+<li>
+<a href="/web/gov/uslugi-dla-rolnika"
+aria-label="See all services for farmers"
+id="govpl-i-services_for_farmers"
+>
+<i class="gov-icon gov-icon--citizen"></i>
+Services for farmers
+</a>
+</li>
+</ul>
+</div>
+<div class="govpl-menu__section govpl-menu__section--secondary">
+<ul>
+<li>
+<a href="https://www.gov.pl/web/profilzaufany"
+id="govpl-i-profil_zaufany"
+>
+Trusted profile
+</a>
+</li>
+<li>
+<a href="/web/baza-wiedzy"
+id="govpl-i-baza_wiedzy"
+>
+Knowledge base
+</a>
+</li>
+<li>
+<a href="https://www.gov.pl/web/civilservice"
+id="govpl-i-civil_service"
+>
+Civil service
+</a>
+</li>
+<li>
+<a href="Сайт для громадян України – Service for Ukrainian citizens"
+id="govpl-i-ukraina"
+>
+<a href="https://www.gov.pl/ua"><img alt="flaga" height="16" src="/photo/a6631d28-8291-4474-b530-32864664800e" width="24" />&nbsp;Сайт для громадян України &ndash; Service for Ukrainian citizens</a>
+</a>
+</li>
+</ul>
+</div>
+<button class="govpl-menu__close">Close the GOV.pl menu</button>
+</div></div>
+</nav>
+<nav id="top-bar-nav" class="govpl__top-bar" aria-label="Menu nagłówka strony">
+<div class="govpl__header">
+<a class="govpl__logotype govpl-logo" href="https://www.gov.pl/" aria-label="Gov.pl home page">
+<span class="govpl__portal-short-name ">gov.pl</span>
+</a>
+<span class="govpl__portal-name ">
+<h1 class="">
+<span class="sr-only">gov.pl</span>
+Website of the Republic of Poland
+</h1>
+</span>
+</div>
+<form class="govpl__search search-form--strong-focus form govpl__search--search-right-button"
+action="https://www.gov.pl/web/gov/szukaj"
+method="GET">
+<input type="hidden" name="scope" value="singapore"/>
+<div class="search-right-button">
+<input id="gov-query"
+name="query"
+placeholder="Search for services, information, news"
+autocomplete="off"
+aria-label="Search in"
+class="search-right-button__input"
+type="text">
+<button type="submit" class="search-right-button__submit btn btn-primary">
+Search
+</button>
+</div>
+</form>
+<a class="govpl__search-link" href="https://www.gov.pl/web/gov/szukaj"><span class="loupe"></span><span class="sr-only">go to search</span></a>
+<a class="govpl__panel-login btn btn-secondary" href="https://www.mobywatel.gov.pl/mObywatel">
+<span class="sr-only">Log in to the panel</span>My Gov
+</a>
+<span class="govpl__separator"></span>
+<img src="/img/icons/eu/eu-center-en.svg" class="govpl__eu-logo" alt="The European Union Logo - a circle of 12 yellow stars formed on a dark blue background, with writing below: European Union">
+</nav>
+</header>
+<div class="govpl-spacer"></div>
+<header class="page-header">
+<div class="main-container">
+<div>
+<div class="header-links">
+<div class="icons">
+</div>
+<div class="lang-links unit-list-item">
+<a href="#" aria-haspopup="true" aria-expanded="false" data-gov-toggle="#lang-links-expand" class="unit-submenu-toggle">
+<span class="sr-only">Change language</span>
+<span class="menu-open">EN</span>
+</a>
+<ul id="lang-links-expand">
+<li><a href="/web/singapur" lang="pl">PL - polski</a></li>
+</ul>
+</div>
+</div>
+<h1 class="unit-h1">
+<a href="/web/singapore">Poland in Singapore</a>
+</h1>
+<nav id="unit-menu" aria-label="Menu główne">
+<button id="unit-menu-toggle" aria-haspopup="true" aria-expanded="false">MENU<i></i></button>
+<ul id="unit-menu-list">
+<li id="unit-submenu-0" class="has-child unit-list-item">
+<a href="/web/singapore/embassy-rp" class="unit-submenu-desktop" >
+Embassy
+</a>
+<button class="unit-submenu-mobile unit-submenu-toggle " aria-haspopup="true" aria-expanded="false">
+<span class="menu-open">Embassy</span>
+</button>
+<ul id="unit-submenu-list-0" class="unit-submenu-list">
+<li>
+<a href="/web/singapore/embassy"
+>Embassy</a>
+</li>
+<li>
+<a href="/web/singapore/ambassador--"
+>Ambassador</a>
+</li>
+<li>
+<a href="/web/singapore/our-staff"
+>Our staff</a>
+</li>
+</ul>
+</li>
+<li>
+<a href="/web/singapore/bilateral-relations-"
+>Bilateral relations</a>
+</li>
+<li>
+<a href="/web/singapore/consular-information"
+>Consular information</a>
+</li>
+<li>
+<a href="/web/singapore/news"
+class="active" aria-current="page">News</a>
+</li>
+<li id="unit-menu-lang" class="unit-list-item">
+<button aria-haspopup="true" aria-expanded="false" class="unit-submenu-toggle">
+<span class="sr-only">Change language</span>
+<span class="menu-open">EN</span>
+</button>
+<ul id="unit-menu-lang-list" class="unit-submenu-list">
+<li><a href="/web/singapur" lang="pl">PL - POLSKI</a></li>
+</ul>
+</li>
+<li id="menu-close"><button>Close the menu</button></li>
+</ul>
+</nav>
+</div>
+</div>
+</header>
+<main>
+<nav class="breadcrumbs main-container" aria-label="Breadcrumb trail"><ul>
+<li><a class="home" href="https://www.gov.pl/" aria-label="Gov.pl home page"></a></li>
+<li>
+<a href="/web/singapore">Poland in Singapore</a>
+</li>
+<li>
+<a href="/web/singapore/news">News</a>
+</li>
+<li>
+Announcement regarding travel medical insurance for foreigners applying for a national visa
+</li>
+</ul></nav>
+<div class="main-container return-button">
+<a href="/web/singapore/news" aria-label="Back to - News">Back</a>
+</div>
+<div class="article-area main-container ">
+<article class="article-area__article " id="main-content">
+<h2>Announcement regarding travel medical insurance for foreigners applying for a national visa</h2>
+<p class="event-date">04.12.2020</p>
+<div class="main-photo"><picture>
+<source
+media="(min-width: 0rem) and (max-width: 43.6875rem)"
+sizes="calc(100vw - 2.2em)"
+srcset="/photo/format/129d7e6c-35ea-47cc-9d60-bb59ad534d19/resolution/700x295 700w,
+/photo/format/129d7e6c-35ea-47cc-9d60-bb59ad534d19/resolution/1044x440 1044w,
+/photo/format/129d7e6c-35ea-47cc-9d60-bb59ad534d19/resolution/1328x560 1328w" />
+<source
+media="(min-width: 43.75rem) and (max-width: 79.9375rem)"
+srcset="/photo/format/129d7e6c-35ea-47cc-9d60-bb59ad534d19/resolution/1408x594" />
+<source
+media="(min-width: 80rem)"
+sizes="(min-width: 93.75rem) 48.1875rem, (min-width:80rem) 51vw"
+srcset="/photo/format/129d7e6c-35ea-47cc-9d60-bb59ad534d19/resolution/729x308 729w,
+/photo/format/129d7e6c-35ea-47cc-9d60-bb59ad534d19/resolution/1460x616 1460w" />
+<img alt="announcement" src="/photo/format/129d7e6c-35ea-47cc-9d60-bb59ad534d19/resolution/1920x810" />
+</picture></div>
+<div class="editor-content">
+<div><p><span style="font-size:11pt">The Embassy of the Republic of Poland in Singapore informs, that since 1 December 2020, the conditions that must be met by travel medical insurance for foreigners applying for a national visa have changed.</span></p>
+<p><span style="font-size:11pt">Travel medical insurance must meet the following requirements:</span></p>
+<p><span style="font-size:11pt">- provides for the insurer&#39;s liability for the amount of insurance of at least 30 000 EUR;</span></p>
+<p><span style="font-size:11pt">- is valid for the entire period of the planned stay of the foreigner in the territory of the Republic of Poland;</span></p>
+<p><span style="font-size:11pt">- covers all expenses that may arise during the foreigner&#39;s stay in this territory in the case of: </span></p>
+<ul>
+<li><span style="font-size:11pt">necessary return travel for medical reasons,</span></li>
+<li><span style="font-size:11pt">urgent medical assistance needed,</span></li>
+<li><span style="font-size:11pt">emergency hospital treatment,</span></li>
+<li><span style="font-size:11pt">death,</span></li>
+</ul>
+<p><span style="font-size:11pt">and the insurer:</span></p>
+<p><span style="font-size:11pt">- reimburses the costs of health services provided to the insured person directly to the entity providing these benefits - on the basis of the invoice issued,</span></p>
+<p><span style="font-size:11pt">- provides a 24/7 emergency assistance, that accepts claims covered by the policy.</span></p>
+<p><span style="font-size:11pt">If the insurer has no registered office or branch in Poland, or countries belonging to the EU, EFTA, EEA or Switzerland, in accordance with the Article 3 point 4 of the Act of March 6, 2018 on the principles of participation of foreign entrepreneurs and other foreign persons in business, it must meet additional conditions:</span></p>
+<p><span style="font-size:11pt">- publish the results of the audit of its activities; the audit should be performed by a recognized international audit body and indicate the actual possibility of satisfying claims due to entities providing health services in the territory of the Republic of Poland;</span></p>
+<p><span style="font-size:11pt">- publish (at least every six months) data on the sum of collected premiums and the size of payments in a given type of insurance.</span></p>
+<p><span style="font-size:11pt">The information of the Minister of Foreign Affairs about insurers and the insurance they offer that meet the conditions referred to in the Act of 12 December 2013 on foreigners is available on the website of the Ministry of Foreign Affairs&nbsp; </span></p>
+<p><span style="font-size:11pt"><a href="https://www.gov.pl/web/diplomacy/visa" style="color:blue; text-decoration:underline">https://www.gov.pl/web/diplomacy/visa</a></span></p>
+<p><span style="font-size:11pt">We recommend you to contact your employer/university about the proper insurance. Some of the insuring companies registered in Poland, which can offer a proper insurance policy can be found below:</span></p>
+<ul>
+<li><span style="font-size:11pt"><a href="http://www.allianz.pl/" style="color:blue; text-decoration:underline">www.allianz.pl</a></span></li>
+<li><span style="font-size:11pt"><a href="http://www.aviva.pl" style="color:blue; text-decoration:underline">www.aviva.pl</a></span></li>
+<li><span style="font-size:11pt"><a href="http://www.axa.pl/" style="color:blue; text-decoration:underline">www.axa.pl</a></span></li>
+<li><span style="font-size:11pt"><a href="http://www.ca-ubezpieczenia.pl/" style="color:blue; text-decoration:underline">www.ca-ubezpieczenia.pl</a></span></li>
+<li><span style="font-size:11pt"><a href="http://www.cardif.pl/" style="color:blue; text-decoration:underline">www.cardif.pl</a></span></li>
+<li><span style="font-size:11pt"><a href="http://www.compensazycie.com.pl/" style="color:blue; text-decoration:underline">www.compensazycie.com.pl</a></span></li>
+<li><span style="font-size:11pt"><a href="http://www.generali.pl/" style="color:blue; text-decoration:underline">www.generali.pl</a></span></li>
+<li><span style="font-size:11pt"><a href="http://www.interpolska.pl/" style="color:blue; text-decoration:underline">www.interpolska.pl</a></span></li>
+<li><span style="font-size:11pt"><a href="http://www.pkoubezpieczenia.pl/" style="color:blue; text-decoration:underline">www.pkoubezpieczenia.pl</a></span></li>
+<li><span style="font-size:11pt"><a href="http://www.ubezpieczeniapocztowe.pl/" style="color:blue; text-decoration:underline">www.ubezpieczeniapocztowe.pl</a></span></li>
+<li><span style="font-size:11pt"><a href="http://www.pzu.pl/" style="color:blue; text-decoration:underline">www.pzu.pl</a></span></li>
+<li><span style="font-size:11pt"><a href="http://www.signal-iduna.pl/" style="color:blue; text-decoration:underline">www.signal-iduna.pl</a></span></li>
+<li><span style="font-size:11pt"><a href="http://www.warta.pl/" style="color:blue; text-decoration:underline">www.warta.pl</a></span></li>
+</ul>
+<p>&nbsp;</p>
+<p><span style="font-size:11pt">The information of the Minister of Foreign Affairs about insurers and the insurance policies they offer, that meet the conditions referred to in the Act of 12 December 2013 on foreigners is available on the website of the Ministry of Foreign Affairs </span></p>
+<p><span style="font-size:11pt">Affairs: <a href="https://www.gov.pl/web/diplomacy/visas" style="color:blue; text-decoration:underline">https://www.gov.pl/web/diplomacy/visas</a></span></p>
+</div>
+</div>
+</article>
+</div>
+<pre id="pageMetadata" class="hide">{"register":{"columns":[]}}</pre>
+</main>
+<footer class="footer">
+<div class="main-container">
+<h2 class="sr-only">footer gov.pl</h2>
+<div class="links" id="footer-links">
+<a href="https://www.gov.pl/" class="logo">
+<img src="/img/icons/godlo-12.svg" alt="Godło Polski" width="30" aria-hidden="true">
+<span class="sr-only">Main site</span> gov.pl
+</a>
+<ul>
+<li><a href="https://www.gov.pl/web/gov/polityka-dotyczaca-cookies">Cookie policy</a></li>
+<li><a href="https://www.gov.pl/web/civilservice">Civil service</a></li>
+<li><a href="https://www.gov.pl/web/profilzaufany">Trusted profile</a></li>
+<li><a href="https://www.bip.gov.pl/">Public Information Bulletin</a></li>
+<li><a href="https://www.premier.gov.pl/prawa-autorskie.html">Copyrights</a></li>
+<li><a href="/web/gov/deklaracja-dostepnosci-serwisu-govpl">Gov.pl accessibility declaration</a></li>
+<li><a href="#" id="manage-consent">Ustawienia prywatności</a></li>
+</ul>
+</div>
+<div class="creative-commons">
+<div class="emails">Pages available in the www.gov.pl domain may contain e-mail addresses. By clicking an e-mail address provided as a link, you consent to the processing of your data (e-mail address and other data provided on a voluntary basis in the message) in order for the recipient to send a response to the submitted questions. The details concerning processing of personal data by each unit can be found in their respective policies concerning the processing of personal data.</div>
+<div class="icons">
+<span class="license-cc" aria-hidden="true"></span>
+<span class="license-by" aria-hidden="true"></span>
+</div>
+<div class="text">All content published on this website is covered by a <a target="_blank" href="https://creativecommons.org/licenses/by/3.0/pl/">Creative Commons Attribution 3.0 PL</a> license, unless stated otherwise.</div>
+</div>
+<div class="eu-logotypes eu-logotypes--footer">
+<img src="/img/icons/eu/fe-pc-left-en.svg" alt="Fundusze Europejskie Logotyp:
+Na granatowym tle częściowo widoczne trzy gwiazdki
+żółta, biała i czerwona obok napis
+European, funds digital of Poland." class="eu-funds-logo">
+<img src="/img/icons/eu/rp-left-en.svg" alt="biało-czerwona flaga polska obok napis Rzeczpospolita Polska Logotyp" class="rp-logo">
+<img src="/img/icons/eu/eu-efrp-left-en.svg" alt="z lewej strony napis Unia Europejska Logotyp. Europejski Fundusz Rozwoju Regionalnego. po prawej strony na granatowym tle 12 żółtych gwiazdek tworzących okrąg flaga Unii Europejskiej" class="eu-logo-left">
+<img src="/img/icons/eu/eu-efrp-right-en.svg" alt="z lewej strony napis Unia Europejska Logotyp. Europejski Fundusz Rozwoju Regionalnego. po prawej strony na granatowym tle 12 żółtych gwiazdek tworzących okrąg flaga Unii Europejskiej" class="eu-logo-right">
+</div>
+</div>
+</footer>
+<script src="/scripts/body_end.js"></script>
+<script src="/scripts/register_metadata.js"></script>
+<script src="/scripts/zawbi_banner.js"></script>
+<link rel="stylesheet" type="text/css" href="/css/zawbi_banner.css">
+<script>
+MatomoConsentSDK.init({
+policyUrl: '/web/gov/polityka-dotyczaca-cookies',
+cookieTableEnabled: false,
+});
+if (!window.location.pathname.includes('/web/gov/polityka-dotyczaca-cookies')) {
+MatomoConsentSDK.showBanner();
+}
+document.getElementById('manage-consent').addEventListener('click', function(e){
+e.preventDefault();
+if (typeof showMatomoConsentBanner === 'function') {
+showMatomoConsentBanner({ forceShow: true, forceCookiePanel: true });
+} else if (typeof MatomoConsentSDK !== 'undefined') {
+MatomoConsentSDK.showBanner({ forceShow: true, forceCookiePanel: true });
+}
+});
+</script>
+</body>
+</html>

--- a/sources/PL_NATD_SG_2026-06-13.html.meta.json
+++ b/sources/PL_NATD_SG_2026-06-13.html.meta.json
@@ -1,0 +1,7 @@
+{
+  "source_id": "PL_NATD_SG_2026",
+  "url": "https://www.gov.pl/web/singapore/announcement-regarding-travel-medical-insurance-for-foreigners-applying-for-a-national-visa",
+  "retrieved_at": "2026-06-13T00:00:00Z",
+  "sha256": "0f0fdf9637bd6cc74fc1e4cffcb3c271493c8f7a4b38e9f793f7bca79d961580",
+  "local_path": "sources/PL_NATD_SG_2026-06-13.html"
+}

--- a/tools/build_content_hubs.py
+++ b/tools/build_content_hubs.py
@@ -251,6 +251,20 @@ VISA_FAQS = {
             "answer": "Travel-medical products (and Spanish-authorized health policies) either do not document coverage in Colombian territory or omit parts of the all-risk list such as maternity, so the engine keeps them UNKNOWN rather than guessing.",
         },
     ],
+    "PL_NATD_NICOSIA_2026": [
+        {
+            "question": "What insurance does the Poland National Visa (Type D) require?",
+            "answer": "The gov.pl consular checklist requires travel medical insurance with minimum coverage of 30,000 EUR, valid for the entire period of the requested national visa, covering urgent medical assistance, emergency hospital treatment and medical repatriation.",
+        },
+        {
+            "question": "Why is SafetyWing YELLOW for this route?",
+            "answer": "The policy must be valid for the entire period of the requested visa. A month-to-month subscription that can lapse does not assure full-period validity, so the engine marks it YELLOW; full-period policies with a documented limit of 30,000 EUR or more are GREEN.",
+        },
+        {
+            "question": "Are there insurer conditions the engine does not model?",
+            "answer": "Yes. The announcement also requires the insurer to settle costs directly with the treating provider and to run a 24/7 assistance centre, and Poland's MFA publishes a list of insurers meeting the statutory conditions. The engine does not model these clauses, so check the MFA list before buying.",
+        },
+    ],
 }
 
 RELATED_POSTS = {
@@ -332,6 +346,11 @@ RELATED_POSTS = {
         ("/posts/albania-unique-permit-insurance/", "Albania Unique Permit (Digital Mover) insurance requirements"),
         ("/posts/digital-nomad-insurance-europe/", "Digital nomad insurance in Europe"),
         ("/guides/how-to-read-results/", "How to read compliance results"),
+    ],
+    "PL_NATD_NICOSIA_2026": [
+        ("/posts/poland-national-d-insurance/", "Poland National Visa (Type D) insurance requirements"),
+        ("/guides/schengen-30000-insurance/", "Schengen 30,000 EUR insurance rule"),
+        ("/posts/digital-nomad-insurance-europe/", "Digital nomad insurance in Europe"),
     ],
 }
 

--- a/tools/editorial_targets.json
+++ b/tools/editorial_targets.json
@@ -186,5 +186,13 @@
   "content/posts/albania-unique-permit-insurance.md": [
     450,
     1050
+  ],
+  "content/visas/poland/national-visa-type-d/d-type-national-visa-gov-pl-nicosia/index.md": [
+    900,
+    1400
+  ],
+  "content/posts/poland-national-d-insurance.md": [
+    450,
+    1200
   ]
 }


### PR DESCRIPTION
## Summary
- New route **PL_NATD_NICOSIA_2026** — Poland National Visa (Type D), long stay
- Primary sources (byte-exact, sha256-validated):
  - gov.pl Embassy of Poland in Nicosia, D-Type national visa checklist
  - gov.pl Embassy of Poland in Singapore, announcement on national-visa medical insurance (effective 2020-12-01)
- Rules encoded verbatim only: `insurance.mandatory`, `insurance.min_coverage >= 30000 EUR` (currency-aware), `insurance.must_cover_full_period`
- Deliberately NOT modeled (disclosed in the post): insurer direct settlement with providers, 24/7 assistance centre, MFA insurer information list (Act of 12 December 2013 on Foreigners)
- Mapping outcomes: Genki Traveler / Genki Native / World Nomads **GREEN**; SafetyWing **YELLOW** (monthly billing vs full-period); ASISA / DKV / Sanitas / Generic **UNKNOWN** (no documented limit)
- No existing mapping changed (verified: only `PL_NATD_NICOSIA_2026__*` files added)

## Content
- Hub: /visas/poland/national-visa-type-d/d-type-national-visa-gov-pl-nicosia/
- Post: /posts/poland-national-d-insurance/ (dated 2026-06-12, past in UTC)
- Affiliate: Genki Traveler paid link, after results only

## Gates run locally
validate, build_mappings, build_index, build_content_hubs, sync_hugo_static, lint_content, seo_audit, check_editorial_targets, check_internal_links, hugo, ui_compliance_tests.ps1, mapping_engine_tests.ps1 — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)