### PR TITLE
🎨 Palette: Improve Form Controls and Mobile Menu Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-13 - Form Controls and Mobile Menu Accessibility
+**Learning:** In layout containers using flex-col, labels and inputs often become visually disconnected. In `ui/index.html`, inputs like `visaSelect` and `productSelect` lacked explicit `for` and `aria-describedby` associations, which breaks screen reader support. Additionally, icon-only toggle buttons like `mobileMenuBtn` need dynamic `aria-expanded` and explicit `aria-controls` to be fully accessible.
+**Action:** Always explicitly link layout-separated form labels to their inputs using `for` and ID references, use `aria-describedby` for hint text, and ensure interactive icon buttons announce their toggled state programmatically via `aria-expanded`.

--- a/ui/index.html
+++ b/ui/index.html
@@ -111,7 +111,7 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+        aria-label="Toggle menu" aria-expanded="false" aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -183,12 +183,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -200,12 +200,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select an insurance product</option>
             </select>
@@ -1179,6 +1179,7 @@
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
+      btn.setAttribute("aria-expanded", String(!isOpen));
     });
 
     init().catch(err => {


### PR DESCRIPTION
💡 What: Added explicit `for` and `aria-describedby` attributes to the `visaSelect` and `productSelect` form elements. Added `aria-expanded` and `aria-controls` attributes to the `#mobileMenuBtn` toggle, and updated its click handler to dynamically switch the `aria-expanded` state. Documented these patterns in `.jules/palette.md`.
🎯 Why: In layout containers using `flex-col`, labels and inputs are visually separated. Without explicit links, screen readers struggle to associate them. Furthermore, icon-only toggle buttons need programmatic state indication for visually impaired users.
📸 Before/After: Visual presentation remains exactly the same, but the underlying accessibility DOM is significantly enhanced.
♿ Accessibility: Ensures that form fields have fully compliant accessible names and hints, and that the mobile menu toggle correctly reports its expanded/collapsed state to assistive technology.

---
*PR created automatically by Jules for task [14284457961308090453](https://jules.google.com/task/14284457961308090453) started by @W73QB*