### PR TITLE
🎨 Palette: Add proper label associations and ARIA descriptions to form selects

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-14 - Explicit Label Associations in Flex Columns
+**Learning:** Input labels require explicit `for` attributes to trigger the corresponding input element for accessibility, particularly when they are visually separated by `flex-col` layouts. Also, form inputs need `aria-describedby` referencing their hint text elements.
+**Action:** Always ensure `<label>` elements use the `for` attribute pointing to the ID of the input, and inputs use `aria-describedby` pointing to the ID of associated helper text.

--- a/ui/index.html
+++ b/ui/index.html
@@ -183,12 +183,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -200,12 +200,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select an insurance product</option>
             </select>


### PR DESCRIPTION
Added `for` attributes to the "I am applying for" and "I want to use" labels, and `aria-describedby` to their respective selects.
Recorded the insight in Palette's journal.

---
*PR created automatically by Jules for task [10981199990640142017](https://jules.google.com/task/10981199990640142017) started by @W73QB*