### PR TITLE
feat(route): add Finland study residence insurance route (evidence-based)

### DIFF
--- a/content/posts/finland-study-insurance.md
+++ b/content/posts/finland-study-insurance.md
@@ -1,0 +1,105 @@
+---
+title: "Finland study residence insurance requirements (evidence-based)"
+date: 2026-06-13
+description: "Evidence-based summary of the insurance requirement for Finland's student residence permit: private insurance valid for your entire stay, covering medical expenses up to EUR 120,000 for studies under two years, per the Finnish Immigration Service."
+tags: ["finland", "student", "residence-permit", "insurance", "compliance"]
+faq:
+  - question: "What insurance does a Finnish study residence permit require?"
+    answer: "The Finnish Immigration Service requires private insurance covering medical and drug expenses, valid throughout your entire stay. For studies under two years the insurance must cover medical expenses up to EUR 120,000."
+  - question: "Why does the amount depend on study length?"
+    answer: "Migri requires up to EUR 120,000 for studies under two years and up to EUR 40,000 for studies of at least two years. This route models the under-two-years threshold."
+  - question: "Why is a monthly subscription marked YELLOW?"
+    answer: "The insurance must be valid throughout your entire stay. A month-to-month policy that can lapse does not assure that, so it is YELLOW; a full-period policy meeting the EUR 120,000 threshold is GREEN."
+---
+
+## Short answer
+
+Finland's student residence permit requires private insurance that covers your medical and drug expenses, valid throughout your entire stay (Source: `FI_STUDY_MIGRI_2026`, Finnish Immigration Service; verified 2026-06-13). The required amount depends on study length: for studies under two years the insurance must cover medical expenses up to EUR 120,000. This route models the under-two-years threshold. The engine encodes three rules: insurance is mandatory, minimum coverage of 120,000 EUR, and full-period validity.
+
+## Key findings at a glance
+
+| Item | Value |
+|---|---|
+| Route | Finland Residence Permit for Studies (under two years) |
+| Authority | Finnish Immigration Service (Migri) |
+| Evidence verified | 2026-06-13 |
+| Snapshot | 2026-06-13 |
+| Modeled rules | Insurance mandatory; minimum coverage 120,000 EUR; valid for the entire stay |
+
+## What the authority requires
+
+- Private insurance covering medical and drug expenses is required for the residence permit. (Source: `FI_STUDY_MIGRI_2026`; verified 2026-06-13)
+- The insurance must be valid throughout your entire stay in Finland. (Source: `FI_STUDY_MIGRI_2026`; verified 2026-06-13)
+- For studies under two years, it must cover medical expenses up to EUR 120,000; for studies of at least two years, pharmaceutical expenses up to EUR 40,000. (Source: `FI_STUDY_MIGRI_2026`; verified 2026-06-13)
+- The insurance excess may not be more than EUR 300; an EHIC/GHIC or Kela card can replace private insurance. (Source: `FI_STUDY_MIGRI_2026`)
+
+Normalized requirements table:
+
+| Requirement | Source URL | Locator | Verified date |
+|---|---|---|---|
+| Insurance is mandatory | https://migri.fi/en/insurance | Students must have insurance | 2026-06-13 |
+| Minimum coverage 120,000 EUR (studies under two years) | https://migri.fi/en/insurance | What kind of insurance do I need? | 2026-06-13 |
+| Valid for the entire stay | https://migri.fi/en/insurance | What kind of insurance do I need? | 2026-06-13 |
+
+## Verified requirements (PASS/FAIL/UNKNOWN)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Insurance is mandatory | PASS | Migri: "you must take out private insurance" |
+| Minimum coverage 120,000 EUR | PASS for products documenting a limit of 120,000 EUR or more; UNKNOWN otherwise | Migri: "studies take less than two years ... up to EUR 120,000" |
+| Valid for the entire stay | PASS for full-period policies; YELLOW for monthly subscriptions | Migri: "valid throughout your entire stay in Finland" |
+
+## How we evaluate
+
+The checker compares each modeled requirement against product evidence. Three rules are encoded from the Migri insurance page: insurance is mandatory, the documented limit must be at least 120,000 EUR (currency-aware), and it must be valid for the entire stay. A monthly subscription that can lapse does not assure full-period validity, so it is YELLOW; a full-period policy meeting the threshold is GREEN; a product whose documents state no overall limit stays UNKNOWN.
+
+Two points are disclosed rather than modeled, following UNKNOWN > Wrong: the amount is conditional (this route uses the under-two-years EUR 120,000 medical threshold; studies of at least two years require EUR 40,000 for pharmaceutical expenses), and Migri also requires the insurance excess to be no more than EUR 300, while an EHIC/GHIC or Kela card can replace private insurance. Confirm your study length and the excess before you buy. See /methodology/ for the full logic.
+
+## Proof package checklist
+
+- A private insurance certificate documenting medical cover of at least 120,000 EUR (studies under two years).
+- Validity throughout your entire stay, with an excess of no more than EUR 300.
+- Alternatively a valid EHIC/GHIC or Kela card, where applicable.
+
+## FAQ
+
+**Q: How much coverage is required?**
+**A:** For studies under two years, medical expenses up to 120,000 EUR, valid for the entire stay (Source: `FI_STUDY_MIGRI_2026`; verified 2026-06-13).
+
+**Q: Why does the amount vary?**
+**A:** Migri requires 120,000 EUR for studies under two years and 40,000 EUR for studies of at least two years.
+
+**Q: Why is a monthly subscription YELLOW?**
+**A:** It can lapse before the stay ends; a full-period policy meeting the 120,000 EUR threshold is GREEN.
+
+## Check in the engine
+
+Use [the compliance checker](/ui/) with the current snapshot for this route:
+
+{{< checker_cta visa="FI_STUDY_MIGRI_2026" product="GENKI_TRAVELER_2026" snapshot="2026-06-13" >}}
+
+## Related reading
+
+- [Finland study residence requirements (route page)](/visas/finland/residence-permit-for-studies/student-residence-permit-studies-under-two-years-migri/)
+- [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## Where to find compliant insurance for studying in Finland
+
+For studies under two years, the requirement combines a full-stay term with a EUR 120,000 medical limit. In the current snapshot, Genki Traveler, Genki Native and World Nomads show GREEN: each documents a limit at or above the threshold and a full-period term. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the stay ends. Check that your excess is no more than EUR 300.
+
+- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+
+> Use the compliance checker to confirm the current GREEN products for this route before you buy.
+
+## Disclaimer + Affiliate disclosure
+
+Not legal advice. Compliance results are evidence-based snapshots.
+
+If an affiliate link is present, it appears only after results and does not change the compliance outcome. The Genki link above is a paid affiliate link.
+
+Last updated: 2026-06-13
+
+## Evidence log
+
+- Source: FI_STUDY_MIGRI_2026

--- a/content/visas/finland/residence-permit-for-studies/_index.md
+++ b/content/visas/finland/residence-permit-for-studies/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Finland Residence Permit for Studies"
+visa_group: "finland-residence-permit-for-studies"
+description: "Insurance requirements for Finland Residence Permit for Studies - evidence-based compliance checker"
+---
+
+## Finland Residence Permit for Studies Requirements
+
+All requirements below are derived from official sources. Missing evidence means UNKNOWN.
+
+## Routes
+
+| Authority | Route | Last Verified | Details |
+| --- | --- | --- | --- |
+| Finnish Immigration Service (Migri) | Student residence permit, studies under two years (Migri) | 2026-06-15 | [View requirements](/visas/finland/residence-permit-for-studies/student-residence-permit-studies-under-two-years-migri/) |
+
+## What the authority requires
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+## How we evaluate
+
+We compare these official requirements against insurance product specifications using our automated rule engine. Each requirement is matched to a product fact with evidence.
+
+## Check in the engine
+
+Try the compliance checker: [Open Checker](/ui/?visa=FI_STUDY_MIGRI_2026&snapshot=2026-06-13)
+
+## Disclaimer
+
+This is not legal advice. VisaFact provides evidence-based compliance checking only. Final visa decisions are made by government authorities. A GREEN result does not ensure visa approval.
+
+## Affiliate disclosure
+
+If affiliate links appear, they are shown only after compliance results and do not influence the compliance evaluation in any way.
+
+## Evidence log
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+
+{{< checker_cta visa="FI_STUDY_MIGRI_2026" snapshot="2026-06-13" >}}

--- a/content/visas/finland/residence-permit-for-studies/student-residence-permit-studies-under-two-years-migri/index.md
+++ b/content/visas/finland/residence-permit-for-studies/student-residence-permit-studies-under-two-years-migri/index.md
@@ -1,0 +1,105 @@
+---
+title: "Finland Residence Permit for Studies - Student residence permit, studies under two years (Migri)"
+visa_id: "FI_STUDY_MIGRI_2026"
+last_verified: "2026-06-15"
+source_ids: ["FI_STUDY_MIGRI_2026"]
+description: "Official insurance requirements for Finland Residence Permit for Studies via Student residence permit, studies under two years (Migri)"
+faq:
+  - question: "What insurance does a Finnish study residence permit require?"
+    answer: "The Finnish Immigration Service requires private insurance covering medical and drug expenses, valid throughout your entire stay. For studies under two years the insurance must cover medical expenses up to EUR 120,000."
+  - question: "Why does the amount depend on study length?"
+    answer: "Migri requires up to EUR 120,000 for studies under two years and up to EUR 40,000 for studies of at least two years. This route models the under-two-years threshold; the post discloses the longer-studies figure."
+  - question: "Why is SafetyWing YELLOW?"
+    answer: "The insurance must be valid throughout your entire stay. A month-to-month subscription that can lapse does not assure that, so it is YELLOW; full-period policies meeting the EUR 120,000 threshold are GREEN."
+---
+
+## Finland Residence Permit for Studies
+
+**Route:** Student residence permit, studies under two years (Migri)  
+**Authority:** Finnish Immigration Service (Migri)  
+**Last Verified:** 2026-06-15
+
+## Requirements
+
+| Requirement | Operator | Value | Evidence |
+| --- | --- | --- | --- |
+| `insurance.mandatory` | `==` | Yes | *Students must have insurance*: "In order to get a residence permit, you must take out private insurance that wil..." ([source](/sources/FI_STUDY_MIGRI_2026-06-15.html)) |
+| `insurance.min_coverage` | `>=` | 120000 | *What kind of insurance do I need?, amount by duration*: "If your studies take less than two years, your insurance must cover medical expe..." ([source](/sources/FI_STUDY_MIGRI_2026-06-15.html)) |
+| `insurance.must_cover_full_period` | `==` | Yes | *What kind of insurance do I need?*: "If you stay in Finland for less than year, your insurance must be valid througho..." ([source](/sources/FI_STUDY_MIGRI_2026-06-15.html)) |
+
+## Source Documents
+
+- **FI_STUDY_MIGRI_2026**: [Local copy](/sources/FI_STUDY_MIGRI_2026-06-15.html) | [Original](https://migri.fi/en/insurance) | Retrieved: 2026-06-15
+
+## Related reading
+
+- [Finland study residence insurance requirements](/posts/finland-study-insurance/)
+- [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## What the authority requires
+
+The points below are taken directly from the official source for the Finland Residence Permit for Studies (Student residence permit, studies under two years (Migri)) route. Each one is recorded with a source identifier and a locator so it can be traced back to the original document. Where the source is silent on a point, the engine records UNKNOWN instead of inferring an answer.
+
+- The authority requires that insurance is mandatory.
+- The authority requires that the medical coverage meets the stated minimum of at least 120000.
+- The authority requires that the policy covers the full authorized stay.
+
+## How we evaluate
+
+Every requirement is compared against the documented specification of each insurance product using an automated rule engine. A product is marked GREEN for a requirement only when product evidence explicitly satisfies it; a conflict produces RED; and absent evidence produces UNKNOWN rather than a guess. The route status is the combination of its per-requirement outcomes.
+
+- Rule `insurance.mandatory == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+- Rule `insurance.min_coverage >= 120000` GREEN at or above the threshold, RED below it, UNKNOWN if unstated.
+- Rule `insurance.must_cover_full_period == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+
+## How each compliance status is decided for this route
+
+GREEN means every recorded requirement is satisfied by product evidence. RED means at least one requirement is contradicted by the product evidence. YELLOW means the evidence is partial: some requirements are met while others lack full proof. UNKNOWN means a requirement exists but the product evidence does not address it, so no claim is made. NOT_REQUIRED means the authority does not impose an insurance requirement for the route, which is itself an evidence-based finding drawn from the official document. A GREEN result reflects the evidence on the snapshot date and is not an assurance of a visa outcome, which always rests with the issuing authority.
+
+## Reading the evidence and snapshots
+
+Each requirement above links to a primary source through a source identifier and a locator (for example a page number, article, or section). The underlying documents are listed under Source Documents and are stored alongside this dataset so the wording can be checked directly. Results are tied to a dated snapshot (`2026-06-13`): a deep link to a past snapshot returns the same verdict even if the authority later changes its rules, which keeps every decision reproducible and auditable.
+
+## Proof package checklist
+
+Before applying for this route, prepare the following so the policy can be checked against each requirement:
+
+- A policy certificate that states the coverage limits, any deductible or co-payment, and the covered period.
+- Written confirmation of the insurer's status where the route requires authorization in a specific country.
+- Documentation that the coverage spans the full authorized stay rather than a partial term.
+- The official source wording for the route, so each clause can be matched to the requirements above.
+
+## Common questions
+
+**What insurance does a Finnish study residence permit require?**  
+The Finnish Immigration Service requires private insurance covering medical and drug expenses, valid throughout your entire stay. For studies under two years the insurance must cover medical expenses up to EUR 120,000.
+
+**Why does the amount depend on study length?**  
+Migri requires up to EUR 120,000 for studies under two years and up to EUR 40,000 for studies of at least two years. This route models the under-two-years threshold; the post discloses the longer-studies figure.
+
+**Why is SafetyWing YELLOW?**  
+The insurance must be valid throughout your entire stay. A month-to-month subscription that can lapse does not assure that, so it is YELLOW; full-period policies meeting the EUR 120,000 threshold are GREEN.
+
+## Check in the engine
+
+Run a specific product against this route in the compliance checker: [Open Checker](/ui/?visa=FI_STUDY_MIGRI_2026&snapshot=2026-06-13). The checker shows the per-requirement outcome and the evidence behind each one.
+
+## Disclaimer
+
+This page is not legal advice. VisaFact provides evidence-based compliance checking only, and final visa decisions are made by government authorities. A GREEN result reflects documented evidence on the snapshot date; it does not ensure that a visa application will succeed. Always confirm the current requirements with the issuing authority before submitting an application.
+
+## Affiliate disclosure
+
+If affiliate links appear on related pages, they are shown only after the compliance result and never change the evaluation, which is generated independently from the official evidence.
+
+## Evidence log
+
+Each entry pairs a requirement with the source identifier and locator it was drawn from:
+
+- `insurance.mandatory` <- FI_STUDY_MIGRI_2026 (Students must have insurance): "In order to get a residence permit, you must take out private insurance that will cover your medical"
+- `insurance.min_coverage` <- FI_STUDY_MIGRI_2026 (What kind of insurance do I need?, amount by duration): "If your studies take less than two years, your insurance must cover medical expenses up to EUR 120,0"
+- `insurance.must_cover_full_period` <- FI_STUDY_MIGRI_2026 (What kind of insurance do I need?): "If you stay in Finland for less than year, your insurance must be valid throughout your entire stay "
+
+
+{{< checker_cta visa="FI_STUDY_MIGRI_2026" snapshot="2026-06-13" >}}

--- a/data/mappings/FI_STUDY_MIGRI_2026__ASISA_HEALTH_RESIDENTS_2026.json
+++ b/data/mappings/FI_STUDY_MIGRI_2026__ASISA_HEALTH_RESIDENTS_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "FI_STUDY_MIGRI_2026",
+  "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/FI_STUDY_MIGRI_2026__DKV_VISADO_2026.json
+++ b/data/mappings/FI_STUDY_MIGRI_2026__DKV_VISADO_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "FI_STUDY_MIGRI_2026",
+  "product_id": "DKV_VISADO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/FI_STUDY_MIGRI_2026__GENERIC_EXPAT_COMPLETE_2026.json
+++ b/data/mappings/FI_STUDY_MIGRI_2026__GENERIC_EXPAT_COMPLETE_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "FI_STUDY_MIGRI_2026",
+  "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/FI_STUDY_MIGRI_2026__GENKI_NATIVE_2026.json
+++ b/data/mappings/FI_STUDY_MIGRI_2026__GENKI_NATIVE_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "FI_STUDY_MIGRI_2026",
+  "product_id": "GENKI_NATIVE_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/FI_STUDY_MIGRI_2026__GENKI_TRAVELER_2026.json
+++ b/data/mappings/FI_STUDY_MIGRI_2026__GENKI_TRAVELER_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "FI_STUDY_MIGRI_2026",
+  "product_id": "GENKI_TRAVELER_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/FI_STUDY_MIGRI_2026__SAFETYWING_NOMAD_2026.json
+++ b/data/mappings/FI_STUDY_MIGRI_2026__SAFETYWING_NOMAD_2026.json
@@ -1,0 +1,18 @@
+{
+  "visa_id": "FI_STUDY_MIGRI_2026",
+  "product_id": "SAFETYWING_NOMAD_2026",
+  "status": "YELLOW",
+  "reasons": [
+    {
+      "text": "Visa requires coverage for full legal stay, monthly subscriptions can be cancelled",
+      "evidence": [
+        {
+          "source_id": "FI_STUDY_MIGRI_2026",
+          "locator": "What kind of insurance do I need?",
+          "excerpt": "If you stay in Finland for less than year, your insurance must be valid throughout your entire stay in Finland."
+        }
+      ]
+    }
+  ],
+  "missing": []
+}

--- a/data/mappings/FI_STUDY_MIGRI_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
+++ b/data/mappings/FI_STUDY_MIGRI_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "FI_STUDY_MIGRI_2026",
+  "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.overall_limit"
+  ]
+}

--- a/data/mappings/FI_STUDY_MIGRI_2026__WORLDNOMADS_EXPLORER_2026.json
+++ b/data/mappings/FI_STUDY_MIGRI_2026__WORLDNOMADS_EXPLORER_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "FI_STUDY_MIGRI_2026",
+  "product_id": "WORLDNOMADS_EXPLORER_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/ui_index.json
+++ b/data/ui_index.json
@@ -1,5 +1,5 @@
 {
-  "built_at": "2026-06-15T05:09:19.369682+00:00",
+  "built_at": "2026-06-15T05:14:52.600570+00:00",
   "snapshot_id": "2026-06-15",
   "visas": [
     {
@@ -675,6 +675,62 @@
               "source_id": "ES_NLV_LA_EXTERIORES_2026",
               "locator": "Required documents, item 8 (note)",
               "excerpt": "No travel insurances with medical assistance coverage will be accepted."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "FI_STUDY_MIGRI_2026",
+      "country": "Finland",
+      "visa_name": "Residence Permit for Studies",
+      "route": "Student residence permit, studies under two years (Migri)",
+      "authority": "Finnish Immigration Service (Migri)",
+      "last_verified": "2026-06-15",
+      "sources": [
+        {
+          "source_id": "FI_STUDY_MIGRI_2026",
+          "url": "https://migri.fi/en/insurance",
+          "retrieved_at": "2026-06-15T00:00:00Z",
+          "sha256": "c38ff6a79dd8d148339541a4f30b447b2d2102866dc062254b5165eeafcc7925",
+          "local_path": "sources/FI_STUDY_MIGRI_2026-06-15.html"
+        }
+      ],
+      "requirements": [
+        {
+          "key": "insurance.mandatory",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "FI_STUDY_MIGRI_2026",
+              "locator": "Students must have insurance",
+              "excerpt": "In order to get a residence permit, you must take out private insurance that will cover your medical and drug expenses."
+            }
+          ]
+        },
+        {
+          "key": "insurance.min_coverage",
+          "op": ">=",
+          "value": 120000,
+          "currency": "EUR",
+          "evidence": [
+            {
+              "source_id": "FI_STUDY_MIGRI_2026",
+              "locator": "What kind of insurance do I need?, amount by duration",
+              "excerpt": "If your studies take less than two years, your insurance must cover medical expenses up to EUR 120,000."
+            }
+          ]
+        },
+        {
+          "key": "insurance.must_cover_full_period",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "FI_STUDY_MIGRI_2026",
+              "locator": "What kind of insurance do I need?",
+              "excerpt": "If you stay in Finland for less than year, your insurance must be valid throughout your entire stay in Finland."
             }
           ]
         }
@@ -3075,6 +3131,89 @@
       "last_verified": "2026-06-08"
     },
     {
+      "visa_id": "FI_STUDY_MIGRI_2026",
+      "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "FI_STUDY_MIGRI_2026",
+      "product_id": "DKV_VISADO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "FI_STUDY_MIGRI_2026",
+      "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "FI_STUDY_MIGRI_2026",
+      "product_id": "GENKI_NATIVE_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "FI_STUDY_MIGRI_2026",
+      "product_id": "GENKI_TRAVELER_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "FI_STUDY_MIGRI_2026",
+      "product_id": "SAFETYWING_NOMAD_2026",
+      "status": "YELLOW",
+      "reasons": [
+        {
+          "text": "Visa requires coverage for full legal stay, monthly subscriptions can be cancelled",
+          "evidence": [
+            {
+              "source_id": "FI_STUDY_MIGRI_2026",
+              "locator": "What kind of insurance do I need?",
+              "excerpt": "If you stay in Finland for less than year, your insurance must be valid throughout your entire stay in Finland."
+            }
+          ]
+        }
+      ],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "FI_STUDY_MIGRI_2026",
+      "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.overall_limit"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "FI_STUDY_MIGRI_2026",
+      "product_id": "WORLDNOMADS_EXPLORER_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
       "visa_id": "GR_DNV_MFA_2026",
       "product_id": "ASISA_HEALTH_RESIDENTS_2026",
       "status": "GREEN",
@@ -3625,7 +3764,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "ME_DNV_GOVME_2026",
@@ -3633,7 +3772,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "ME_DNV_GOVME_2026",
@@ -3641,7 +3780,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "ME_DNV_GOVME_2026",
@@ -3649,7 +3788,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "ME_DNV_GOVME_2026",
@@ -3657,7 +3796,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "ME_DNV_GOVME_2026",
@@ -3665,7 +3804,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "ME_DNV_GOVME_2026",
@@ -3673,7 +3812,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "ME_DNV_GOVME_2026",
@@ -3681,7 +3820,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "MT_NOMAD_RESIDENCY_2026",
@@ -4678,6 +4817,13 @@
       "retrieved_at": "2026-01-15T00:00:00Z",
       "sha256": "534fc72ab060d94b98959ae5b246d2bdb16fb72aa493ca3938491289770c5062",
       "local_path": "sources/EU_VISA_CODE_ARTICLE_15_2026-01-15.html"
+    },
+    "FI_STUDY_MIGRI_2026": {
+      "source_id": "FI_STUDY_MIGRI_2026",
+      "url": "https://migri.fi/en/insurance",
+      "retrieved_at": "2026-06-15T00:00:00Z",
+      "sha256": "c38ff6a79dd8d148339541a4f30b447b2d2102866dc062254b5165eeafcc7925",
+      "local_path": "sources/FI_STUDY_MIGRI_2026-06-15.html"
     },
     "GENERIC_WEBSITE_2026": {
       "source_id": "GENERIC_WEBSITE_2026",

--- a/data/visas/FI/STUDY/migri/2026-06-15/visa_facts.json
+++ b/data/visas/FI/STUDY/migri/2026-06-15/visa_facts.json
@@ -1,0 +1,56 @@
+{
+  "id": "FI_STUDY_MIGRI_2026",
+  "country": "Finland",
+  "visa_name": "Residence Permit for Studies",
+  "route": "Student residence permit, studies under two years (Migri)",
+  "authority": "Finnish Immigration Service (Migri)",
+  "last_verified": "2026-06-15",
+  "sources": [
+    {
+      "source_id": "FI_STUDY_MIGRI_2026",
+      "url": "https://migri.fi/en/insurance",
+      "retrieved_at": "2026-06-15T00:00:00Z",
+      "sha256": "c38ff6a79dd8d148339541a4f30b447b2d2102866dc062254b5165eeafcc7925",
+      "local_path": "sources/FI_STUDY_MIGRI_2026-06-15.html"
+    }
+  ],
+  "requirements": [
+    {
+      "key": "insurance.mandatory",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "FI_STUDY_MIGRI_2026",
+          "locator": "Students must have insurance",
+          "excerpt": "In order to get a residence permit, you must take out private insurance that will cover your medical and drug expenses."
+        }
+      ]
+    },
+    {
+      "key": "insurance.min_coverage",
+      "op": ">=",
+      "value": 120000,
+      "currency": "EUR",
+      "evidence": [
+        {
+          "source_id": "FI_STUDY_MIGRI_2026",
+          "locator": "What kind of insurance do I need?, amount by duration",
+          "excerpt": "If your studies take less than two years, your insurance must cover medical expenses up to EUR 120,000."
+        }
+      ]
+    },
+    {
+      "key": "insurance.must_cover_full_period",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "FI_STUDY_MIGRI_2026",
+          "locator": "What kind of insurance do I need?",
+          "excerpt": "If you stay in Finland for less than year, your insurance must be valid throughout your entire stay in Finland."
+        }
+      ]
+    }
+  ]
+}

--- a/sources/FI_STUDY_MIGRI_2026-06-15.html
+++ b/sources/FI_STUDY_MIGRI_2026-06-15.html
@@ -1,0 +1,6122 @@
+<html class="ltr site-theme top-frame yui3-js-enabled js mac chrome" dir="ltr" lang="en-US"><head> 
+  <link rel="alternate" hreflang="en" href="https://migri.fi/en/insurance"> 
+  <link rel="alternate" hreflang="sv" href="https://migri.fi/sv/forsakringar"> 
+  <link rel="alternate" hreflang="fi" href="https://migri.fi/vakuutukset"> 
+  <title>Insurance | Maahanmuuttovirasto</title> 
+  <meta http-equiv="X-UA-Compatible" content="IE=edge"> 
+  <meta content="initial-scale=1.0, width=device-width" name="viewport"> 
+  <meta content="text/html; charset=UTF-8" http-equiv="content-type"> 
+  <script data-senna-track="permanent" src="/o/frontend-js-svg4everybody-web/index.js" type="text/javascript"></script> 
+  <link href="/documents/5202425/12394585/Favicon+Migri/ac59e4e6-4d42-7479-ea8f-7c6a344ce5ff?t=1562669151321" rel="shortcut icon"> 
+  <link data-senna-track="permanent" href="/o/frontend-theme-font-awesome-web/css/main.css" rel="stylesheet" type="text/css"> 
+  <script data-senna-track="permanent" src="/o/frontend-js-jquery-web/jquery/jquery.min.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-jquery-web/jquery/init.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-jquery-web/jquery/ajax.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-jquery-web/jquery/bootstrap.bundle.min.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-jquery-web/jquery/collapsible_search.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-jquery-web/jquery/fm.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-jquery-web/jquery/form.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-jquery-web/jquery/popper.min.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-jquery-web/jquery/side_navigation.js" type="text/javascript"></script> 
+  <meta property="og:locale" content="en_US"> 
+  <meta property="og:locale:alternate" content="fi_FI"> 
+  <meta property="og:locale:alternate" content="sv_SE"> 
+  <meta property="og:locale:alternate" content="en_US"> 
+  <meta property="og:locale:alternate" content="uk_UA"> 
+  <meta property="og:site_name" content="Maahanmuuttovirasto"> 
+  <meta property="og:title" content="Insurance - Maahanmuuttovirasto"> 
+  <meta property="og:type" content="website"> 
+  <meta property="og:url" content="https://migri.fi/en/insurance"> 
+  <meta property="og:image" content="https://migri.fi/documents/5202425/0/Migri%20logo%20somejakoon%20en.png/e12d05b2-1828-df7e-db77-dac05bf146c3?version=1.0&amp;t=1652856176539&amp;imagePreview=1"> 
+  <meta property="og:image:secure_url" content="https://migri.fi/documents/5202425/0/Migri%20logo%20somejakoon%20en.png/e12d05b2-1828-df7e-db77-dac05bf146c3?version=1.0&amp;t=1652856176539&amp;imagePreview=1"> 
+  <meta property="og:image:type" content="image/png"> 
+  <meta property="og:image:url" content="https://migri.fi/documents/5202425/0/Migri%20logo%20somejakoon%20en.png/e12d05b2-1828-df7e-db77-dac05bf146c3?version=1.0&amp;t=1652856176539&amp;imagePreview=1"> 
+  <meta property="og:image:height" content="1090"> 
+  <meta property="og:image:width" content="1793">  
+  <link class="lfr-css-file" data-senna-track="temporary" href="https://migri.fi/o/yja-site-template-theme/css/clay.css?browserId=chrome&amp;themeId=yjasitetemplate_WAR_yjasitetemplatetheme&amp;minifierType=css&amp;languageId=en_US&amp;t=1780930970000" id="liferayAUICSS" rel="stylesheet" type="text/css"> 
+  <script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_49" src="https://migri.fi/o/frontend-js-aui-web/aui/yui-throttle/yui-throttle.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_50" src="https://migri.fi/o/frontend-js-aui-web/aui/classnamemanager/classnamemanager.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_51" src="https://migri.fi/o/frontend-js-aui-web/aui/aui-classnamemanager/aui-classnamemanager.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_52" src="https://migri.fi/o/frontend-js-aui-web/aui/aui-debounce/aui-debounce.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_53" src="https://migri.fi/o/frontend-js-aui-web/aui/array-extras/array-extras.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_54" src="https://migri.fi/o/frontend-js-aui-web/aui/event-base/event-base.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_55" src="https://migri.fi/o/frontend-js-aui-web/aui/dom-core/dom-core.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_56" src="https://migri.fi/o/frontend-js-aui-web/aui/dom-base/dom-base.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_57" src="https://migri.fi/o/frontend-js-aui-web/aui/selector-native/selector-native.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_58" src="https://migri.fi/o/frontend-js-aui-web/aui/selector/selector.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_59" src="https://migri.fi/o/frontend-js-aui-web/aui/node-core/node-core.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_60" src="https://migri.fi/o/frontend-js-aui-web/aui/dom-style/dom-style.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_61" src="https://migri.fi/o/frontend-js-aui-web/aui/node-base/node-base.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_62" src="https://migri.fi/o/frontend-js-aui-web/aui/event-delegate/event-delegate.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_63" src="https://migri.fi/o/frontend-js-aui-web/aui/node-event-delegate/node-event-delegate.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_64" src="https://migri.fi/o/frontend-js-aui-web/aui/pluginhost-base/pluginhost-base.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_65" src="https://migri.fi/o/frontend-js-aui-web/aui/pluginhost-config/pluginhost-config.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_66" src="https://migri.fi/o/frontend-js-aui-web/aui/node-pluginhost/node-pluginhost.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_67" src="https://migri.fi/o/frontend-js-aui-web/aui/dom-screen/dom-screen.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_68" src="https://migri.fi/o/frontend-js-aui-web/aui/node-screen/node-screen.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_69" src="https://migri.fi/o/frontend-js-aui-web/aui/node-style/node-style.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_70" src="https://migri.fi/o/frontend-js-aui-web/aui/aui-node-base/aui-node-base.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_71" src="https://migri.fi/o/frontend-js-aui-web/aui/aui-timer/aui-timer.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_72" src="https://migri.fi/o/frontend-js-aui-web/aui/event-touch/event-touch.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_73" src="https://migri.fi/o/frontend-js-aui-web/aui/event-synthetic/event-synthetic.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_74" src="https://migri.fi/o/frontend-js-aui-web/aui/event-move/event-move.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_78" src="https://migri.fi/o/frontend-js-aui-web/liferay/menu.js?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;t=1780941680480" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_93" src="https://migri.fi/o/frontend-js-aui-web/aui/array-invoke/array-invoke.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_94" src="https://migri.fi/o/frontend-js-aui-web/liferay/language.js?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;t=1780941680480" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_95" src="https://migri.fi/o/frontend-js-web/liferay/available_languages.jsp?browserId=chrome&amp;themeId=yjasitetemplate_WAR_yjasitetemplatetheme&amp;colorSchemeId=01&amp;languageId=en_US&amp;t=1781065975275" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_99" src="https://migri.fi/o/frontend-js-aui-web/liferay/portlet_url.js?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;t=1780941680480" async=""></script><link rel="stylesheet" id="yui_patched_v3_18_7_1_1781500287819_101" href="https://migri.fi/o/frontend-js-aui-web/aui/widget-base/assets/skins/sam/widget-base.css"><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_102" src="https://migri.fi/o/frontend-js-aui-web/aui/base-core/base-core.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_103" src="https://migri.fi/o/frontend-js-aui-web/aui/base-observable/base-observable.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_104" src="https://migri.fi/o/frontend-js-aui-web/aui/base-base/base-base.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_105" src="https://migri.fi/o/frontend-js-aui-web/aui/base-pluginhost/base-pluginhost.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_106" src="https://migri.fi/o/frontend-js-aui-web/aui/event-focus/event-focus.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_107" src="https://migri.fi/o/frontend-js-aui-web/aui/widget-base/widget-base.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_108" src="https://migri.fi/o/frontend-js-aui-web/aui/aui-widget-cssclass/aui-widget-cssclass.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_109" src="https://migri.fi/o/frontend-js-aui-web/aui/aui-widget-toggle/aui-widget-toggle.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_110" src="https://migri.fi/o/frontend-js-aui-web/aui/base-build/base-build.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_111" src="https://migri.fi/o/frontend-js-aui-web/aui/aui-component/aui-component.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_112" src="https://migri.fi/o/frontend-js-aui-web/aui/cookie/cookie.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_113" src="https://migri.fi/o/frontend-js-aui-web/aui/plugin/plugin.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_114" src="https://migri.fi/o/frontend-js-aui-web/liferay/session.js?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;t=1780941680480" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_130" src="https://migri.fi/o/frontend-js-aui-web/aui/querystring-stringify-simple/querystring-stringify-simple.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_131" src="https://migri.fi/o/frontend-js-aui-web/aui/io-base/io-base.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_132" src="https://migri.fi/o/frontend-js-aui-web/aui/json-parse/json-parse.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_133" src="https://migri.fi/o/frontend-js-aui-web/aui/json-stringify/json-stringify.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_134" src="https://migri.fi/o/frontend-js-aui-web/aui/querystring-stringify/querystring-stringify.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_7_1_1781500287819_135" src="https://migri.fi/o/frontend-js-aui-web/aui/aui-io-request/aui-io-request.js" async=""></script><link data-senna-track="temporary" href="/o/frontend-css-web/main.css?browserId=chrome&amp;themeId=yjasitetemplate_WAR_yjasitetemplatetheme&amp;minifierType=css&amp;languageId=en_US&amp;t=1699991559480" id="liferayPortalCSS" rel="stylesheet" type="text/css"> 
+  <link data-senna-track="temporary" href="/combo?browserId=chrome&amp;minifierType=&amp;themeId=yjasitetemplate_WAR_yjasitetemplatetheme&amp;languageId=en_US&amp;com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_mhuLal9iWw3I:%2Fcss%2Fmain.css&amp;com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_5844369_rs:%2Fcss%2Fmain.css&amp;com_liferay_product_navigation_product_menu_web_portlet_ProductMenuPortlet:%2Fcss%2Fmain.css&amp;com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_EvX4qMMxVCAa:%2Fcss%2Fmain.css&amp;fi_yja_language_version_tool_web_portlet_LanguageVersionToolSelectionPortlet:%2Fcss%2Fmain.css&amp;fi_yja_sitetemplatesettings_web_SiteTemplateSettingsFooter_WAR_fiyjasitetemplatesettingsweb_INSTANCE_sitetemplateFooter:%2Fcss%2Ffooter.css&amp;fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb:%2Fcss%2Fheader.css&amp;t=1780930970000" id="a7fa001" rel="stylesheet" type="text/css"> 
+  <script data-senna-track="temporary" type="text/javascript">
+	// <![CDATA[
+		var Liferay = Liferay || {};
+
+		Liferay.Browser = {
+			acceptsGzip: function() {
+				return true;
+			},
+
+			
+
+			getMajorVersion: function() {
+				return 149.0;
+			},
+
+			getRevision: function() {
+				return '537.36';
+			},
+			getVersion: function() {
+				return '149.0';
+			},
+
+			
+
+			isAir: function() {
+				return false;
+			},
+			isChrome: function() {
+				return true;
+			},
+			isEdge: function() {
+				return false;
+			},
+			isFirefox: function() {
+				return false;
+			},
+			isGecko: function() {
+				return true;
+			},
+			isIe: function() {
+				return false;
+			},
+			isIphone: function() {
+				return false;
+			},
+			isLinux: function() {
+				return false;
+			},
+			isMac: function() {
+				return true;
+			},
+			isMobile: function() {
+				return false;
+			},
+			isMozilla: function() {
+				return false;
+			},
+			isOpera: function() {
+				return false;
+			},
+			isRtf: function() {
+				return true;
+			},
+			isSafari: function() {
+				return true;
+			},
+			isSun: function() {
+				return false;
+			},
+			isWebKit: function() {
+				return true;
+			},
+			isWindows: function() {
+				return false;
+			}
+		};
+
+		Liferay.Data = Liferay.Data || {};
+
+		Liferay.Data.ICONS_INLINE_SVG = true;
+
+		Liferay.Data.NAV_SELECTOR = '#navigation';
+
+		Liferay.Data.NAV_SELECTOR_MOBILE = '#navigationCollapse';
+
+		Liferay.Data.isCustomizationView = function() {
+			return false;
+		};
+
+		Liferay.Data.notices = [
+			
+
+			
+		];
+
+		Liferay.PortletKeys = {
+			DOCUMENT_LIBRARY: 'com_liferay_document_library_web_portlet_DLPortlet',
+			DYNAMIC_DATA_MAPPING: 'com_liferay_dynamic_data_mapping_web_portlet_DDMPortlet',
+			ITEM_SELECTOR: 'com_liferay_item_selector_web_portlet_ItemSelectorPortlet'
+		};
+
+		Liferay.PropsValues = {
+			JAVASCRIPT_SINGLE_PAGE_APPLICATION_TIMEOUT: 0,
+			NTLM_AUTH_ENABLED: false,
+			UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE: 3048576000
+		};
+
+		Liferay.ThemeDisplay = {
+
+			
+
+			
+				getLayoutId: function() {
+					return '744';
+				},
+
+				
+
+				getLayoutRelativeControlPanelURL: function() {
+					return '/en/group/migri/~/control_panel/manage';
+				},
+
+				getLayoutRelativeURL: function() {
+					return '/en/insurance';
+				},
+				getLayoutURL: function() {
+					return 'https://migri.fi/en/insurance';
+				},
+				getParentLayoutId: function() {
+					return '741';
+				},
+				isControlPanel: function() {
+					return false;
+				},
+				isPrivateLayout: function() {
+					return 'false';
+				},
+				isVirtualLayout: function() {
+					return false;
+				},
+			
+
+			getBCP47LanguageId: function() {
+				return 'en-US';
+			},
+			getCanonicalURL: function() {
+
+				
+
+				return 'https\x3a\x2f\x2fmigri\x2efi\x2finsurance';
+			},
+			getCDNBaseURL: function() {
+				return 'https://migri.fi';
+			},
+			getCDNDynamicResourcesHost: function() {
+				return '';
+			},
+			getCDNHost: function() {
+				return '';
+			},
+			getCompanyGroupId: function() {
+				return '10197';
+			},
+			getCompanyId: function() {
+				return '10157';
+			},
+			getDefaultLanguageId: function() {
+				return 'fi_FI';
+			},
+			getDoAsUserIdEncoded: function() {
+				return '';
+			},
+			getLanguageId: function() {
+				return 'en_US';
+			},
+			getParentGroupId: function() {
+				return '5202425';
+			},
+			getPathContext: function() {
+				return '';
+			},
+			getPathImage: function() {
+				return '/image';
+			},
+			getPathJavaScript: function() {
+				return '/o/frontend-js-web';
+			},
+			getPathMain: function() {
+				return '/en/c';
+			},
+			getPathThemeImages: function() {
+				return 'https://migri.fi/o/yja-site-template-theme/images';
+			},
+			getPathThemeRoot: function() {
+				return '/o/yja-site-template-theme';
+			},
+			getPlid: function() {
+				return '5844369';
+			},
+			getPortalURL: function() {
+				return 'https://migri.fi';
+			},
+			getRealUserId: function() {
+				return '10161';
+			},
+			getScopeGroupId: function() {
+				return '5202425';
+			},
+			getScopeGroupIdOrLiveGroupId: function() {
+				return '5202425';
+			},
+			getSessionId: function() {
+				return '';
+			},
+			getSiteAdminURL: function() {
+				return 'https://migri.fi/group/migri/~/control_panel/manage?p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view';
+			},
+			getSiteGroupId: function() {
+				return '5202425';
+			},
+			getURLControlPanel: function() {
+				return '/en/group/control_panel?refererPlid=5844369';
+			},
+			getURLHome: function() {
+				return 'https\x3a\x2f\x2fmigri\x2efi\x2f';
+			},
+			getUserEmailAddress: function() {
+				return '';
+			},
+			getUserId: function() {
+				return '10161';
+			},
+			getUserName: function() {
+				return '';
+			},
+			isAddSessionIdToURL: function() {
+				return false;
+			},
+			isImpersonated: function() {
+				return false;
+			},
+			isSignedIn: function() {
+				return false;
+			},
+
+			isStagedPortlet: function() {
+				
+					
+						return false;
+					
+				
+			},
+
+			isStateExclusive: function() {
+				return false;
+			},
+			isStateMaximized: function() {
+				return false;
+			},
+			isStatePopUp: function() {
+				return false;
+			}
+		};
+
+		var themeDisplay = Liferay.ThemeDisplay;
+
+		Liferay.AUI = {
+
+			
+
+			getAvailableLangPath: function() {
+				return 'available_languages.jsp?browserId=chrome&themeId=yjasitetemplate_WAR_yjasitetemplatetheme&colorSchemeId=01&languageId=en_US&t=1781065975275';
+			},
+			getCombine: function() {
+				return false;
+			},
+			getComboPath: function() {
+				return '/combo/?browserId=chrome&minifierType=&languageId=en_US&t=1780941680480&';
+			},
+			getDateFormat: function() {
+				return '%m/%d/%Y';
+			},
+			getEditorCKEditorPath: function() {
+				return '/o/frontend-editor-ckeditor-web';
+			},
+			getFilter: function() {
+				var filter = 'raw';
+
+				
+					
+
+				return filter;
+			},
+			getFilterConfig: function() {
+				var instance = this;
+
+				var filterConfig = null;
+
+				if (!instance.getCombine()) {
+					filterConfig = {
+						replaceStr: '.js' + instance.getStaticResourceURLParams(),
+						searchExp: '\\.js$'
+					};
+				}
+
+				return filterConfig;
+			},
+			getJavaScriptRootPath: function() {
+				return '/o/frontend-js-web';
+			},
+			getLangPath: function() {
+				return 'aui_lang.jsp?browserId=chrome&themeId=yjasitetemplate_WAR_yjasitetemplatetheme&colorSchemeId=01&languageId=en_US&t=1780941680480';
+			},
+			getPortletRootPath: function() {
+				return '/html/portlet';
+			},
+			getStaticResourceURLParams: function() {
+				return '?browserId=chrome&minifierType=&languageId=en_US&t=1780941680480';
+			}
+		};
+
+		Liferay.authToken = 'zSXKd2qu';
+
+		
+
+		Liferay.currentURL = '\x2fen\x2finsurance';
+		Liferay.currentURLEncoded = '\x252Fen\x252Finsurance';
+	// ]]>
+</script> 
+  <script src="/o/js_loader_config?t=1780941667833" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-aui-web/aui/aui/aui.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-aui-web/liferay/modules.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-aui-web/liferay/aui_sandbox.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-aui-web/aui/attribute-base/attribute-base.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-aui-web/aui/attribute-complex/attribute-complex.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-aui-web/aui/attribute-core/attribute-core.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-aui-web/aui/attribute-observable/attribute-observable.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-aui-web/aui/attribute-extras/attribute-extras.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-aui-web/aui/event-custom-base/event-custom-base.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-aui-web/aui/event-custom-complex/event-custom-complex.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-aui-web/aui/oop/oop.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-aui-web/aui/aui-base-lang/aui-base-lang.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-aui-web/liferay/dependency.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-aui-web/liferay/util.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-web/loader/config.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-web/loader/loader.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-web/liferay/dom_task_runner.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-web/liferay/events.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-web/liferay/lazy_load.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-web/liferay/liferay.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-web/liferay/global.bundle.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-web/liferay/portlet.js" type="text/javascript"></script> 
+  <script data-senna-track="permanent" src="/o/frontend-js-web/liferay/workflow.js" type="text/javascript"></script> 
+  <script data-senna-track="temporary" src="/o/js_bundle_config?t=1780941681640" type="text/javascript"></script> 
+  <script data-senna-track="temporary" type="text/javascript">
+	// <![CDATA[
+		
+			
+				
+		
+
+		
+
+		
+	// ]]>
+</script> 
+  <!--Snoobi siteanalytics V2.0--> 
+   
+  <meta name="google-site-verification" content="9ErTC4fVdwAw4ziqqD8I0cguVXAiKIk3PHwuflZWZ48"> 
+  <meta name="google-site-verification" content="Lkc4RuMBHCiAWWEOApCvwzkAOgdZoBt7TKFrXWmPqvY"> 
+  <meta name="yandex-verification" content="abb8d1fceb25f214"> 
+  <link class="lfr-css-file" data-senna-track="temporary" href="https://migri.fi/o/yja-site-template-theme/css/main.css?browserId=chrome&amp;themeId=yjasitetemplate_WAR_yjasitetemplatetheme&amp;minifierType=css&amp;languageId=en_US&amp;t=1780930970000" id="liferayThemeCSS" rel="stylesheet" type="text/css"> 
+  <style data-senna-track="temporary" type="text/css">
+		.site-theme.top-frame #main-content{
+padding: 0 !important;
+width: 100%;
+}
+.site-theme.top-frame #main-content > .portlet-layout.row{
+margin: 0 !important
+}
+.site-theme.top-frame #main-content > .portlet-layout.row > .col-12{
+padding: 0 !important;
+}
+.site-theme.top-frame #banner nav ul[role="menubar"] a {
+    padding-top: 7px !important;
+    padding-bottom: 10px !important;
+}
+.top-frame body #main-content li{
+line-height: 20px;
+}
+.top-frame body .heroCards p{
+line-height: 20px;
+}
+/* .top-frame .haluan-hakea__category-list__category-wrapper.calcMe_3{
+width: 100%;
+} */
+.top-frame .hed-section.portlet-title.portlet-title-text{
+max-width: none;
+}
+.top-frame .feed__image{
+width: 100%;
+}
+.top-frame #main-content img{
+max-width: 100%;
+}
+.top-frame .portlet-boundary .portlet .portlet-header h3.portlet-title-text{
+    margin-bottom: 1.25rem;
+}
+	</style> 
+  <style data-senna-track="temporary" type="text/css">
+
+		
+
+			
+
+		
+
+			
+
+				
+
+					
+
+#p_p_id_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_mhuLal9iWw3I_ .portlet-content {
+
+}
+
+
+
+
+				
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+	</style> 
+  <style>
+/* Publication Theme Mobile navigation */
+.yja-publication .yja-mobile-navigation { display: none; }
+/* YJAOM-815 */
+.top-frame .has-control-menu.controls-visible .portlet-asset-publisher .portlet-topper{
+    z-index: 3;
+}
+
+/* YJAY-3881  */
+.chrome .input-group .btn:focus, .chrome .input-group .form-control:focus {
+    z-index: inherit;
+}
+
+/* SD-30779 */ 
+*[lang="ar_SA"], *[lang="ar-SA"], *[lang="ar-SA"] *{ direction: rtl !important; }
+
+
+/* YJALR71-2924 */
+.controls-visible.signed-in .portlet-column-content.empty {min-height: 50px;margin-bottom: 10px;border: 1px dashed #d1d1d1;}
+
+/* YJAVNK-1622 */
+.has-control-menu .lfr-add-panel.open-admin-panel.sidenav-menu-slider{
+    width: 500px !important;
+}
+.has-control-menu .lfr-admin-panel.sidenav-menu-slider .product-menu{
+    width: 500px !important;
+} 
+
+</style> 
+  <script>
+    /* YJAY-1778 */
+    (function () {
+        window.YjaSearcher = window.YjaSearcher || {};
+        window.YjaSearcher.encodeInput = window.YjaSearcher.encodeInput || function (userInput) {
+            return encodeURIComponent(userInput).trim()
+                .replace(/%2[f|F]/g, '/')
+                .replace(/%5[c|C]/g, '%20')
+                .replace(",", "%2C")
+                .replace("\"", "%22")
+                .replace("!", "%21")
+                .replace("&", "%26")
+                .replace("'", "%27")
+                .replace('(', '%28')
+                .replace(')', '%29');
+        };
+
+        window.YjaSearcher.readInput = window.YjaSearcher.readInput || function (input) {
+            input = input || '';
+            if (('' + input).trim().indexOf('#') < 0) {
+                input = '#' + input;
+            }
+            var keywords = $(input).val();
+            keywords = window.YjaSearcher.encodeInput(keywords);
+            return keywords;
+        };
+
+        window.YjaSearcher.submitSearchForm = window.YjaSearcher.submitSearchForm || function (input) {
+            var keywords = window.YjaSearcher.readInput(input);
+            var formSearchUrl = window.YjaSearcher.formSearchUrl;
+            if (formSearchUrl && keywords) {
+                document.location.href = formSearchUrl + "?q=" + keywords;
+            }
+        };
+    })();
+</script> 
+  <style data-senna-track="temporary" type="text/css">
+</style> 
+  <link data-senna-track="permanent" href="https://migri.fi/combo?browserId=chrome&amp;minifierType=css&amp;languageId=en_US&amp;t=1780941655133&amp;/o/yja-common-ui-theme-contributor/css/yja-common-ui.css" rel="stylesheet" type="text/css"> 
+  <script data-senna-track="permanent" src="https://migri.fi/o/yja-common-ui-theme-contributor/js/yja-common-ui.js?browserId=chrome&amp;languageId=en_US&amp;t=1780941655133" type="text/javascript"></script> 
+  <script type="text/javascript">
+// <![CDATA[
+Liferay.on(
+	'ddmFieldBlur', function(event) {
+		if (window.Analytics) {
+			Analytics.send(
+				'fieldBlurred',
+				'Form',
+				{
+					fieldName: event.fieldName,
+					focusDuration: event.focusDuration,
+					formId: event.formId,
+					formPageTitle: event.formPageTitle,
+					page: event.page,
+					title: event.title
+				}
+			);
+		}
+	}
+);
+
+Liferay.on(
+	'ddmFieldFocus', function(event) {
+		if (window.Analytics) {
+			Analytics.send(
+				'fieldFocused',
+				'Form',
+				{
+					fieldName: event.fieldName,
+					formId: event.formId,
+					formPageTitle: event.formPageTitle,
+					page: event.page,
+					title: event.title
+				}
+			);
+		}
+	}
+);
+
+Liferay.on(
+	'ddmFormPageShow', function(event) {
+		if (window.Analytics) {
+			Analytics.send(
+				'pageViewed',
+				'Form',
+				{
+					formId: event.formId,
+					formPageTitle: event.formPageTitle,
+					page: event.page,
+					title: event.title
+				}
+			);
+		}
+	}
+);
+
+Liferay.on(
+	'ddmFormSubmit', function(event) {
+		if (window.Analytics) {
+			Analytics.send(
+				'formSubmitted',
+				'Form',
+				{
+					formId: event.formId
+				}
+			);
+		}
+	}
+);
+
+Liferay.on(
+	'ddmFormView', function(event) {
+		if (window.Analytics) {
+			Analytics.send(
+				'formViewed',
+				'Form',
+				{
+					formId: event.formId,
+					title: event.title
+				}
+			);
+		}
+	}
+);
+// ]]>
+</script> 
+  <script data-senna-track="temporary" type="text/javascript">
+	if (window.Analytics) {
+		window._com_liferay_document_library_analytics_isViewFileEntry = false;
+	}
+</script> 
+  <link rel="stylesheet" href="/o/fi.yja.sitetemplatesettings.web/support/5202425/1780374238173.css"> 
+  <link rel="stylesheet" href="    /o/common-ui-resources/standalone/font-awesome-4.7.0/css/font-awesome.min.css?t=1668424256000
+"> 
+  <meta name="twitter:card" content="summary_large_image"> 
+  <meta name="twitter:title" content="Insurance | Maahanmuuttovirasto"> 
+  <meta name="twitter:image" content="https://migri.fi/documents/5202425/0/Migri+logo+somejakoon+en.png/e12d05b2-1828-df7e-db77-dac05bf146c3?t=1652856176539&amp;imagePreview=1"> 
+  <link rel="stylesheet" href="/o/common-ui-resources/standalone/a11y/css/main.css?browserId=chrome&amp;themeId=yjasitetemplate_WAR_yjasitetemplatetheme&amp;minifierType=css&amp;languageId=en_US&amp;t=1780930970000
+"> 
+  <link rel="stylesheet" href="/o/common-ui-resources/standalone/mobile-navigation/css/main.css?browserId=chrome&amp;themeId=yjasitetemplate_WAR_yjasitetemplatetheme&amp;minifierType=css&amp;languageId=en_US&amp;t=1780930970000
+"> 
+  <link rel="stylesheet" href="/o/common-ui-resources/standalone/owl/css/owl.carousel.min.css?browserId=chrome&amp;themeId=yjasitetemplate_WAR_yjasitetemplatetheme&amp;minifierType=css&amp;languageId=en_US&amp;t=1780930970000
+"> 
+  <link rel="stylesheet" type="text/css" href="/o/yja-cookie-consent-web/css/main.css?browserId=chrome&amp;themeId=yjasitetemplate_WAR_yjasitetemplatetheme&amp;minifierType=css&amp;languageId=en_US&amp;t=1780930970000"> 
+ <script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/coreNamed.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/core.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/array/array.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/async/async.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/disposable/Disposable.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/object/object.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/string/string.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/metal.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/domData.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-events@2.16.8/lib/EventHandle.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-events@2.16.8/lib/EventEmitter.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-events@2.16.8/lib/EventEmitterProxy.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-events@2.16.8/lib/EventHandler.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-events@2.16.8/lib/events.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/DomDelegatedEventHandle.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/DomEventHandle.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/domNamed.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/dom.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/DomEventEmitterProxy.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/features.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/globalEval.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/globalEvalStyles.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/events.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/all/dom.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web@4.0.15/bridge/metal-dom/src/all/dom.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-taglib-clay$classnames@2.2.6/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web$object-assign@4.1.1/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web$react@16.12.0/cjs/react.production.min.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web$react@16.12.0/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-taglib-clay$warning@4.0.3/warning.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/icon@3.56.0/lib/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/layout@3.65.1/lib/Col.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/layout@3.65.1/lib/Container.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/layout@3.65.1/lib/ContainerFluid.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/layout@3.65.1/lib/Content.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/layout@3.65.1/lib/Row.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/layout@3.65.1/lib/Sheet.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/layout@3.65.1/lib/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/alert@3.5.0/lib/Footer.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/alert@3.5.0/lib/ToastContainer.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/alert@3.5.0/lib/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-node-shims$process@0.11.10/browser.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-node-shims$process@0.11.10/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web$scheduler@0.18.0/cjs/scheduler.production.min.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web$scheduler@0.18.0/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web$react-dom@16.12.0/cjs/react-dom.production.min.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web$react-dom@16.12.0/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web@4.0.22/js/render.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web@4.0.22/js/hooks/useEventListener.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web@4.0.22/js/hooks/useIsMounted.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web@4.0.22/js/hooks/useInterval.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web@4.0.22/js/hooks/usePrevious.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web@4.0.22/js/hooks/useStateSafe.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web@4.0.22/js/hooks/useThunk.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web@4.0.22/js/hooks/useTimeout.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web@4.0.22/js/index.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/toast/commands/OpenToast.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/bridge/frontend-js-web/liferay/toast/commands/OpenToast.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/aop/AOP.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/autosize/autosize.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/debounce/debounce.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/delegate/delegate.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/form/object_to_form_data.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/breakpoints.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-state@2.16.8/lib/validators.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-state@2.16.8/lib/Config.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-state@2.16.8/lib/State.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-state@2.16.8/lib/all/state.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/CompatibilityEventProxy.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-component@2.16.8/lib/events/events.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-component@2.16.8/lib/sync/sync.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-component@2.16.8/lib/ComponentDataManager.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-component@2.16.8/lib/ComponentRenderer.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-component@2.16.8/lib/Component.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-component@2.16.8/lib/ComponentRegistry.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-component@2.16.8/lib/all/component.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/PortletBase.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/DefaultEventHandler.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/toggle_disabled.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/ItemSelectorDialog.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/button@3.83.0/lib/Group.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/button@3.83.0/lib/Button.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/button@3.83.0/lib/ButtonWithIcon.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/button@3.83.0/lib/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/loading-indicator@3.60.0/lib/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/provider@3.77.0/lib/LRUCache.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/provider@3.77.0/lib/DataClient.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/provider@3.77.0/lib/Provider.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/provider@3.77.0/lib/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/Portal.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/delegate.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-taglib-clay$dom-align@1.12.3/dist-node/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/doAlign.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/Keys.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/useFocusManagement.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/FocusScope.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/getEllipsisItems.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/link@3.88.0/lib/Context.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/link@3.88.0/lib/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/LinkOrButton.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/useMousePosition.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/MouseSafeArea.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/observeRect.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-taglib-clay$aria-hidden@1.2.3/dist/es5/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/useInteractOutside.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/Overlay.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/setElementFullHeight.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/sub.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/useDebounce.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/useId.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/platform.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/useInteractionFocus.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/useInternalState.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/useNavigation.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/useOverlayPositon.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/useHover.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/useIsMobileDevice.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.89.0/lib/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.89.0/lib/Body.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.89.0/lib/Context.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.89.0/lib/Footer.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.89.0/lib/Header.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.89.0/lib/Hook.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.89.0/lib/types.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.89.0/lib/Modal.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.89.0/lib/useModal.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.89.0/lib/Provider.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.89.0/lib/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web$classnames@2.2.6/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web$prop-types@15.7.2/lib/ReactPropTypesSecret.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web$prop-types@15.7.2/factoryWithThrowingShims.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-react-web$prop-types@15.7.2/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/modal/Modal.scss.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/navigate.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/modal/Modal.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.89.0/lib/Checkbox.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.89.0/lib/SelectBox.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.89.0/lib/DualListBox.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.89.0/lib/Form.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.89.0/lib/Input.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.89.0/lib/Radio.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.89.0/lib/RadioGroup.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.89.0/lib/Select.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.89.0/lib/SelectWithOption.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.89.0/lib/Toggle.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.89.0/lib/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/modal/components/SimpleInputModal.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/modal/commands/OpenSimpleInputModal.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/get_portlet_namespace.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/portlet_url/create_portlet_url.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/portlet_url/create_action_url.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/portlet_url/create_render_url.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/portlet_url/create_resource_url.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/fetch.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/session.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/throttle.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/add_params.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/get_dom.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/get_element.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/in_browser_view.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/focus_form_field.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/get_portlet_id.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/is_phone.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/is_tablet.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/liferay/util/normalize_friendly_url.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-web@4.0.59/index.es.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/remote-app-support-web@1.0.8/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-collapse-support-web@1.0.15/CollapseProvider.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-collapse-support-web@1.0.15/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/tooltip@3.4.0/lib/Tooltip.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/tooltip@3.4.0/lib/TooltipProvider.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/@frontend-taglib-clay$clayui/tooltip@3.4.0/lib/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-position@2.1.2/lib/Geometry.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-position@2.1.2/lib/Position.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-position@2.1.2/lib/Align.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-metal-web$metal-position@2.1.2/lib/all/position.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-tooltip-support-web@3.0.7/reducer.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-tooltip-support-web@3.0.7/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-tabs-support-web@1.0.11/TabsProvider.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-tabs-support-web@1.0.11/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-alert-support-web@1.0.10/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-dropdown-support-web$dom-align@1.10.4/dist-node/index.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-dropdown-support-web@1.0.11/DropdownProvider.js?languageId=en_US"></script><script src="https://migri.fi/o/js/resolved-module/frontend-js-dropdown-support-web@1.0.11/index.js?languageId=en_US"></script><link rel="stylesheet" type="text/css" href="/o/frontend-js-web/liferay/modal/Modal.css"></head> 
+ <body class="chrome controls-visible yui3-skin-sam signed-out public-page site extranet-user en migri-1234" itemscope="" itemtype="http://schema.org/WebPage"><div role="dialog" tabindex="-1" id="yja-cookie-dialog" class="yja-cookie-dialog__theme-two" style="display: block;"><section data-nosnippet="" aria-label="Cookie consent" aria-describedby="yja-cookie-dialog-note-text" tabindex="-1" class="yja-cookie-dialog-content"><div id="yja-cookie-dialog-note-text" class="yja-cookie-dialog-note"><p>The website uses cookies and plugins to improve the user experience. Some cookies are essential to website performance and are automatically activated.&nbsp;<a href="/about-this-site" target="">Learn more about site cookies.</a></p></div><div tabindex="-1" class="yja-cookie-dialog-buttons"><button id="yja-cookie-accept" class="btn btn-primary">I accept all cookies</button><button id="yja-cookie-reject" class="btn btn-primary">I accept only necessary cookies</button></div></section></div> 
+  <a href="#content-main" id="skip-to-maincontent">Skip to Content</a> 
+  <script>var YjaSearcher = YjaSearcher || {};
+YjaSearcher.formSearchUrl = '/search';</script> 
+  <div class="bg-image"></div> 
+  <div class="page-wrapper"> 
+   <header id="banner" role="banner"> 
+    <div id="heading"> 
+     <div class="portlet-boundary portlet-boundary_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb_  portlet-static portlet-static-end portlet-barebone yja-site-template-settings-header-portlet " id="p_p_id_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb_"> 
+      <span id="p_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb"></span> 
+      <section class="portlet" id="portlet_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb"> 
+       <a id="aineisto-fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb" name="aineisto-fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb" class="yja-anchor-elements"></a> 
+       <div class="portlet-content"> 
+        <div class="autofit-float autofit-row portlet-header "> 
+         <div class="autofit-col autofit-col-end"> 
+          <div class="autofit-section"> 
+          </div> 
+         </div> 
+        </div> 
+        <div class=" portlet-content-container"> 
+         <div class="portlet-body"> 
+          <div class="header-top-bar hasLangDrowpdown"> 
+           <div class="layout-wrapper-wide-container"> 
+            <div class="header-top-bar-links-lang" role="navigation" aria-label="Language selection"> 
+             <div class="portlet-boundary portlet-boundary_fi_yja_language_version_tool_web_portlet_LanguageVersionToolSelectionPortlet_  portlet-static portlet-static-end portlet-barebone language-version-selection-portlet " id="p_p_id_fi_yja_language_version_tool_web_portlet_LanguageVersionToolSelectionPortlet_"> 
+              <span id="p_fi_yja_language_version_tool_web_portlet_LanguageVersionToolSelectionPortlet"></span> 
+              <section class="portlet" id="portlet_fi_yja_language_version_tool_web_portlet_LanguageVersionToolSelectionPortlet"> 
+               <a id="aineisto-fi_yja_language_version_tool_web_portlet_LanguageVersionToolSelectionPortlet" name="aineisto-fi_yja_language_version_tool_web_portlet_LanguageVersionToolSelectionPortlet" class="yja-anchor-elements"></a> 
+               <div class="portlet-content"> 
+                <div class="autofit-float autofit-row portlet-header "> 
+                 <div class="autofit-col autofit-col-end"> 
+                  <div class="autofit-section"> 
+                  </div> 
+                 </div> 
+                </div> 
+                <div class=" portlet-content-container"> 
+                 <div class="portlet-body"> 
+                  <ul class="lang-nav"><li class="lang-text"><a href="#"><span class="sr-only">Select language</span> English</a><ul aria-label="Select site language" class="en" id="languageSelectionMenu" data-test="true" aria-hidden="true"> 
+                   <li class="fi" lang="fi"><a href="https://migri.fi/vakuutukset" tabindex="-1"><span class="sr-only">Valitse kieli</span> Suomi</a></li> 
+                   <li class="sv" lang="sv"><a href="https://migri.fi/sv/forsakringar" tabindex="-1"><span class="sr-only">Välj språket</span> Svenska</a></li> 
+                   <li class="en" lang="en"><a href="https://migri.fi/en/insurance" tabindex="-1"><span class="sr-only">Select language</span> English</a></li> 
+                   <li class="uk" lang="uk"><a rel="nofollow" href="https://migri.fi/uk/?p_p_id=fi_yja_language_version_tool_web_portlet_LanguageVersionToolMissingNotificationPortlet&amp;_fi_yja_language_version_tool_web_portlet_LanguageVersionToolMissingNotificationPortlet_missingLanguageVersion=1" tabindex="-1">Українська</a></li> 
+                  </ul></li></ul> 
+                  <div class="yja-metacontent" hidden=""> 
+                  </div> 
+                  <div class="yja-metacontent" hidden=""> 
+                  </div> 
+                  <div class="yja-metacontent" hidden=""> 
+                  </div> 
+                 </div> 
+                </div> 
+               </div> 
+              </section> 
+             </div> 
+            </div> 
+            <div class="header-top-bar-links-right"> 
+             <div> 
+              <ul> 
+               <li><button aria-expanded="false" aria-haspopup="true">Online service<span class="sr-only">Open submenu</span></button> 
+                <ul> 
+                 <li><a href="https://enterfinland.fi/eServices" target="_blank" class="yja-external-link">Customers</a></li> 
+                 <li><a href="https://enterfinland.fi/eServices/home/employer" target="_blank" class="yja-external-link">Employers</a></li> 
+                 <li><a href="https://enterfinland.fi/eServices/home/advisor" target="_blank" class="yja-external-link">Counsels and representatives</a></li> 
+                </ul></li> 
+               <li><a href="https://migri.vihta.com" target="_blank" class="yja-external-link">Book an appointment</a></li> 
+              </ul> 
+              <div class="yja-meta-content-info"> 
+              </div> 
+             </div> 
+            </div> 
+           </div> 
+          </div> 
+          <div class="layout-wrapper-wide-container"> 
+           <div class="row header-row"> 
+            <div class="col col-md-7 header-top-left-cell"> 
+             <a class="logo" href="/en" aria-label="Go to Maahanmuuttovirasto site frontpage "> <img src="/documents/5202425/12394585/MIGRI_logo_RGB_opt.svg/c2647bfc-34d0-b844-5a85-2e6681102034?t=1551072686000" alt="Maahanmuuttovirasto"> </a> 
+            </div> 
+            <div class="col col-md-5 header-top-right-cell text-right hasLangDrowpdown"> 
+             <div class="header-top-right-area"> 
+              <!-- if showTopBar is true, don't show language selection here but instead in the top bar --> 
+              <form class="search-form" action="/search?q=" onsubmit="YjaSearcher.submitSearchForm('_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb_search-keywords'); return false;"> 
+               <div class="input-group"> 
+                <label class="sr-only" for="_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb_search-keywords">Search from website</label> 
+                <input type="search" id="_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb_search-keywords" name="keywords" class="search-query form-control" placeholder="Search from website"> 
+                <div class="input-group-append"> 
+                 <input onclick="YjaSearcher.submitSearchForm('_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb_search-keywords'); return false;" class="btn btn-small btn-default search-form_submit" type="submit" value="Search"> 
+                </div> 
+               </div> 
+              </form> 
+              <a href="/search" class="header-advanced-search-link">Search page</a> 
+             </div> 
+            </div> 
+           </div> 
+          </div> 
+          <style data-senna-track="temporary">
+			:root {
+			
+				--yja-menu-overlay-background: #003da5;
+			
+			
+				--yja-menu-link-color:#ffffff;
+			
+			
+				--yja-menu-border-color: #ffffff;
+			
+			}
+		</style> 
+         </div> 
+        </div> 
+       </div> 
+      </section> 
+     </div> 
+    </div> 
+    <div class="d-block d-md-none mobile-menu-actions visible-phone" data-menu-position="right"> 
+     <button class="menu-icon mmenu-toggler" id="mmenu-open-panel" aria-expanded="false" aria-haspopup="true"> <span role="presentation" class="icon-reorder" aria-hidden="true"></span> <span>Menu</span> </button> 
+    </div> 
+    <nav class="sort-pages modify-pages main-nav d-none d-md-block a11y-navigation" data-focus-target="ul" aria-label="Main navigation"> 
+     <ul class="a11y-nav site-theme__navigation" id="a11y-nav-root"> 
+      <li class="a11y-nav__item a11y-nav__item" id="layout_387"><a href="https://migri.fi/en/home"> <span>Home</span> </a></li> 
+      <li class="a11y-nav__item a11y-nav__item has-children" id="layout_392"><a href="https://migri.fi/en/i-want-to-apply"> <span>I want to apply</span> </a> <button id="megamenu-392-toggle" data-layout-id="392" class="a11y-toggler js-toggle-special-nav" aria-haspopup="true" aria-expanded="false"> <span class="sr-only a11y-nav__toggle_text"> Open submenu </span> <span class="sr-only">, I want to apply</span> <span role="presentation" class="icon icon-plus "></span> </button> 
+       <div class="a11y-nav__sub d-none" id="megamenu-392-dropdown" data-layout-id="392" aria-hidden="true"> 
+        <ul class="site-theme__navigation--sub child-menu a11y-navgroup" id="a11y-subnav__392" tabindex="-1" aria-label="I want to apply, subpages"> 
+         <li class="a11y-nav__item " id="layout_569"><a href="https://migri.fi/en/i-want-to-come-to-finland">I want to come to Finland</a></li> 
+         <li class="a11y-nav__item " id="layout_570"><a href="https://migri.fi/en/i-am-visiting-finland">I am visiting Finland</a></li> 
+         <li class="a11y-nav__item " id="layout_405"><a href="https://migri.fi/en/i-want-a-residence-permit">I want a residence permit</a></li> 
+         <li class="a11y-nav__item " id="layout_2661"><a href="https://migri.fi/en/i-want-to-fast-track-my-application">I want to fast-track my application</a></li> 
+         <li class="a11y-nav__item " id="layout_416"><a href="https://migri.fi/en/i-want-to-extend-my-residence-permit">I want to extend my residence permit</a></li> 
+         <li class="a11y-nav__item " id="layout_407"><a href="https://migri.fi/en/i-am-an-eu-citizen-or-a-family-member">I am an EU citizen or an EU citizen's family member</a></li> 
+         <li class="a11y-nav__item " id="layout_413"><a href="https://migri.fi/en/i-am-a-nordic-citizen">I am a Nordic citizen</a></li> 
+         <li class="a11y-nav__item " id="layout_417"><a href="https://migri.fi/en/i-want-to-become-a-finnish-citizen">I want to become a Finnish citizen</a></li> 
+         <li class="a11y-nav__item " id="layout_1891"><a href="https://migri.fi/en/i-want-to-apply/brexit">Brexit</a></li> 
+        </ul> 
+       </div></li> 
+      <li class="a11y-nav__item a11y-nav__item" id="layout_393"><a href="https://migri.fi/en/after-applying"> <span>After applying</span> </a></li> 
+      <li class="a11y-nav__item a11y-nav__item has-children selected" id="layout_394"><a aria-current="true" href="https://migri.fi/en/permits-and-citizenship"> <span>Permits and citizenship</span> </a> <button id="megamenu-394-toggle" data-layout-id="394" class="a11y-toggler js-toggle-special-nav" aria-haspopup="true" aria-expanded="false"> <span class="sr-only a11y-nav__toggle_text"> Open submenu </span> <span class="sr-only">, Permits and citizenship</span> <span role="presentation" class="icon icon-plus "></span> </button> 
+       <div class="a11y-nav__sub d-none" id="megamenu-394-dropdown" data-layout-id="394" aria-hidden="true"> 
+        <ul class="site-theme__navigation--sub child-menu a11y-navgroup" id="a11y-subnav__394" tabindex="-1" aria-label="Permits and citizenship, subpages"> 
+         <li class="a11y-nav__item " id="layout_574"><a href="https://migri.fi/en/residence-permit">Residence permit</a></li> 
+         <li class="a11y-nav__item " id="layout_824"><a href="https://migri.fi/en/eu-citizen">EU citizen</a></li> 
+         <li class="a11y-nav__item " id="layout_424"><a href="https://migri.fi/en/finnish-citizenship">Finnish citizenship</a></li> 
+         <li class="a11y-nav__item " id="layout_996"><a href="https://migri.fi/en/asylum-in-finland">Asylum in Finland</a></li> 
+         <li class="a11y-nav__item " id="layout_1446"><a href="https://migri.fi/en/brexit/en">Brexit</a></li> 
+         <li class="a11y-nav__item " id="layout_1208"><a href="https://migri.fi/en/travel-documents">Travel documents</a></li> 
+         <li class="a11y-nav__item " id="layout_1221"><a href="https://migri.fi/en/income-requirement">Income requirement</a></li> 
+         <li class="a11y-nav__item " id="layout_2421"><a href="https://migri.fi/en/incomes-register">Incomes register</a></li> 
+         <li class="a11y-nav__item " id="layout_1212"><a href="https://migri.fi/en/processing-of-applications">Processing of applications</a></li> 
+         <li class="a11y-nav__item " id="layout_1223"><a href="https://migri.fi/en/changes-and-supplementary-documents">Changes and supplementary documents</a></li> 
+         <li class="a11y-nav__item " id="layout_1227"><a href="https://migri.fi/en/requests-and-certificates">Requests and certificates</a></li> 
+         <li class="a11y-nav__item " id="layout_1231"><a href="https://migri.fi/en/legislation">Legislation</a></li> 
+         <li class="a11y-nav__item " id="layout_2678"><a href="https://migri.fi/en/guidelines-for-application-of-law">Guidelines for application of law</a></li> 
+         <li class="a11y-nav__item " id="layout_1232"><a href="https://migri.fi/en/informing-of-the-decision">Informing of the decision</a></li> 
+         <li class="a11y-nav__item " id="layout_1234"><a href="https://migri.fi/en/appealing-a-decision">Appealing a decision</a></li> 
+         <li class="a11y-nav__item " id="layout_2644"><a href="https://migri.fi/en/procedural-provisions">Procedural provisions</a></li> 
+         <li class="a11y-nav__item " id="layout_1237"><a href="https://migri.fi/en/cancellation-of-a-permit">Cancellation of a permit</a></li> 
+         <li class="a11y-nav__item " id="layout_1238"><a href="https://migri.fi/en/denial-of-admittance-or-stay-deportation-entry-ban">Denial of admittance or stay, deportation, entry ban</a></li> 
+         <li class="a11y-nav__item " id="layout_1239"><a href="https://migri.fi/en/work-in-finland">Work in Finland</a></li> 
+         <li class="a11y-nav__item " id="layout_638"><a href="https://migri.fi/en/for-employers">For employers</a></li> 
+         <li class="a11y-nav__item " id="layout_1240"><a href="https://migri.fi/en/travelling">Travelling</a></li> 
+         <li class="a11y-nav__item " id="layout_1241"><a href="https://migri.fi/en/visiting-finland">Visiting Finland</a></li> 
+        </ul> 
+       </div></li> 
+      <li class="a11y-nav__item a11y-nav__item has-children" id="layout_2491" lang="uk"><a href="https://migri.fi/en/ukraine"> <span>Ukraine</span> </a> <button id="megamenu-2491-toggle" data-layout-id="2491" class="a11y-toggler js-toggle-special-nav" aria-haspopup="true" aria-expanded="false"> <span class="sr-only a11y-nav__toggle_text"> Open submenu </span> <span class="sr-only">, Ukraine</span> <span role="presentation" class="icon icon-plus "></span> </button> 
+       <div class="a11y-nav__sub d-none" id="megamenu-2491-dropdown" data-layout-id="2491" aria-hidden="true"> 
+        <ul class="site-theme__navigation--sub child-menu a11y-navgroup" id="a11y-subnav__2491" tabindex="-1" aria-label="Ukraine, subpages"> 
+         <li class="a11y-nav__item " id="layout_2492"><a href="https://migri.fi/en/after-arrival">After arrival</a></li> 
+         <li class="a11y-nav__item " id="layout_2493"><a href="https://migri.fi/en/children-who-have-fled-ukraine">Children who have fled Ukraine</a></li> 
+         <li class="a11y-nav__item " id="layout_2494"><a href="https://migri.fi/en/accommodation">Accommodation</a></li> 
+         <li class="a11y-nav__item " id="layout_2495"><a href="https://migri.fi/en/work-and-studies">Work and studies</a></li> 
+         <li class="a11y-nav__item " id="layout_2496"><a href="https://migri.fi/en/family">Family</a></li> 
+         <li class="a11y-nav__item " id="layout_2497"><a href="https://migri.fi/en/health-and-social-services">Health and social services</a></li> 
+         <li class="a11y-nav__item " id="layout_2498"><a href="https://migri.fi/en/financial-support">Financial support</a></li> 
+         <li class="a11y-nav__item " id="layout_2499"><a href="https://migri.fi/en/traveling-from-finland">Traveling from Finland</a></li> 
+         <li class="a11y-nav__item " id="layout_2500"><a href="https://migri.fi/en/temporary-protection-and-municipality-of-residence">Municipality of residence</a></li> 
+         <li class="a11y-nav__item " id="layout_2903"><a href="https://migri.fi/en/finnish-society-course-for-ukrainians">Finnish society course for Ukrainians</a></li> 
+         <li class="a11y-nav__item " id="layout_2501"><a href="https://migri.fi/en/temporary-protection">Temporary protection</a></li> 
+         <li class="a11y-nav__item " id="layout_2503"><a href="https://migri.fi/en/other-residence-permits">Other residence permits</a></li> 
+         <li class="a11y-nav__item " id="layout_2504"><a href="https://migri.fi/en/withdrawal-of-applications-or-permits">Withdrawal of applications or permits</a></li> 
+         <li class="a11y-nav__item " id="layout_2505"><a href="https://migri.fi/en/faq-russia-s-invasion-of-ukraine">Frequently asked questions about Russia’s invasion of Ukraine</a></li> 
+         <li class="a11y-nav__item " id="layout_2506"><a href="https://migri.fi/en/contact-information1">Contact information</a></li> 
+         <li class="a11y-nav__item " id="layout_2507"><a href="https://migri.fi/en/how-can-i-help-ukrainians-">How can I help Ukrainians?</a></li> 
+         <li class="a11y-nav__item " id="layout_2508"><a href="https://migri.fi/en/for-employers1">For employers</a></li> 
+         <li class="a11y-nav__item " id="layout_2509"><a href="https://migri.fi/en/for-municipalities">For municipalities</a></li> 
+         <li class="a11y-nav__item " id="layout_2674"><a href="https://migri.fi/en/printable-instructions">Printable instructions</a></li> 
+        </ul> 
+       </div></li> 
+      <li class="a11y-nav__item a11y-nav__item has-children" id="layout_395"><a href="https://migri.fi/en/services"> <span>Services</span> </a> <button id="megamenu-395-toggle" data-layout-id="395" class="a11y-toggler js-toggle-special-nav" aria-haspopup="true" aria-expanded="false"> <span class="sr-only a11y-nav__toggle_text"> Open submenu </span> <span class="sr-only">, Services</span> <span role="presentation" class="icon icon-plus "></span> </button> 
+       <div class="a11y-nav__sub d-none" id="megamenu-395-dropdown" data-layout-id="395" aria-hidden="true"> 
+        <ul class="site-theme__navigation--sub child-menu a11y-navgroup" id="a11y-subnav__395" tabindex="-1" aria-label="Services, subpages"> 
+         <li class="a11y-nav__item " id="layout_1091"><a href="https://migri.fi/en/submit-your-application-in-the-e-service">Online service Enter Finland</a></li> 
+         <li class="a11y-nav__item " id="layout_1092"><a href="https://migri.fi/en/book-an-appointment">Book an appointment at a service point</a></li> 
+         <li class="a11y-nav__item " id="layout_2166"><a href="https://migri.fi/en/telephone-service1">Telephone service</a></li> 
+         <li class="a11y-nav__item " id="layout_3502"><a href="https://migri.fi/en/ask-for-guidance-by-email">Ask for guidance by email</a></li> 
+         <li class="a11y-nav__item " id="layout_3404"><a href="https://migri.fi/en/partners-and-stakeholders">Partners and stakeholders</a></li> 
+         <li class="a11y-nav__item " id="layout_1096"><a href="https://migri.fi/en/faq">Frequently Asked Questions</a></li> 
+         <li class="a11y-nav__item " id="layout_1097"><a href="https://migri.fi/en/instructions">Instructions</a></li> 
+         <li class="a11y-nav__item " id="layout_1125"><a href="https://migri.fi/en/brochures-and-publications">Brochures and publications</a></li> 
+         <li class="a11y-nav__item " id="layout_1094"><a href="https://migri.fi/en/check-the-processing-time-of-your-application">Check the processing time of your application</a></li> 
+         <li class="a11y-nav__item " id="layout_2735"><a href="https://migri.fi/en/give-feedback">Give feedback</a></li> 
+         <li class="a11y-nav__item " id="layout_448"><a href="https://migri.fi/en/about-us">About us</a></li> 
+         <li class="a11y-nav__item " id="layout_2697"><a href="https://migri.fi/en/newsroom1">Newsroom</a></li> 
+         <li class="a11y-nav__item " id="layout_1123"><a href="https://migri.fi/en/emn/en">EMN</a></li> 
+         <li class="a11y-nav__item " id="layout_1119"><a href="https://migri.fi/en/country-information-service">Country Information Service</a></li> 
+         <li class="a11y-nav__item " id="layout_1277"><a href="https://migri.fi/en/reception-centres">Reception centres</a></li> 
+         <li class="a11y-nav__item " id="layout_1318"><a href="https://migri.fi/en/detention-units">Detention units</a></li> 
+         <li class="a11y-nav__item " id="layout_454"><a href="https://migri.fi/en/social-media">Social media</a></li> 
+         <li class="a11y-nav__item " id="layout_2720"><a href="https://migri.fi/en/safe-use-of-online-services">Safe use of online services</a></li> 
+         <li class="a11y-nav__item " id="layout_463"><a href="https://migri.fi/en/press-releases-and-bulletins">Press releases and bulletins</a></li> 
+         <li class="a11y-nav__item " id="layout_555"><a href="https://migri.fi/en/statistics">Statistics</a></li> 
+         <li class="a11y-nav__item " id="layout_450"><a href="https://migri.fi/en/glossary">Glossary</a></li> 
+        </ul> 
+       </div></li> 
+     </ul> 
+    </nav> 
+   </header> 
+   <section id="content" role="main"> 
+    <div id="main-content" class="landingpage-layout-container" role="region" aria-label="Page content region"><span id="content-main"></span> 
+     <span id="content-main"></span> 
+     <div class="portlet-layout row" style="position: relative;"> 
+      <div class="portlet-column col col-12" id="column-5"> 
+       <div class="portlet-dropzone portlet-column-content" id="layout-column_column-5"> 
+        <div class="portlet-boundary portlet-boundary_com_liferay_journal_content_web_portlet_JournalContentPortlet_  portlet-static portlet-static-end portlet-barebone portlet-journal-content " id="p_p_id_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_SSKDNE5ODInk_"> 
+         <span id="p_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_SSKDNE5ODInk"></span> 
+         <section class="portlet" id="portlet_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_SSKDNE5ODInk"> 
+          <a id="aineisto-com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_SSKDNE5ODInk" name="aineisto-com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_SSKDNE5ODInk" class="yja-anchor-elements"></a> 
+          <div class="portlet-content"> 
+           <div class="autofit-float autofit-row portlet-header "> 
+            <div class="autofit-col autofit-col-end"> 
+             <div class="autofit-section"> 
+              <div class="visible-interaction"> 
+              </div> 
+             </div> 
+            </div> 
+           </div> 
+           <div class=" portlet-content-container"> 
+            <div class="portlet-body"> 
+             <div class="" data-fragments-editor-item-id="10109-5693090" data-fragments-editor-item-type="fragments-editor-mapped-item"> 
+              <div class="journal-content-article " data-analytics-asset-id="5693088" data-analytics-asset-title="Oleskelulupa - matala hero" data-analytics-asset-type="web-content"> 
+               <div class="hero hero--low" style="background: url('/documents/5202425/12394643/Vihrea%CC%88_tapetti_rgb_2200x200_Oleskelulupa.svg/50b6c826-99cf-02c7-a615-6865b2001ae6?t=1551359618000')"> 
+                <div class="layout-wrapper-wide-container"> 
+                 <div class="hero__themeHeading"> 
+                  <div class="hero__themeHeading__image"> 
+                   <img src="https://migri.fi/documents/5202425/5208108/oleskeluluvat-invert.svg/55a6b3bc-411e-41e1-8faa-745810e2360c?version=1.1&amp;t=1551077581000" alt=""> 
+                  </div> 
+                  <h1 class="hero-heading-migri"><div class="hero__themeHeading__text">
+                    Residence permit 
+                  </div></h1> 
+                 </div> 
+                </div> 
+                <div class="hero__overlay hero__overlay--green"></div> 
+               </div> 
+              </div> 
+             </div> 
+            </div> 
+           </div> 
+          </div> 
+         </section> 
+        </div> 
+        <div class="portlet-boundary portlet-boundary_com_liferay_site_navigation_breadcrumb_web_portlet_SiteNavigationBreadcrumbPortlet_  portlet-static portlet-static-end portlet-barebone portlet-breadcrumb " id="p_p_id_com_liferay_site_navigation_breadcrumb_web_portlet_SiteNavigationBreadcrumbPortlet_INSTANCE_g4caL14LC89m_"> 
+         <span id="p_com_liferay_site_navigation_breadcrumb_web_portlet_SiteNavigationBreadcrumbPortlet_INSTANCE_g4caL14LC89m"></span> 
+         <section class="portlet" id="portlet_com_liferay_site_navigation_breadcrumb_web_portlet_SiteNavigationBreadcrumbPortlet_INSTANCE_g4caL14LC89m"> 
+          <a id="aineisto-com_liferay_site_navigation_breadcrumb_web_portlet_SiteNavigationBreadcrumbPortlet_INSTANCE_g4caL14LC89m" name="aineisto-com_liferay_site_navigation_breadcrumb_web_portlet_SiteNavigationBreadcrumbPortlet_INSTANCE_g4caL14LC89m" class="yja-anchor-elements"></a> 
+          <div class="portlet-content"> 
+           <div class="autofit-float autofit-row portlet-header "> 
+            <div class="autofit-col autofit-col-end"> 
+             <div class="autofit-section"> 
+             </div> 
+            </div> 
+           </div> 
+           <div class=" portlet-content-container"> 
+            <div class="portlet-body"> 
+             <nav aria-label="Breadcrumb" id="_com_liferay_site_navigation_breadcrumb_web_portlet_SiteNavigationBreadcrumbPortlet_INSTANCE_g4caL14LC89m_breadcrumbs-defaultScreen"> 
+              <ul class="breadcrumb breadcrumb-horizontal"> 
+               <li class=""><a href="https://migri.fi/en"> Maahanmuuttovirasto </a></li> 
+               <li class=""><a href="https://migri.fi/en"> en </a></li> 
+               <li class=""><a href="https://migri.fi/en/permits-and-citizenship"> Permits and citizenship </a></li> 
+               <li class=""><a href="https://migri.fi/en/residence-permit"> Residence permit </a></li> 
+               <li class=""><a href="https://migri.fi/en/first-residence-permit"> First residence permit </a></li> 
+               <li class=""><a href="https://migri.fi/en/studying-in-finland"> Studying in Finland </a></li> 
+               <li class="active" aria-current="page">Insurance</li> 
+              </ul> 
+             </nav> 
+            </div> 
+           </div> 
+          </div> 
+         </section> 
+        </div> 
+       </div> 
+      </div> 
+     </div> 
+     <div class="landingpage-layout"> 
+      <div class="portlet-layout row"> 
+       <div class="portlet-column col col-12" id="column-1"> 
+        <div class="portlet-dropzone portlet-column-content" id="layout-column_column-1"> 
+         <div class="portlet-boundary portlet-boundary_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_  portlet-static portlet-static-end portlet-borderless portlet-nested-portlets " id="p_p_id_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3_"> 
+          <span id="p_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3"></span> 
+          <section class="portlet" id="portlet_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3"> 
+           <a id="aineisto-com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3" name="aineisto-com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3" class="yja-anchor-elements"></a> 
+           <div class="portlet-content"> 
+            <div class="autofit-float autofit-row portlet-header "> 
+             <div class="autofit-col autofit-col-end"> 
+              <div class="autofit-section"> 
+              </div> 
+             </div> 
+            </div> 
+            <div class=" portlet-content-container"> 
+             <div class="portlet-body"> 
+              <div class="columns-2" id="_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3__main-content"> 
+               <div class="portlet-layout row"> 
+                <div class="col-md-4 portlet-column portlet-column-first" id="_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3__column-1"> 
+                 <div class="portlet-dropzone portlet-column-content portlet-column-content-first" id="layout-column__com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3__column-1"> 
+                  <div class="portlet-boundary portlet-boundary_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_  portlet-static portlet-static-end portlet-barebone portlet-navigation " id="p_p_id_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_EvX4qMMxVCAa_"> 
+                   <span id="p_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_EvX4qMMxVCAa"></span> 
+                   <section class="portlet" id="portlet_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_EvX4qMMxVCAa"> 
+                    <a id="aineisto-com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_EvX4qMMxVCAa" name="aineisto-com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_EvX4qMMxVCAa" class="yja-anchor-elements"></a> 
+                    <div class="portlet-content"> 
+                     <div class="autofit-float autofit-row portlet-header "> 
+                      <div class="autofit-col autofit-col-end"> 
+                       <div class="autofit-section"> 
+                       </div> 
+                      </div> 
+                     </div> 
+                     <div class=" portlet-content-container"> 
+                      <div class="portlet-body"> 
+                       <nav aria-label="Sub navigation"> 
+                        <div class="list-menu"> 
+                         <ul class="layouts level-1"> 
+                          <li class="lfr-nav-item open hasChild top active-li selected"><a class="lfr-nav-item open" href="https://migri.fi/en/residence-permit" aria-current="true">Residence permit</a><button aria-expanded="true" class="toggleVisibility icon-chevron-down"><span class="sr-only">Close submenu, Residence permit</span></button> 
+                           <ul class="layouts level-2"> 
+                            <li class="lfr-nav-item open hasChild top sub active-li selected"><a class="lfr-nav-item open" href="https://migri.fi/en/first-residence-permit" aria-current="true">First residence permit</a><button aria-expanded="true" class="toggleVisibility icon-chevron-down"><span class="sr-only">Close submenu, First residence permit</span></button> 
+                             <ul class="layouts level-3"> 
+                              <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/coming-to-finland-for-work">Coming to Finland for work</a></li> 
+                              <li class="lfr-nav-item open hasChild top sub active-li selected"><a class="lfr-nav-item open" href="https://migri.fi/en/studying-in-finland" aria-current="true">Studying in Finland</a><button aria-expanded="true" class="toggleVisibility icon-chevron-down"><span class="sr-only">Close submenu, Studying in Finland</span></button> 
+                               <ul class="layouts level-4"> 
+                                <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/residence-permit-application-for-studies">Residence permit application for studies</a></li> 
+                                <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/application-for-students-and-researchers-residence-permit-to-look-for-work">Application for students and researchers: residence permit to look for work</a></li> 
+                                <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/guide-for-students">Guide for students</a></li> 
+                                <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/study-place">Study place</a></li> 
+                                <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/income-requirement-for-students">Income requirement for students</a></li> 
+                                <li class="lfr-nav-item open selected active active-li"><a class="lfr-nav-item open selected active" href="https://migri.fi/en/insurance" aria-current="page">Insurance</a></li> 
+                                <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/tuition-fees">Tuition fees</a></li> 
+                                <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/customer-instructions-for-students">Customer instructions for students</a></li> 
+                                <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/the-processing-queue-of-students-residence-permit-applications">The processing queue of students’ residence permit applications</a></li> 
+                                <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/students-family-members">Student’s family members</a></li> 
+                                <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/mobility-notification-to-finland">Mobility notification to Finland</a></li> 
+                                <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/after-graduation">After graduation</a></li> 
+                                <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/for-educational-institutions">For educational institutions</a></li> 
+                                <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/frequently-asked-questions9">Frequently asked questions</a></li> 
+                               </ul></li> 
+                              <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/moving-to-finland-as-a-researcher">Moving to Finland as a researcher</a></li> 
+                              <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/moving-to-finland-to-be-with-a-family-member">Moving to Finland to be with a family member</a></li> 
+                              <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/d-visa">D visa</a></li> 
+                              <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/remigration">Remigration</a></li> 
+                              <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/coming-to-finland-on-other-grounds">Coming to Finland on other grounds</a></li> 
+                              <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/residence-permit-for-a-victim-of-human-trafficking">Residence permit for a victim of human trafficking</a></li> 
+                              <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/personal-identity-code">Personal identity code in connection with a residence permit</a></li> 
+                             </ul></li> 
+                            <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/extended-permit">Extended permit</a></li> 
+                            <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/permanent-residence-permits">Permanent residence permits</a></li> 
+                            <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/residence-permit-or-certificate-due-to-exploitation-by-employer">Residence permit or certificate due to exploitation by employer</a></li> 
+                            <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/residence-permit-types">Residence permit types</a></li> 
+                            <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/residence-permit-card">Residence permit card</a></li> 
+                            <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/post-decision-monitoring-of-residence-permits">Post-decision monitoring of residence permits</a></li> 
+                            <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/frequently-asked-questions2">Frequently asked questions</a></li> 
+                           </ul></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/eu-citizen">EU citizen</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/finnish-citizenship">Finnish citizenship</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/asylum-in-finland">Asylum in Finland</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/brexit/en">Brexit</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/travel-documents">Travel documents</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/income-requirement">Income requirement</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/incomes-register">Incomes register</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/processing-of-applications">Processing of applications</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/changes-and-supplementary-documents">Changes and supplementary documents</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/requests-and-certificates">Requests and certificates</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/legislation">Legislation</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/guidelines-for-application-of-law">Guidelines for application of law</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/informing-of-the-decision">Informing of the decision</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/appealing-a-decision">Appealing a decision</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/procedural-provisions">Procedural provisions</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/cancellation-of-a-permit">Cancellation of a permit</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/denial-of-admittance-or-stay-deportation-entry-ban">Denial of admittance or stay, deportation, entry ban</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/work-in-finland">Work in Finland</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/for-employers">For employers</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/travelling">Travelling</a></li> 
+                          <li class="lfr-nav-item"><a class="lfr-nav-item" href="https://migri.fi/en/visiting-finland">Visiting Finland</a></li> 
+                         </ul> 
+                        </div> 
+                       </nav> 
+                      </div> 
+                     </div> 
+                    </div> 
+                   </section> 
+                  </div> 
+                 </div> 
+                </div> 
+                <div class="col-md-8 portlet-column portlet-column-last" id="_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3__column-2"> 
+                 <div class="portlet-dropzone portlet-column-content portlet-column-content-last" id="layout-column__com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3__column-2"> 
+                  <div class="portlet-boundary portlet-boundary_com_liferay_journal_content_web_portlet_JournalContentPortlet_  portlet-static portlet-static-end portlet-barebone portlet-journal-content " id="p_p_id_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_JNydRvax7GSY_"> 
+                   <span id="p_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_JNydRvax7GSY"></span> 
+                   <section class="portlet" id="portlet_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_JNydRvax7GSY"> 
+                    <a id="aineisto-com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_JNydRvax7GSY" name="aineisto-com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_JNydRvax7GSY" class="yja-anchor-elements"></a> 
+                    <div class="portlet-content"> 
+                     <div class="autofit-float autofit-row portlet-header "> 
+                      <div class="autofit-col autofit-col-end"> 
+                       <div class="autofit-section"> 
+                        <div class="visible-interaction"> 
+                        </div> 
+                       </div> 
+                      </div> 
+                     </div> 
+                     <div class=" portlet-content-container"> 
+                      <div class="portlet-body"> 
+                       <div class="" data-fragments-editor-item-id="10109-5985135" data-fragments-editor-item-type="fragments-editor-mapped-item"> 
+                        <div class="journal-content-article " data-analytics-asset-id="5985133" data-analytics-asset-title="Vakuutukset (en)" data-analytics-asset-type="web-content"> 
+                         <h1 abp="2532">Students must have insurance</h1> 
+                         <p abp="2534">As a student, you must personally cover the costs if you become ill in Finland. In order to get a residence permit, you must take out private insurance that will cover your medical and drug expenses. The insurance you need depends on the duration of your studies in Finland. If you have a Kela card, a European Health Insurance Card (EHIC) or a UK Global Health Insurance Card (GHIC), you do not need to take out insurance.&nbsp;The card must be valid even after you have moved to Finland.</p> 
+                         <p abp="2535">Attach to your residence permit application</p> 
+                         <ul> 
+                          <li abp="2535">a certificate of insurance or</li> 
+                          <li abp="2535">a copy of your Kela card or</li> 
+                          <li abp="2535">a copy of your European Health Insurance Card (EHIC) or</li> 
+                          <li abp="2535">a copy of your UK Global Health Insurance Card (GHIC).</li> 
+                         </ul> 
+                         <h2 abp="2536">What kind of insurance do I need?</h2> 
+                         <p abp="2538">All insurance must meet the following requirements:</p> 
+                         <ul> 
+                          <li>The insurance excess may not be more than EUR 300.</li> 
+                          <li>If you stay in Finland for less than year, your insurance must be valid throughout your entire stay in Finland.</li> 
+                          <li>If your studies in Finland take longer than a year, your insurance must be valid without a break for at least one year. There cannot be any restrictions on the validity of your insurance. It must be valid throughout your entire stay in Finland. This means that the insurance cannot be a regular travel insurance that is only valid during trips that last a maximum of 90 days. 
+                           <ul> 
+                            <li>Renew your insurance if you are granted a residence permit for five years, for example, but your insurance is only valid for a year.</li> 
+                           </ul></li> 
+                          <li>Your insurance must be valid when you arrive in Finland.</li> 
+                         </ul> 
+                         <p>If your studies take at least two years, your insurance must cover pharmaceutical expenses up to EUR 40,000.</p> 
+                         <p>The required amount of insurance depends on the duration of your studies in Finland.</p> 
+                         <ul abp="2547"> 
+                          <li abp="2548"><p>If your studies take less than two years, your insurance must cover medical expenses up to EUR 120,000.</p></li> 
+                          <li abp="2553"><p>If your studies take at least two years, your insurance must cover pharmaceutical expenses up to EUR 40,000.</p></li> 
+                         </ul> 
+                         <p>In other words, the shorter your studies will take, the more extensive insurance coverage you will need. For example, an exchange student needs more comprehensive insurance than a degree student.</p> 
+                         <h2 abp="2557">Where can I take out acceptable insurance?</h2> 
+                         <p>When you are outside Finland, you can take out insurance from an insurance company in your home country. Alternatively, you may ask for suitable insurance from an international insurance company.</p> 
+                         <p>You can also look into insurance providers that offer international health insurance for students. For instance the following insurance companies offer students insurance contracts that meet the requirements for granting a residence permit for studies:</p> 
+                         <ul abp="2562"> 
+                          <li abp="2563">the French company Assurances Courtages et Services (ACS) (<a href="http://www.acs-ami.com" target="_blank" class="yja-external-link">www.acs-ami.com<span class="sr-only">Link to an external website</span><span class="sr-only">, Opens in a new tab</span></a>)</li> 
+                          <li abp="2565">Aon&nbsp;Student&nbsp;Insurance, whose parent company is the Brittish-American&nbsp;company Aon&nbsp;Corporation (<a href="https://www.aonstudentinsurance.com/" target="_blank" class="yja-external-link">https://www.aonstudentinsurance.com<span class="sr-only">Link to an external website</span><span class="sr-only">, Opens in a new tab</span></a>)</li> 
+                          <li abp="2567">the US company International Student Insurance (<a href="http://www.internationalstudentinsurance.com" target="_blank" class="yja-external-link">www.internationalstudentinsurance.com<span class="sr-only">Link to an external website</span><span class="sr-only">, Opens in a new tab</span></a>)</li> 
+                          <li abp="2569">the Swiss insurance company Swisscare – ESI Finland plan (<a href="https://swisscare.com/" target="_blank" class="yja-external-link">https://swisscare.com/<span class="sr-only">Link to an external website</span><span class="sr-only">, Opens in a new tab</span></a>)</li> 
+                         </ul> 
+                         <p>We assess each insurance policy and its terms and conditions individually when we process residence permit applications. The insurance policy must include at least the following information:</p> 
+                         <ul abp="2572"> 
+                          <li abp="2573">your personal details</li> 
+                          <li abp="2575">period of validity of insurance</li> 
+                          <li abp="2577">geographical area in which your insurance is valid</li> 
+                          <li abp="2579">insurance coverage</li> 
+                          <li abp="2581">insured amounts</li> 
+                          <li abp="2583"><p>amount of excess, or a mention that there is no excess.</p></li> 
+                         </ul> 
+                         <h2 abp="2585">European Health Insurance Card</h2> 
+                         <p>If you have a European Health Insurance Card (EHIC), you do not need to take out other insurance. By presenting the European Health Insurance Card, you can prove your right to necessary medical treatment in another EU or EEA country and in Switzerland.</p> 
+                         <p>Your card must be valid for the duration of your stay in Finland. Under EU legislation, you can access health care at the same cost and under the same conditions as people living permanently in Finland. With the card, you can get medical treatment if you become suddenly ill or have an accident. You can also get medical treatment if you have a chronic illness that requires medical attention. The card also gives access to necessary treatment during pregnancy and childbirth.</p> 
+                         <p>The European Health Insurance Card is recognised within the public health care services as well as by private doctors and hospitals that have signed a health insurance agreement. More information on the European Health Insurance Card can be found on the website of the <a href="http://ec.europa.eu/social/main.jsp?catId=559&amp;langId=en" rel="noopener noreferrer" target="_blank" class="yja-external-link">website of the European Commission&nbsp;(ec.europa.eu)<span class="sr-only">Link to an external website</span><span class="sr-only">, Opens in a new tab</span></a>.</p> 
+                         <div class="yja-meta-content-info"> 
+                         </div> 
+                        </div> 
+                       </div> 
+                      </div> 
+                     </div> 
+                    </div> 
+                   </section> 
+                  </div> 
+                  <div class="portlet-boundary portlet-boundary_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_  portlet-static portlet-static-end portlet-barebone portlet-asset-publisher " id="p_p_id_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_mhuLal9iWw3I_"> 
+                   <span id="p_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_mhuLal9iWw3I"></span> 
+                   <section class="portlet" id="portlet_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_mhuLal9iWw3I"> 
+                    <a id="aineisto-Customerbulletinsresidencepermits" name="aineisto-Customerbulletinsresidencepermits" class="yja-anchor-elements"></a> 
+                    <div class="portlet-content"> 
+                     <div class="autofit-float autofit-row portlet-header  use-custom-title "> 
+                      <div class="autofit-col autofit-col-expand"> 
+                       <h2 class="hed-section portlet-title portlet-title-text">Customer bulletins - residence permits</h2> 
+                      </div> 
+                      <div class="autofit-col autofit-col-end"> 
+                       <div class="autofit-section"> 
+                       </div> 
+                      </div> 
+                     </div> 
+                     <div class=" portlet-content-container"> 
+                      <div class="portlet-body"> 
+                       <div class="feed-item simple"> 
+                        <h3 class="feed-item__heading"><a title="Aliens Act amended on 12 June 2026, affects beneficiaries of temporary protection" href="/en/-/aliens-act-amended-on-12-june-2026-affects-beneficiaries-of-temporary-protection">Aliens Act amended on 12 June 2026, affects beneficiaries of temporary protection</a></h3> 
+                        <div class="meta"> 
+                         <span class="label"><span class="sr-only">Type:</span>Press release</span> 
+                         <span class="date"><span class="sr-only">Publication date:</span>12.6.2026 14.10</span> 
+                        </div> 
+                       </div> 
+                       <div class="feed-item simple"> 
+                        <h3 class="feed-item__heading"><a title="Aliens Act amended on 12 June 2026, affects removal from country and entry ban" href="/en/-/aliens-act-amended-on-12-june-2026-affects-removal-from-country-and-entry-ban">Aliens Act amended on 12 June 2026, affects removal from country and entry ban</a></h3> 
+                        <div class="meta"> 
+                         <span class="label"><span class="sr-only">Type:</span>Press release</span> 
+                         <span class="date"><span class="sr-only">Publication date:</span>12.6.2026 14.10</span> 
+                        </div> 
+                       </div> 
+                       <div class="feed-item simple"> 
+                        <h3 class="feed-item__heading"><a title="Are you planning to travel out of Finland during the summer?" href="/en/-/are-you-planning-to-travel-out-of-finland-during-the-summer-1">Are you planning to travel out of Finland during the summer?</a></h3> 
+                        <div class="meta"> 
+                         <span class="label"><span class="sr-only">Type:</span>Press release</span> 
+                         <span class="date"><span class="sr-only">Publication date:</span>18.5.2026 11.10</span> 
+                        </div> 
+                       </div> 
+                       <div class="feed-item simple"> 
+                        <h3 class="feed-item__heading"><a title="Current information about processing of asylum applications submitted by Iranians" href="/en/-/current-information-about-processing-of-asylum-applications-submitted-by-iranians">Current information about processing of asylum applications submitted by Iranians</a></h3> 
+                        <div class="meta"> 
+                         <span class="label"><span class="sr-only">Type:</span>Press release</span> 
+                         <span class="date"><span class="sr-only">Publication date:</span>15.4.2026 13.00</span> 
+                        </div> 
+                       </div> 
+                       <div class="feed-item simple"> 
+                        <h3 class="feed-item__heading"><a title="Decision-making on Iranian asylum applications partly paused" href="/en/-/decision-making-on-iranian-asylum-applications-partly-paused">Decision-making on Iranian asylum applications partly paused</a></h3> 
+                        <div class="meta"> 
+                         <span class="label"><span class="sr-only">Type:</span>Press release</span> 
+                         <span class="date"><span class="sr-only">Publication date:</span>5.2.2026 11.00</span> 
+                        </div> 
+                       </div> 
+                      </div> 
+                     </div> 
+                    </div> 
+                   </section> 
+                  </div> 
+                  <div class="portlet-boundary portlet-boundary_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_  portlet-static portlet-static-end portlet-borderless portlet-nested-portlets " id="p_p_id_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm_"> 
+                   <span id="p_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm"></span> 
+                   <section class="portlet" id="portlet_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm"> 
+                    <a id="aineisto-com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm" name="aineisto-com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm" class="yja-anchor-elements"></a> 
+                    <div class="portlet-content"> 
+                     <div class="autofit-float autofit-row portlet-header "> 
+                      <div class="autofit-col autofit-col-end"> 
+                       <div class="autofit-section"> 
+                       </div> 
+                      </div> 
+                     </div> 
+                     <div class=" portlet-content-container"> 
+                      <div class="portlet-body"> 
+                       <div class="columns-1-2" id="_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm__main-content"> 
+                        <div class="portlet-layout row"> 
+                         <div class="col-md-12 portlet-column portlet-column-only" id="_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm__column-1"> 
+                          <div class="empty portlet-dropzone portlet-column-content portlet-column-content-only" id="layout-column__com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm__column-1"></div> 
+                         </div> 
+                        </div> 
+                        <div class="portlet-layout row"> 
+                         <div class="col-md-4 portlet-column portlet-column-first" id="_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm__column-2"> 
+                          <div class="empty portlet-dropzone portlet-column-content portlet-column-content-first" id="layout-column__com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm__column-2"></div> 
+                         </div> 
+                         <div class="col-md-8 portlet-column portlet-column-last" id="_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm__column-3"> 
+                          <div class="empty portlet-dropzone portlet-column-content portlet-column-content-last" id="layout-column__com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm__column-3"></div> 
+                         </div> 
+                        </div> 
+                       </div> 
+                      </div> 
+                     </div> 
+                    </div> 
+                   </section> 
+                  </div> 
+                 </div> 
+                </div> 
+               </div> 
+              </div> 
+             </div> 
+            </div> 
+           </div> 
+          </section> 
+         </div> 
+        </div> 
+       </div> 
+      </div> 
+      <div class="portlet-layout row"> 
+       <div class="portlet-column portlet-column-first col col-12 col-md-8" id="column-2" role="main"> 
+        <span id="content-main"></span> 
+        <div class="empty portlet-dropzone portlet-column-content portlet-column-content-first" id="layout-column_column-2"></div> 
+       </div> 
+       <div class="portlet-column portlet-column-last col col-12 col-md-4" id="column-3" role="complementary"> 
+        <div class="empty portlet-dropzone portlet-column-content portlet-column-content-last" id="layout-column_column-3"></div> 
+       </div> 
+      </div> 
+      <div class="portlet-layout row"> 
+       <div class="portlet-column col col-12" id="column-4"> 
+        <div class="empty portlet-dropzone portlet-column-content" id="layout-column_column-4"></div> 
+       </div> 
+      </div> 
+     </div> 
+    </div> 
+    <form action="#" aria-hidden="true" class="hide" id="hrefFm" method="post" name="hrefFm"> 
+     <span></span> 
+     <button hidden="" type="submit">Hidden</button> 
+    </form> 
+    <div class="rns-embed"> 
+     <div class="portlet-boundary portlet-boundary_com_liferay_journal_content_web_portlet_JournalContentPortlet_  portlet-static portlet-static-end portlet-barebone portlet-journal-content " id="p_p_id_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_5844369_rs_"> 
+      <span id="p_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_5844369_rs"></span> 
+      <section class="portlet" id="portlet_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_5844369_rs"> 
+       <a id="aineisto-com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_5844369_rs" name="aineisto-com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_5844369_rs" class="yja-anchor-elements"></a> 
+       <div class="portlet-content"> 
+        <div class="autofit-float autofit-row portlet-header "> 
+         <div class="autofit-col autofit-col-end"> 
+          <div class="autofit-section"> 
+           <div class="visible-interaction"> 
+           </div> 
+          </div> 
+         </div> 
+        </div> 
+        <div class=" portlet-content-container"> 
+         <div class="portlet-body"> 
+          <div class="" data-fragments-editor-item-id="10109-87731106" data-fragments-editor-item-type="fragments-editor-mapped-item"> 
+           <div class="journal-content-article " data-analytics-asset-id="87731104" data-analytics-asset-title="React and share" data-analytics-asset-type="web-content"> 
+            <div class="rns">
+              &nbsp; 
+            </div> 
+             
+            <div class="yja-meta-content-info"> 
+            </div> 
+           </div> 
+          </div> 
+         </div> 
+        </div> 
+       </div> 
+      </section> 
+     </div> 
+    </div> 
+   </section> 
+  </div> 
+  <footer id="footer"> 
+   <div class="portlet-boundary portlet-boundary_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsFooter_WAR_fiyjasitetemplatesettingsweb_  portlet-static portlet-static-end portlet-barebone yja-site-template-settings-footer-portlet " id="p_p_id_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsFooter_WAR_fiyjasitetemplatesettingsweb_INSTANCE_sitetemplateFooter_"> 
+    <span id="p_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsFooter_WAR_fiyjasitetemplatesettingsweb_INSTANCE_sitetemplateFooter"></span> 
+    <section class="portlet" id="portlet_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsFooter_WAR_fiyjasitetemplatesettingsweb_INSTANCE_sitetemplateFooter"> 
+     <a id="aineisto-fi_yja_sitetemplatesettings_web_SiteTemplateSettingsFooter_WAR_fiyjasitetemplatesettingsweb_INSTANCE_sitetemplateFooter" name="aineisto-fi_yja_sitetemplatesettings_web_SiteTemplateSettingsFooter_WAR_fiyjasitetemplatesettingsweb_INSTANCE_sitetemplateFooter" class="yja-anchor-elements"></a> 
+     <div class="portlet-content"> 
+      <div class="autofit-float autofit-row portlet-header "> 
+       <div class="autofit-col autofit-col-end"> 
+        <div class="autofit-section"> 
+        </div> 
+       </div> 
+      </div> 
+      <div class=" portlet-content-container"> 
+       <div class="portlet-body"> 
+        <div class="container footer-main-content"> 
+         <div class="row"> 
+          <div class="col col-md-4"> 
+           <div> 
+            <h4 abp="1985"><span abp="1986" lang="EN-GB">Permits and citizenship</span></h4> 
+            <ul abp="1987"> 
+             <li abp="1988"><a abp="2008" href="/residence-permit">Residence permit</a></li> 
+             <li abp="1990"><a abp="2009" href="/eu-citizen">Registration of the right of residence of an EU citizen or a family member</a></li> 
+             <li abp="1991"><a href="/finnish-citizenship">Finnish citizenship</a></li> 
+             <li abp="1992"><a href="/asylum-in-finland">Asylum</a></li> 
+             <li abp="1993"><a href="/travel-documents">Travel documents</a></li> 
+            </ul> 
+            <p abp="1994">&nbsp;</p> 
+            <div class="yja-meta-content-info"> 
+            </div> 
+           </div> 
+          </div> 
+          <div class="col col-md-4"> 
+           <div> 
+            <h4 abp="1638"><span abp="1639" lang="EN-GB">Services</span></h4> 
+            <ul abp="1640"> 
+             <li abp="1641"><a abp="1642" href="/submit-your-application-in-the-e-service" target="_blank">E-service</a></li> 
+             <li abp="1643"><a abp="1644" href="/book-an-appointment" target="_blank">Book an appointment at a service point</a></li> 
+             <li abp="1646"><a abp="1647" href="/check-the-processing-time-of-your-application">Processing times</a></li> 
+             <li abp="1648"><a abp="1649" href="/processing-fees-and-payment-methods">Processing fees</a></li> 
+             <li abp="1650"><a abp="1651" href="/requests-and-certificates">Requests and certificates</a></li> 
+             <li abp="1652"><a abp="1653" href="/faq">Frequently asked questions</a></li> 
+             <li abp="1654"><a abp="1655" href="/instructions">Instructions</a></li> 
+            </ul> 
+            <p abp="1657">&nbsp;</p> 
+            <div class="yja-meta-content-info"> 
+            </div> 
+           </div> 
+          </div> 
+          <div class="col col-md-4"> 
+           <div> 
+            <h4 abp="2451"><span abp="2452" lang="EN-GB">Finnish Immigration Service</span></h4> 
+            <ul abp="2453"> 
+             <li abp="2454"><a href="/newsroom">Newsroom</a></li> 
+             <li abp="2457"><a abp="2458" href="https://tilastot.migri.fi/index.html#decisions?l=en" target="_blank" class="yja-external-link">Statistics</a></li> 
+             <li abp="2459"><a abp="2460" href="/glossary">Glossary</a></li> 
+             <li abp="2461"><a abp="2462" href="/about-the-finnish-immigration-service">About the Finnish Immigration Service</a></li> 
+             <li abp="2461"><a href="https://migri.fi/en/data-protection" target="">Data protection</a></li> 
+             <li abp="2463"><a abp="2464" href="/vacant-positions-and-traineeships">Vacancies</a></li> 
+             <li abp="2467"><a abp="2468" href="/contact-information">Contact information</a></li> 
+            </ul> 
+            <div class="yja-meta-content-info"> 
+            </div> 
+           </div> 
+          </div> 
+          <div class="col col-md-4"> 
+           <div> 
+            <style type="text/css">
+    .icons__direction--rtl {
+        text-align: right;
+    }
+    .icons__direction--center {
+        text-align: center;
+    }
+    .icons__direction--ltr {
+        text-align: left;
+    }
+</style> 
+            <ul class="list-unstyled list-inline icons__direction--rtl ml-0"> 
+             <li class="list-inline-item social-icon custom"><a href="https://fi-fi.facebook.com/Maahanmuuttovir/" title="Facebook" target="_blank" class="yja-external-link"> 
+               <svg xmlns="http://www.w3.org/2000/svg" width="10%" viewBox="0 0 512 512"> 
+                <path fill="#003da5" d="M504 256C504 119 393 8 256 8S8 119 8 256c0 123.78 90.69 226.38 209.25 245V327.69h-63V256h63v-54.64c0-62.15 37-96.48 93.67-96.48 27.14 0 55.52 4.84 55.52 4.84v61h-31.28c-30.8 0-40.41 19.12-40.41 38.73V256h68.78l-11 71.69h-57.78V501C413.31 482.38 504 379.78 504 256z"></path> 
+               </svg> <span class="sr-only">Facebook</span> </a></li> 
+             <li class="list-inline-item social-icon custom"><a href="https://twitter.com/Maahanmuuttovir" title="X" target="_blank" class="yja-external-link"> 
+               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"> 
+                <!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--> 
+                <path fill="#003da5" d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"></path> 
+               </svg> <span class="sr-only">X</span> </a></li> 
+             <li class="list-inline-item social-icon custom"><a href="https://fi.linkedin.com/company/maahanmuuttovirasto" title="LinkedIn" target="_blank" class="yja-external-link"> 
+               <svg xmlns="http://www.w3.org/2000/svg" width="10%" viewBox="0 0 448 512"> 
+                <path fill="#003da5" d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"></path> 
+               </svg> <span class="sr-only">LinkedIn</span> </a></li> 
+             <li class="list-inline-item social-icon custom"><a href="https://www.youtube.com/channel/UCGvHfyQfBlRxmYCKAQr7d_A" title="YouTube" target="_blank" class="yja-external-link"> 
+               <svg xmlns="http://www.w3.org/2000/svg" width="10%" viewBox="0 0 576 512"> 
+                <path fill="#003da5" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z"></path> 
+               </svg> <span class="sr-only">YouTube</span> </a></li> 
+             <li class="list-inline-item social-icon custom"><a href="https://www.instagram.com/maahanmuuttovir" title="Instagram" target="_blank" class="yja-external-link"> 
+               <svg xmlns="http://www.w3.org/2000/svg" width="10%" viewBox="0 0 448 512"> 
+                <path fill="#003da5" d="M224,202.66A53.34,53.34,0,1,0,277.36,256,53.38,53.38,0,0,0,224,202.66Zm124.71-41a54,54,0,0,0-30.41-30.41c-21-8.29-71-6.43-94.3-6.43s-73.25-1.93-94.31,6.43a54,54,0,0,0-30.41,30.41c-8.28,21-6.43,71.05-6.43,94.33S91,329.26,99.32,350.33a54,54,0,0,0,30.41,30.41c21,8.29,71,6.43,94.31,6.43s73.24,1.93,94.3-6.43a54,54,0,0,0,30.41-30.41c8.35-21,6.43-71.05,6.43-94.33S357.1,182.74,348.75,161.67ZM224,338a82,82,0,1,1,82-82A81.9,81.9,0,0,1,224,338Zm85.38-148.3a19.14,19.14,0,1,1,19.13-19.14A19.1,19.1,0,0,1,309.42,189.74ZM400,32H48A48,48,0,0,0,0,80V432a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V80A48,48,0,0,0,400,32ZM382.88,322c-1.29,25.63-7.14,48.34-25.85,67s-41.4,24.63-67,25.85c-26.41,1.49-105.59,1.49-132,0-25.63-1.29-48.26-7.15-67-25.85s-24.63-41.42-25.85-67c-1.49-26.42-1.49-105.61,0-132,1.29-25.63,7.07-48.34,25.85-67s41.47-24.56,67-25.78c26.41-1.49,105.59-1.49,132,0,25.63,1.29,48.33,7.15,67,25.85s24.63,41.42,25.85,67.05C384.37,216.44,384.37,295.56,382.88,322Z"></path> 
+               </svg> <span class="sr-only">Instagram</span> </a></li> 
+            </ul> 
+           </div> 
+          </div> 
+         </div> 
+        </div> 
+        <div class="footer-bottom-bar"> 
+         <div class="container"> 
+          <div class="d-block"> 
+           <div> 
+            <div class="footer-bottom-columns"> 
+             <div class="footer-bottom-col footer-bottom-col-logo" aria-label="Maahanmuuttovirasto"> 
+              <img src="/documents/5202425/12394585/MIGRI_logo_WHITE_opt.svg/d988a274-0a8a-f75c-c2c0-9fb3b1f925c3?t=1551072685000" alt="Maahanmuuttovirasto"> 
+             </div> 
+             <div class="footer-bottom-col footer-bottom-col-links"> 
+              <ul> 
+               <li><a href="/en/about-this-site">About this site</a></li> 
+               <li><a href="/en/feedback">Send feedback</a></li> 
+               <li><a href="/en/sitemap">Sitemap</a></li> 
+              </ul> 
+             </div> 
+             <div class="footer-bottom-col footer-bottom-col-last"> 
+              <div class="copy">
+                © Maahanmuuttovirasto 2026 
+              </div> 
+             </div> 
+            </div> 
+           </div> 
+          </div> 
+         </div> 
+        </div> 
+       </div> 
+      </div> 
+     </div> 
+    </section> 
+   </div> 
+  </footer> 
+  <nav class="sort-pages modify-pages yja-mobile-navigation" id="mmenu" aria-label="Mobile main navigation" data-menu-position="right"> 
+   <div class="yja-mobile-navigation__content"> 
+    <div class="yja-mobile-navigation__toolbar"> 
+     <button class="yja-mobile-navigation__button yja-mobile-navigation__button--close" id="yjaMenuButtonClose"> <span class="sr-only">Close menu</span> 
+      <svg class="lexicon-icon lexicon-icon-times" role="presentation" viewBox="0 0 512 512"> 
+        
+      <g>
+	<path class="lexicon-icon-outline" d="M300.4,256L467,89.4c29.6-29.6-14.8-74.1-44.4-44.4L256,211.6L89.4,45C59.8,15.3,15.3,59.8,45,89.4L211.6,256L45,422.6 c-29.7,29.7,14.7,74.1,44.4,44.4L256,300.4L422.6,467c29.7,29.7,74.1-14.7,44.4-44.4L300.4,256z"></path>
+</g></svg> </button> 
+    </div> 
+    <div class="yja-mobile-navigation__tree"> 
+     <ul class="nav mm-listview" id="mainMenubar"> 
+      <li class="mm-listitem level-1" id="mobile-layout_387"> 
+       <div class="nav-item__container"> 
+        <a href="https://migri.fi/en/home" class="mm-listitem__text"> <span>Home</span> </a> 
+       </div></li> 
+      <li class="mm-listitem level-1" id="mobile-layout_392"> 
+       <div class="nav-item__container"> 
+        <a href="https://migri.fi/en/i-want-to-apply" class="mm-listitem__text has-btn"> <span>I want to apply</span> </a> 
+        <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false"> <span class="sr-only">I want to apply yja.nav.submenu.title.end</span> 
+         <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+           
+         <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+       </div> 
+       <ul class="child-menu mm-listview " id="child_menu_392" aria-label="I want to apply - submenu"> 
+        <li class="mm-listitem level-2" id="mobile-layout_569"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/i-want-to-come-to-finland" class="mm-listitem__text">I want to come to Finland</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_570"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/i-am-visiting-finland" class="mm-listitem__text">I am visiting Finland</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_405"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/i-want-a-residence-permit" class="mm-listitem__text">I want a residence permit</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2661"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/i-want-to-fast-track-my-application" class="mm-listitem__text">I want to fast-track my application</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_416"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/i-want-to-extend-my-residence-permit" class="mm-listitem__text">I want to extend my residence permit</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_407"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/i-am-an-eu-citizen-or-a-family-member" class="mm-listitem__text has-btn">I am an EU citizen or an EU citizen's family member</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_407_5"> <span class="sr-only">I am an EU citizen or an EU citizen's family member - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_407" aria-label="I am an EU citizen or an EU citizen's family member - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_410"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/i-am-an-eu-citizen" class="mm-listitem__text">I am an EU citizen</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_411"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/i-am-a-family-member-of-an-eu-citizen" class="mm-listitem__text">I am a family member of an EU citizen</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1257"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/i-want-a-permanent-right-of-residence" class="mm-listitem__text">I want a permanent right of residence</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_413"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/i-am-a-nordic-citizen" class="mm-listitem__text">I am a Nordic citizen</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_417"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/i-want-to-become-a-finnish-citizen" class="mm-listitem__text">I want to become a Finnish citizen</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1891"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/i-want-to-apply/brexit" class="mm-listitem__text">Brexit</a> 
+         </div></li> 
+       </ul></li> 
+      <li class="mm-listitem level-1" id="mobile-layout_393"> 
+       <div class="nav-item__container"> 
+        <a href="https://migri.fi/en/after-applying" class="mm-listitem__text"> <span>After applying</span> </a> 
+       </div></li> 
+      <li aria-current="true" class="mm-listitem mm-listitem_selected yja-mobile-navigation--open level-1" id="mobile-layout_394"> 
+       <div class="nav-item__container"> 
+        <a href="https://migri.fi/en/permits-and-citizenship" class="mm-listitem__text has-btn"> <span>Permits and citizenship</span> </a> 
+        <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="true"> <span class="sr-only">Permits and citizenship yja.nav.submenu.title.end</span> 
+         <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+           
+         <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+       </div> 
+       <ul class="child-menu mm-listview " id="child_menu_394" aria-label="Permits and citizenship - submenu"> 
+        <li aria-current="true" class="mm-listitem mm-listitem_selected yja-mobile-navigation--open level-2" id="mobile-layout_574"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/residence-permit" class="mm-listitem__text has-btn">Residence permit</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="true" controls="child_menu_574_0"> <span class="sr-only">Residence permit - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_574" aria-label="Residence permit - submenu"> 
+          <li aria-current="true" class="mm-listitem mm-listitem_selected yja-mobile-navigation--open level-3" id="mobile-layout_575"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/first-residence-permit" class="mm-listitem__text has-btn">First residence permit</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="true" controls="child_menu_575_0"> <span class="sr-only">First residence permit - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_575" aria-label="First residence permit - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_576"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/coming-to-finland-for-work" class="mm-listitem__text has-btn">Coming to Finland for work</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_576_0"> <span class="sr-only">Coming to Finland for work - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_576" aria-label="Coming to Finland for work - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_579"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/coming-to-finland-for-work/applications" class="mm-listitem__text has-btn">Applications</a> 
+                <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_579_0"> <span class="sr-only">Applications - submenu</span> 
+                 <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                   
+                 <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+               </div> 
+               <ul class="child-menu mm-listview " id="child_menu_579" aria-label="Applications - submenu"> 
+                <li class="mm-listitem level-6" id="mobile-layout_625"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/residence-permit-for-an-employed-person" class="mm-listitem__text has-btn">Residence permit for an employed person</a> 
+                  <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_625_0"> <span class="sr-only">Residence permit for an employed person - submenu</span> 
+                   <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                     
+                   <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+                 </div> 
+                 <ul class="child-menu mm-listview " id="child_menu_625" aria-label="Residence permit for an employed person - submenu"> 
+                  <li class="mm-listitem level-7" id="mobile-layout_2368"> 
+                   <div class="nav-item__container"> 
+                    <a href="https://migri.fi/en/guide-for-employed-persons" class="mm-listitem__text">Guide for employed persons</a> 
+                   </div></li> 
+                 </ul></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_619"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/entrepreneur" class="mm-listitem__text">Entrepreneur</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_1300"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/start-up-entrepreneur" class="mm-listitem__text">Start-up entrepreneur</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_580"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/specialist" class="mm-listitem__text">Specialist</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_613"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/eu-blue-card" class="mm-listitem__text">EU Blue Card</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_1596"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/research-completed-in-finland" class="mm-listitem__text">Research completed in Finland</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_611"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/degree-completed-in-finland" class="mm-listitem__text">Degree completed in Finland</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_1075"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/residence-permit-to-look-for-work" class="mm-listitem__text">Application for students and researchers: residence permit to look for work</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_591"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/internship" class="mm-listitem__text">Internship</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_1150"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/seasonal-work" class="mm-listitem__text has-btn">Seasonal work</a> 
+                  <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1150_9"> <span class="sr-only">Seasonal work - submenu</span> 
+                   <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                     
+                   <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+                 </div> 
+                 <ul class="child-menu mm-listview " id="child_menu_1150" aria-label="Seasonal work - submenu"> 
+                  <li class="mm-listitem level-7" id="mobile-layout_1151"> 
+                   <div class="nav-item__container"> 
+                    <a href="https://migri.fi/en/residence-permit-for-seasonal-work" class="mm-listitem__text">Residence permit for seasonal work</a> 
+                   </div></li> 
+                  <li class="mm-listitem level-7" id="mobile-layout_1152"> 
+                   <div class="nav-item__container"> 
+                    <a href="https://migri.fi/en/seasonal-work-certificate" class="mm-listitem__text">Seasonal work certificate</a> 
+                   </div></li> 
+                  <li class="mm-listitem level-7" id="mobile-layout_1432"> 
+                   <div class="nav-item__container"> 
+                    <a href="https://migri.fi/en/what-counts-as-seasonal-work" class="mm-listitem__text">What counts as seasonal work?</a> 
+                   </div></li> 
+                  <li class="mm-listitem level-7" id="mobile-layout_2973"> 
+                   <div class="nav-item__container"> 
+                    <a href="https://migri.fi/en/accommodation-for-seasonal-workers" class="mm-listitem__text">Accommodation for seasonal workers</a> 
+                   </div></li> 
+                  <li class="mm-listitem level-7" id="mobile-layout_1973"> 
+                   <div class="nav-item__container"> 
+                    <a href="https://migri.fi/en/seasonal-work-adding-new-employer" class="mm-listitem__text">Adding an employer to a seasonal work permit</a> 
+                   </div></li> 
+                  <li class="mm-listitem level-7" id="mobile-layout_1976"> 
+                   <div class="nav-item__container"> 
+                    <a href="https://migri.fi/en/returning-seasonal-workers" class="mm-listitem__text">Returning seasonal workers</a> 
+                   </div></li> 
+                  <li class="mm-listitem level-7" id="mobile-layout_1930"> 
+                   <div class="nav-item__container"> 
+                    <a href="https://migri.fi/en/instructions-for-seasonal-workers" class="mm-listitem__text">Instructions for seasonal workers</a> 
+                   </div></li> 
+                  <li class="mm-listitem level-7" id="mobile-layout_2027"> 
+                   <div class="nav-item__container"> 
+                    <a href="https://migri.fi/en/frequently-asked-questions12" class="mm-listitem__text">Frequently asked questions</a> 
+                   </div></li> 
+                 </ul></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_587"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/employee-of-a-religious-community" class="mm-listitem__text">Employee of a religious community</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_593"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/working-holiday/en" class="mm-listitem__text">Working holiday</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_596"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/internal-transfer-within-a-company" class="mm-listitem__text">Internal transfer within a company</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_1295"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/intra-corporate-transfer-mobile-ict-" class="mm-listitem__text">Intra-corporate transfer (Mobile ICT)</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_1593"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/mobility-notification-for-persons-with-ict-residence-permit" class="mm-listitem__text">Mobility notification for persons with ICT residence permit</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_599"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/work-in-the-field-of-culture-or-arts" class="mm-listitem__text">Work in the field of culture or arts</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_600"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/work-in-the-field-of-mass-media" class="mm-listitem__text">Work in the field of mass media</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_601"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/international-organisations-and-cooperation-between-states" class="mm-listitem__text">International organisations and cooperation between states</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_605"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/preparation-of-a-company-s-arrival-in-finland-and-supervision-of-orders" class="mm-listitem__text">Preparation of a company’s arrival in Finland and supervision of orders</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_607"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/delivery-of-a-machine-or-a-system" class="mm-listitem__text">Delivery of a machine or a system</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_609"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/athlete-coach-or-trainer" class="mm-listitem__text">Athlete, coach or trainer</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_615"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/top-and-middle-management" class="mm-listitem__text">Top and middle management</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_621"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/au-pair/en" class="mm-listitem__text">Au pair</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_1781"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/volunteering" class="mm-listitem__text">Volunteering</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_2630"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/consultant" class="mm-listitem__text">Consultant</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_2631"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/visiting-teacher-lecturer-or-instructor" class="mm-listitem__text">Visiting teacher, lecturer or instructor</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_2632"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/intergovernmental-agreement" class="mm-listitem__text">Intergovernmental agreement</a> 
+                 </div></li> 
+               </ul></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2290"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/fast-track" class="mm-listitem__text has-btn">Fast track</a> 
+                <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2290_1"> <span class="sr-only">Fast track - submenu</span> 
+                 <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                   
+                 <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+               </div> 
+               <ul class="child-menu mm-listview " id="child_menu_2290" aria-label="Fast track - submenu"> 
+                <li class="mm-listitem level-6" id="mobile-layout_2308"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/fast-track-for-specialist" class="mm-listitem__text">Fast track for specialist</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_2309"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/fast-track-for-eu-blue-card" class="mm-listitem__text">Fast track for EU Blue Card</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_2310"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/fast-track-for-specialist-and-manager-ict" class="mm-listitem__text">Fast track for specialist and manager (ICT)</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_2408"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/fast-track-for-top-and-middle-management" class="mm-listitem__text">Fast track for top and middle management</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_2311"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/fast-track-for-startup-entrepreneur" class="mm-listitem__text">Fast track for startup entrepreneur</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_2312"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/fast-track-for-family-member" class="mm-listitem__text">Fast track for family member</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_2318"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/fast-track-intsructions-for-employers" class="mm-listitem__text">Fast track intsructions for employers</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_2330"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/frequently-asked-questions6" class="mm-listitem__text">Frequently asked questions</a> 
+                 </div></li> 
+               </ul></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_633"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/seeking-work-after-graduation-or-completion-of-research" class="mm-listitem__text">Seeking work after graduation or completion of research</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_652"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/working-in-finland/income-requirement" class="mm-listitem__text">Income requirement</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2022"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/frequently-asked-questions7" class="mm-listitem__text">Frequently asked questions</a> 
+               </div></li> 
+             </ul></li> 
+            <li aria-current="true" class="mm-listitem mm-listitem_selected yja-mobile-navigation--open level-4" id="mobile-layout_741"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/studying-in-finland" class="mm-listitem__text has-btn">Studying in Finland</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="true" controls="child_menu_741_1"> <span class="sr-only">Studying in Finland - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_741" aria-label="Studying in Finland - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_742"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/residence-permit-application-for-studies" class="mm-listitem__text">Residence permit application for studies</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2256"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/application-for-students-and-researchers-residence-permit-to-look-for-work" class="mm-listitem__text">Application for students and researchers: residence permit to look for work</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2364"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/guide-for-students" class="mm-listitem__text">Guide for students</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_743"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/study-place" class="mm-listitem__text">Study place</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_746"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/income-requirement-for-students" class="mm-listitem__text">Income requirement for students</a> 
+               </div></li> 
+              <li aria-current="page" class="mm-listitem mm-listitem_selected yja-mobile-navigation--open level-5" id="mobile-layout_744"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/insurance" class="mm-listitem__text">Insurance</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_745"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/tuition-fees" class="mm-listitem__text">Tuition fees</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_1914"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/customer-instructions-for-students" class="mm-listitem__text has-btn">Customer instructions for students</a> 
+                <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1914_7"> <span class="sr-only">Customer instructions for students - submenu</span> 
+                 <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                   
+                 <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+               </div> 
+               <ul class="child-menu mm-listview " id="child_menu_1914" aria-label="Customer instructions for students - submenu"> 
+                <li class="mm-listitem level-6" id="mobile-layout_2141"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/instructions-for-degree-students-with-tuition-fees" class="mm-listitem__text">Instructions for degree students with tuition fees</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_2142"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/instructions-for-degree-students-without-tuition-fees" class="mm-listitem__text">Instructions for degree students without tuition fees</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_2139"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/instructions-for-exchange-students" class="mm-listitem__text">Instructions for exchange students</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_2140"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/instructions-for-high-school-exchange-students" class="mm-listitem__text">Instructions for high school exchange students</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_2143"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/instructions-for-students-applying-for-an-extended-permit" class="mm-listitem__text">Instructions for students applying for an extended permit</a> 
+                 </div></li> 
+               </ul></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2231"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/the-processing-queue-of-students-residence-permit-applications" class="mm-listitem__text">The processing queue of students’ residence permit applications</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2371"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/students-family-members" class="mm-listitem__text">Student’s family members</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_1378"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/mobility-notification-to-finland" class="mm-listitem__text">Mobility notification to Finland</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_747"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/after-graduation" class="mm-listitem__text">After graduation</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_748"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/for-educational-institutions" class="mm-listitem__text has-btn">For educational institutions</a> 
+                <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_748_12"> <span class="sr-only">For educational institutions - submenu</span> 
+                 <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                   
+                 <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+               </div> 
+               <ul class="child-menu mm-listview " id="child_menu_748" aria-label="For educational institutions - submenu"> 
+                <li class="mm-listitem level-6" id="mobile-layout_749"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/role-of-the-educational-institution-in-a-residence-permit-process" class="mm-listitem__text">Role of the educational institution in a residence permit process</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_750"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/tuition-fees-and-contents-of-a-residence-permit-card" class="mm-listitem__text">Tuition fees and contents of a residence permit card</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_752"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/working-and-internships-during-studies" class="mm-listitem__text">Working and internships during studies</a> 
+                 </div></li> 
+               </ul></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2024"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/frequently-asked-questions9" class="mm-listitem__text">Frequently asked questions</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2346"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/moving-to-finland-as-a-researcher" class="mm-listitem__text has-btn">Moving to Finland as a researcher</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2346_2"> <span class="sr-only">Moving to Finland as a researcher - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_2346" aria-label="Moving to Finland as a researcher - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_584"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/researcher" class="mm-listitem__text">Residence permit for a researcher</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2144"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/instructions-for-scientific-researchers" class="mm-listitem__text">Instructions for scientific researchers</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2352"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/residence-permit-to-look-for-work1" class="mm-listitem__text">Application for students and researchers: residence permit to look for work</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2353"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/research-work-finished-in-finland1" class="mm-listitem__text">Research work finished in Finland</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_1386"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/mobility-notification-for-researchers" class="mm-listitem__text">Mobility notification for researchers</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_656"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/moving-to-finland-to-be-with-a-family-member" class="mm-listitem__text has-btn">Moving to Finland to be with a family member</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_656_3"> <span class="sr-only">Moving to Finland to be with a family member - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_656" aria-label="Moving to Finland to be with a family member - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_658"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/my-spouse-is-in-finland" class="mm-listitem__text has-btn">My spouse is in Finland</a> 
+                <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_658_0"> <span class="sr-only">My spouse is in Finland - submenu</span> 
+                 <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                   
+                 <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+               </div> 
+               <ul class="child-menu mm-listview " id="child_menu_658" aria-label="My spouse is in Finland - submenu"> 
+                <li class="mm-listitem level-6" id="mobile-layout_668"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/spouse-in-finland-with-a-residence-permit" class="mm-listitem__text">Spouse in Finland with a residence permit</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_669"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/cohabiting-partner-in-finland-with-a-residence-permit" class="mm-listitem__text">Cohabiting partner in Finland with a residence permit</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_670"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/spouse-in-finland-on-the-basis-of-international-or-temporary-protection" class="mm-listitem__text">Spouse in Finland on the basis of international or temporary protection</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_672"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/cohabiting-partner-in-finland-on-the-basis-of-international-or-temporary-protection" class="mm-listitem__text">Cohabiting partner in Finland on the basis of international or temporary protection</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_674"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/spouse-is-a-finnish-citizen" class="mm-listitem__text">Spouse is a Finnish citizen</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_675"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/cohabiting-partner-is-a-finnish-citizen" class="mm-listitem__text">Cohabiting partner is a Finnish citizen</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_676"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/established-relationship" class="mm-listitem__text">Established relationship</a> 
+                 </div></li> 
+               </ul></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_677"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/my-child-is-in-finland" class="mm-listitem__text has-btn">My child is in Finland</a> 
+                <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_677_1"> <span class="sr-only">My child is in Finland - submenu</span> 
+                 <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                   
+                 <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+               </div> 
+               <ul class="child-menu mm-listview " id="child_menu_677" aria-label="My child is in Finland - submenu"> 
+                <li class="mm-listitem level-6" id="mobile-layout_683"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/child-in-finland-with-a-residence-permit" class="mm-listitem__text">Child in Finland with a residence permit</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_684"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/child-in-finland-on-the-basis-of-international-or-temporary-protection" class="mm-listitem__text">Child in Finland on the basis of international or temporary protection</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_686"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/my-child-is-a-finnish-citizen" class="mm-listitem__text">My child is a Finnish citizen</a> 
+                 </div></li> 
+               </ul></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_692"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/my-guardian-is-in-finland" class="mm-listitem__text has-btn">My guardian is in Finland</a> 
+                <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_692_2"> <span class="sr-only">My guardian is in Finland - submenu</span> 
+                 <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                   
+                 <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+               </div> 
+               <ul class="child-menu mm-listview " id="child_menu_692" aria-label="My guardian is in Finland - submenu"> 
+                <li class="mm-listitem level-6" id="mobile-layout_693"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/guardian-in-finland-with-a-fixed-term-residence-permit" class="mm-listitem__text">Guardian in Finland with a fixed-term residence permit</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_694"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/guardian-in-finland-on-the-basis-of-international-or-temporary-protection" class="mm-listitem__text">Guardian in Finland on the basis of international or temporary protection</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_696"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/guardian-is-a-finnish-citizen" class="mm-listitem__text">Guardian is a Finnish citizenor married to a Finnish citizen</a> 
+                 </div></li> 
+               </ul></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_701"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/my-other-relative-is-in-finland" class="mm-listitem__text has-btn">My other relative is in Finland</a> 
+                <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_701_3"> <span class="sr-only">My other relative is in Finland - submenu</span> 
+                 <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                   
+                 <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+               </div> 
+               <ul class="child-menu mm-listview " id="child_menu_701" aria-label="My other relative is in Finland - submenu"> 
+                <li class="mm-listitem level-6" id="mobile-layout_702"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/my-relative-is-a-finnish-citizen" class="mm-listitem__text">My relative is a Finnish citizen</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_703"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/my-relative-has-been-granted-international-or-temporary-protection" class="mm-listitem__text">My relative has been granted international or temporary protection</a> 
+                 </div></li> 
+               </ul></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_704"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/adoption-en" class="mm-listitem__text">Adoption</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_1266"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/income-requirement-for-family-members-of-a-person-who-has-been-granted-a-residence-permit-in-finland" class="mm-listitem__text">Income requirement for family members of a person who has been granted a residence permit in Finland</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_1268"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/income-requirement-for-family-members-of-a-person-who-has-been-granted-international-or-temporary-protection" class="mm-listitem__text">Income requirement for family members of a person who has been granted international or temporary protection</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_3461"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/period-of-residence-requirement-for-family-members-of-a-person-who-has-been-granted-international-or-temporary-protection" class="mm-listitem__text">Period of residence requirement for family members of a person who has been granted international or temporary protection</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_1135"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/who-is-the-childs-guardian" class="mm-listitem__text">Who is the child’s guardian?</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_714"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/missing-documentation-of-family-ties" class="mm-listitem__text">Missing documentation of family ties</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_716"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/oral-hearing-or-interview" class="mm-listitem__text">Oral hearing or interview</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_717"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/dna-analysis-for-family-members" class="mm-listitem__text">DNA analysis for family members</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_719"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/establishment-of-the-age-of-a-person-under-18-years-of-age" class="mm-listitem__text">Establishment of the age of a person under 18 years of age</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_720"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/changes-in-your-family-ties" class="mm-listitem__text">Changes in your family ties</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_721"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/for-a-family-member" class="mm-listitem__text has-btn">For a family member</a> 
+                <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_721_14"> <span class="sr-only">For a family member - submenu</span> 
+                 <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                   
+                 <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+               </div> 
+               <ul class="child-menu mm-listview " id="child_menu_721" aria-label="For a family member - submenu"> 
+                <li class="mm-listitem level-6" id="mobile-layout_723"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/obligations-of-the-sponsor" class="mm-listitem__text">Obligations of the sponsor</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_724"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/useful-links" class="mm-listitem__text">Useful links</a> 
+                 </div></li> 
+               </ul></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_3437"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/amendments-to-family-reunification-provisions-2025" class="mm-listitem__text">Amendments to family reunification provisions 2025</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2023"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/frequently-asked-questions8" class="mm-listitem__text">Frequently asked questions</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2313"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/d-visa" class="mm-listitem__text has-btn">D visa</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2313_4"> <span class="sr-only">D visa - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_2313" aria-label="D visa - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_2822"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/d-visa-for-returning-to-finland" class="mm-listitem__text">D visa for returning to Finland</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_760"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/remigration" class="mm-listitem__text has-btn">Remigration</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_760_5"> <span class="sr-only">Remigration - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_760" aria-label="Remigration - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_761"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/remigration/former-finnish-citizen" class="mm-listitem__text">Former Finnish citizen</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_762"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/descendant-of-a-finnish-citizen" class="mm-listitem__text">Descendant of someone who is or was a Finnish citizen by birth</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_763"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/ingrian-evacuee" class="mm-listitem__text">Ingrian evacuee</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_764"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/person-who-served-in-the-finnish-army" class="mm-listitem__text">Person who served in the Finnish army</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_765"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/finding-accommodation" class="mm-listitem__text">Finding accommodation</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2025"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/frequently-asked-questions10" class="mm-listitem__text">Frequently asked questions</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_770"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/coming-to-finland-on-other-grounds" class="mm-listitem__text has-btn">Coming to Finland on other grounds</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_770_6"> <span class="sr-only">Coming to Finland on other grounds - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_770" aria-label="Coming to Finland on other grounds - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_772"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/residence-permit-on-other-grounds" class="mm-listitem__text">Residence permit on other grounds</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_771"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/residence-permit-for-a-victim-of-human-trafficking" class="mm-listitem__text has-btn">Residence permit for a victim of human trafficking</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_771_7"> <span class="sr-only">Residence permit for a victim of human trafficking - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_771" aria-label="Residence permit for a victim of human trafficking - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_773"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/residence-permit-application-for-a-victim-of-human-trafficking" class="mm-listitem__text">Residence permit application for a victim of human trafficking</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1381"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/personal-identity-code" class="mm-listitem__text">Personal identity code in connection with a residence permit</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_775"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/extended-permit" class="mm-listitem__text has-btn">Extended permit</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_775_1"> <span class="sr-only">Extended permit - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_775" aria-label="Extended permit - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_786"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/extended-permit-for-a-family-member" class="mm-listitem__text has-btn">Extended permit for a family member</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_786_0"> <span class="sr-only">Extended permit for a family member - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_786" aria-label="Extended permit for a family member - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_787"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/application-for-an-extended-permit-on-the-basis-of-family-ties" class="mm-listitem__text">Application for an extended permit on the basis of family ties</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_1283"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/application-for-an-extended-permit-on-the-basis-of-an-established-relationship" class="mm-listitem__text">Application for an extended permit on the basis of an established relationship</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_788"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/extended-permit-for-studies" class="mm-listitem__text has-btn">Extended permit for studies</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_788_1"> <span class="sr-only">Extended permit for studies - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_788" aria-label="Extended permit for studies - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_1311"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/application-for-an-extended-permit-on-the-basis-of-studies" class="mm-listitem__text">Application for an extended permit on the basis of studies</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2247"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/extended-permit-to-look-for-work1" class="mm-listitem__text">Extended permit to look for work</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2360"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/degree-completed-in-finland1" class="mm-listitem__text">Degree completed in Finland</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_789"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/extended-permit-on-the-basis-of-work" class="mm-listitem__text">Extended permit on the basis of work</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_790"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/returnee-s-extended-permit" class="mm-listitem__text has-btn">Returnee’s extended permit</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_790_5"> <span class="sr-only">Returnee’s extended permit - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_790" aria-label="Returnee’s extended permit - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_791"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/application-for-an-extended-permit-on-the-basis-of-finnish-origin" class="mm-listitem__text">Application for an extended permit on the basis of Finnish origin</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_1207"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/application-for-an-extended-permit-on-the-basis-of-remigration-from-the-area-of-the-former-soviet-union" class="mm-listitem__text">Application for an extended permit on the basis of remigration from the area of the former Soviet Union</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_792"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/extended-permit-for-a-person-who-has-been-granted-international-protection" class="mm-listitem__text has-btn">Extended permit for a person who has been granted international protection</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_792_6"> <span class="sr-only">Extended permit for a person who has been granted international protection - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_792" aria-label="Extended permit for a person who has been granted international protection - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_793"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/application-for-an-extended-permit-on-the-basis-of-international-protection" class="mm-listitem__text">Application for an extended permit on the basis of international protection</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1250"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/extended-permit-for-a-victim-of-human-trafficking" class="mm-listitem__text">Extended permit for a victim of human trafficking</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2717"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/extended-permit-on-the-basis-of-domestic-violence" class="mm-listitem__text">Extended permit on the basis of domestic violence</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_794"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/extended-permit-on-other-grounds" class="mm-listitem__text">Extended permit on other grounds</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2636"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/working-while-your-extended-permit-application-is-being-processed2" class="mm-listitem__text">Working while your extended permit application is being processed</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2977"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/permanent-residence-permits" class="mm-listitem__text has-btn">Permanent residence permits</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2977_2"> <span class="sr-only">Permanent residence permits - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_2977" aria-label="Permanent residence permits - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_799"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/permanent-residence-permit" class="mm-listitem__text has-btn">Permanent residence permit</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_799_0"> <span class="sr-only">Permanent residence permit - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_799" aria-label="Permanent residence permit - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_800"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/application-for-a-permanent-residence-permit" class="mm-listitem__text">Application for a permanent residence permit</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_3516"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/work-history-requirement" class="mm-listitem__text">Work history requirement</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_3517"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/permanent-residence-permit-for-a-child" class="mm-listitem__text">Permanent residence permit for a child</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_807"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/p-eu-residence-permit" class="mm-listitem__text has-btn">P-EU permit</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_807_1"> <span class="sr-only">P-EU permit - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_807" aria-label="P-EU permit - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_808"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/application-for-an-p-eu-residence-permit" class="mm-listitem__text">Application for an P-EU residence permit</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3515"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/period-of-residence-requirement" class="mm-listitem__text">Period of residence requirement</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3514"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/language-skills-requirement" class="mm-listitem__text">Language skills requirement</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3379"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/permanent-residence-permits/income-requirement" class="mm-listitem__text">Income requirement</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1136"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/impact-of-crimes" class="mm-listitem__text">Impact of crimes on getting a permanent residence permit</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3504"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/amendments-to-aliens-act-regarding-permanent-residence-permits-2026" class="mm-listitem__text">Amendments to Aliens Act regarding permanent residence permits 2026</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3612"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/frequently-asked-questions15" class="mm-listitem__text">Frequently asked questions</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2103"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/residence-permit-or-certificate-due-to-exploitation-by-employer" class="mm-listitem__text has-btn">Residence permit or certificate due to exploitation by employer</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2103_3"> <span class="sr-only">Residence permit or certificate due to exploitation by employer - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_2103" aria-label="Residence permit or certificate due to exploitation by employer - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_2106"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/extended-permit-for-victim-of-employer-negligence-or-exploitation" class="mm-listitem__text">Extended permit for victim of employer negligence or exploitation</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2110"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/certificate-of-expanded-right-to-work-for-victim-of-employer-negligence-or-exploitation" class="mm-listitem__text">Certificate of expanded right to work for victim of employer negligence or exploitation</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2113"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/significant-negligence-or-exploitation-by-employer" class="mm-listitem__text">Significant negligence or exploitation by employer</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_815"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/residence-permit-types" class="mm-listitem__text">Residence permit types</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_816"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/residence-permit-card" class="mm-listitem__text has-btn">Residence permit card</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_816_5"> <span class="sr-only">Residence permit card - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_816" aria-label="Residence permit card - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_817"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/renewal-of-a-residence-permit-card" class="mm-listitem__text">Renewal of a residence permit card</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2026"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/frequently-asked-questions11" class="mm-listitem__text">Frequently asked questions</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2730"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/post-decision-monitoring-of-residence-permits" class="mm-listitem__text">Post-decision monitoring of residence permits</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2017"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/frequently-asked-questions2" class="mm-listitem__text">Frequently asked questions</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_824"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/eu-citizen" class="mm-listitem__text has-btn">EU citizen</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_824_1"> <span class="sr-only">EU citizen - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_824" aria-label="EU citizen - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_825"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/registration-of-right-of-residence" class="mm-listitem__text">Registration of right of residence</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_827"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/right-of-permanent-residence" class="mm-listitem__text">Right of permanent residence</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_826"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/residence-card-for-family-members" class="mm-listitem__text">Residence card for family members</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2797"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/permanent-residence-card-for-a-family-member" class="mm-listitem__text">Permanent residence card for a family member</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_829"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/residence-card-and-its-renewal" class="mm-listitem__text">Renewal of residence card</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_828"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/cancellation-and-expiry-of-right-of-residence" class="mm-listitem__text">Cancellation and expiry</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1288"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/eu-member-states" class="mm-listitem__text">EU Member States</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2018"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/frequently-asked-questions3" class="mm-listitem__text">Frequently asked questions</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_424"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/finnish-citizenship" class="mm-listitem__text has-btn">Finnish citizenship</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_424_2"> <span class="sr-only">Finnish citizenship - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_424" aria-label="Finnish citizenship - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_830"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/citizenship-for-adults" class="mm-listitem__text has-btn">Citizenship application for adults</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_830_0"> <span class="sr-only">Citizenship application for adults - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_830" aria-label="Citizenship application for adults - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_831"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/establishment-of-identity" class="mm-listitem__text">Establishment of identity</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_832"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/18-years-of-age" class="mm-listitem__text">18 years of age</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2858"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/period-of-residence" class="mm-listitem__text">Period of residence</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_833"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/period-of-residence-before-10/2024" class="mm-listitem__text">Period of residence: application submitted before 1 October 2024</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_839"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/language-skills" class="mm-listitem__text has-btn">Language skills</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_839_4"> <span class="sr-only">Language skills - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_839" aria-label="Language skills - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_840"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/national-certificate-of-language-proficiency-yki-" class="mm-listitem__text">National Certificate of Language Proficiency (YKI)</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_841"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/exceptions-to-the-language-skills-requirement" class="mm-listitem__text has-btn">Exceptions to the language skills requirement</a> 
+                <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_841_1"> <span class="sr-only">Exceptions to the language skills requirement - submenu</span> 
+                 <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                   
+                 <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+               </div> 
+               <ul class="child-menu mm-listview " id="child_menu_841" aria-label="Exceptions to the language skills requirement - submenu"> 
+                <li class="mm-listitem level-6" id="mobile-layout_842"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/applicants-over-the-age-of-65" class="mm-listitem__text">Applicants over the age of 65</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_843"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/health" class="mm-listitem__text">Health</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_844"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/illiteracy" class="mm-listitem__text">Illiteracy</a> 
+                 </div></li> 
+                <li class="mm-listitem level-6" id="mobile-layout_845"> 
+                 <div class="nav-item__container"> 
+                  <a href="https://migri.fi/en/other-grounds-for-an-exception-to-the-language-skills-requirement" class="mm-listitem__text">Other grounds for an exception to the language skills requirement</a> 
+                 </div></li> 
+               </ul></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_836"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/integrity" class="mm-listitem__text">Integrity</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_837"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/payment-obligation" class="mm-listitem__text">Payment obligation</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_838"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/citizenship-application/means-of-support" class="mm-listitem__text">Means of support</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3416"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/processing-of-citizenship-applications" class="mm-listitem__text">Processing of citizenship applications</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_863"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/citizenship-declaration" class="mm-listitem__text has-btn">Citizenship declaration</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_863_1"> <span class="sr-only">Citizenship declaration - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_863" aria-label="Citizenship declaration - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_868"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/nordic-citizen" class="mm-listitem__text">Nordic citizen</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_867"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/former-finnish-citizen" class="mm-listitem__text has-btn">Former Finnish citizen</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_867_1"> <span class="sr-only">Former Finnish citizen - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_867" aria-label="Former Finnish citizen - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_871"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/if-the-decision-shows-your-old-name" class="mm-listitem__text">If the decision shows your old name</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_866"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/young-person-between-18-and-22-years-of-age" class="mm-listitem__text">Young person between 18 and 22 years of age</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_865"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/adopted-child-between-12-and-17-years-of-age" class="mm-listitem__text">Adopted child between 12 and 17 years of age</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_864"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/child-born-abroad" class="mm-listitem__text">Child born abroad</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2899"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/citizenship-declaration/adult-one-parent-finnish-citizen" class="mm-listitem__text">Adult whose parent is a Finnish citizen</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_880"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/citizenship-for-a-child" class="mm-listitem__text has-btn">Citizenship for a child</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_880_2"> <span class="sr-only">Citizenship for a child - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_880" aria-label="Citizenship for a child - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_881"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/child-born-in-finland" class="mm-listitem__text">Child born in Finland</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_882"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/requirements-for-a-child-for-becoming-a-finnish-citizen" class="mm-listitem__text">Requirements for a child for becoming a Finnish citizen</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_883"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/when-a-child-turns-18" class="mm-listitem__text">When a child turns 18</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_884"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/citizenship-application-for-a-child" class="mm-listitem__text">Citizenship application for a child</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_885"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/loss-of-citizenship" class="mm-listitem__text has-btn">Loss of citizenship</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_885_3"> <span class="sr-only">Loss of citizenship - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_885" aria-label="Loss of citizenship - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_886"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/retaining-finnish-citizenship-at-the-age-of-22" class="mm-listitem__text">Retaining Finnish citizenship at the age of 22</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_887"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/release-from-citizenship" class="mm-listitem__text">Release from citizenship</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_889"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/determination-of-citizenship" class="mm-listitem__text">Determination of citizenship</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1927"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/contact-information-for-finnish-citizen" class="mm-listitem__text">Information for new Finnish citizens</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2019"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/frequently-asked-questions4" class="mm-listitem__text has-btn">Frequently asked questions</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2019_6"> <span class="sr-only">Frequently asked questions - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_2019" aria-label="Frequently asked questions - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_2872"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/frequently-asked-questions-finnish-citizenship-application-submitted-before-1-october-2024" class="mm-listitem__text">Frequently asked questions: Finnish citizenship - application submitted before 1 October 2024</a> 
+             </div></li> 
+           </ul></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_996"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/asylum-in-finland" class="mm-listitem__text has-btn">Asylum in Finland</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_996_3"> <span class="sr-only">Asylum in Finland - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_996" aria-label="Asylum in Finland - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_3674"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/asylum-in-finland-before-12/6/2026" class="mm-listitem__text">Asylum in Finland: application submitted before 12 June 2026</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1011"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/processing-of-asylum-applications" class="mm-listitem__text has-btn">Processing of asylum applications</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1011_1"> <span class="sr-only">Processing of asylum applications - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1011" aria-label="Processing of asylum applications - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_3667"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/processing-of-asylum-applications-before-12/6/2026" class="mm-listitem__text has-btn">Processing of asylum applications : application submitted before 12 June 2026</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_3667_0"> <span class="sr-only">Processing of asylum applications : application submitted before 12 June 2026 - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_3667" aria-label="Processing of asylum applications : application submitted before 12 June 2026 - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_2896"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/information-after-asylum-interview/fa" class="mm-listitem__text" lang="fa">اطلاعاتی برای پناهجو پس از مصاحبه</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2852"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/after-asylum-interview/ps" class="mm-listitem__text">مهاجرت اداره ممکن له تاسې څخه د مرکې وروسته نور وضاحت وغواړي – خپل ځواب په ټاکلي وخت کې مهاجرت ادارهته وسپارئ</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2851"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/after-asylum-interview/ka" class="mm-listitem__text">ინფორმაცია თავშესაფრის მაძიებლისთვის ინტერვიუს შემდეგ</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2850"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/after-asylum-interview/am" class="mm-listitem__text">ቃለ መጠይቅ ላደረጉ ጥገኝነት ጠያቂዎች ተጨማሪ መረጃ</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2849"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/information-after-asylum-interview/kmr" class="mm-listitem__text">Agahiyên ji bo penaxwaz piştî hevpeyvînê</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2848"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/information-after-asylum-interview/rw" class="mm-listitem__text">Amakuru agenewe abasaba ubuhungiro nyuma yo kubazwa</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2895"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/information-after-asylum-interview/tr" class="mm-listitem__text">Mülakat Sonrası Sığınmacı İçin Bilgi</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2892"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/information-after-asylum-interview/ar" class="mm-listitem__text" lang="ar">معلومات لطالب اللجوء بعد المقابلة</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2847"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/information-after-asylum-interview/ru" class="mm-listitem__text" lang="ru">Информация для просителей убежища после собеседования</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2894"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/information-after-asylum-interview/dari" class="mm-listitem__text" lang="fa-AF">معلومات برای پناهجویان بعد از انترویو (مصاحبە)</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2846"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/information-after-asylum-interview/es" class="mm-listitem__text">Información para solicitantes de asilo después de la entrevista</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2893"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/information-after-asylum-interview/sorani" class="mm-listitem__text" lang="ku">زانیاری بۆ داواکەری پەنابەری لە دوای چاوپێکەوتن</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2845"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/information-after-asylum-interview/so" class="mm-listitem__text" lang="so">Macluumaad loogu talaggalay qofka magangalyoddoonka ah, warysiga kaddib</a> 
+               </div></li> 
+              <li class="mm-listitem level-5" id="mobile-layout_2844"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/information-after-asylum-interview/fr" class="mm-listitem__text">Information à l’attention du demandeur d’asile après l'entretien</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3683"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/procedures" class="mm-listitem__text">Procedures</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1359"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/subsequent-applications" class="mm-listitem__text has-btn">Subsequent applications</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1359_2"> <span class="sr-only">Subsequent applications - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_1359" aria-label="Subsequent applications - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_3669"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/subsequent-applications-before-12/6/2026" class="mm-listitem__text">Subsequent applications : application submitted before 12 June 2026</a> 
+               </div></li> 
+             </ul></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1020"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/when-is-an-application-not-processed-in-finland-" class="mm-listitem__text">When is an application not processed in Finland?</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2837"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/border-procedure" class="mm-listitem__text">Border procedure</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1003"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/legal-advice" class="mm-listitem__text">Legal advice</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1004"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/representative-of-an-unaccompanied-minor-asylum-seeker" class="mm-listitem__text">Representative of an unaccompanied minor asylum seeker</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1005"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/daily-life-in-a-reception-centre" class="mm-listitem__text has-btn">Daily life in a reception centre</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1005_6"> <span class="sr-only">Daily life in a reception centre - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1005" aria-label="Daily life in a reception centre - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_1001"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/accommodation-of-an-unaccompanied-minor-asylum-seeker" class="mm-listitem__text">Accommodation of an unaccompanied minor asylum seeker</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1000"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/living-in-private-accommodation" class="mm-listitem__text">Living in private accommodation</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_999"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/living-in-a-reception-centre" class="mm-listitem__text">Living in a reception centre</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2855"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/accommodation-in-reception-centre" class="mm-listitem__text">Accommodation</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1007"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/health-care" class="mm-listitem__text">Health care</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1008"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/social-services" class="mm-listitem__text">Social services</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1006"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/reception-allowance" class="mm-listitem__text">Reception allowance</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1009"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/interpreting" class="mm-listitem__text">Interpreting</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1010"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/work-and-study-activities" class="mm-listitem__text">Work and study activities</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1912"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/finnish-society-course" class="mm-listitem__text">Finnish society course</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1876"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/information-about-the-asylum-process" class="mm-listitem__text">Information about the asylum process</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1140"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/asylum-seeker-s-right-to-work" class="mm-listitem__text">Asylum seeker’s right to work</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2724"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/asylum-seekers-right-to-study" class="mm-listitem__text">Asylum seekers’ right to study</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1023"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/asylum-in-finland/cancelling-an-application" class="mm-listitem__text">Cancelling an application</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1024"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/asylum-in-finland/positive-decision" class="mm-listitem__text">Positive decision</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1029"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/asylum-in-finland/negative-decision" class="mm-listitem__text">Negative decision</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1739"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/family-members-seeking-asylum-in-europe" class="mm-listitem__text">Family members seeking asylum in Europe</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1040"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/resettlement-of-quota-refugees" class="mm-listitem__text has-btn">Resettlement of quota refugees</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1040_13"> <span class="sr-only">Resettlement of quota refugees - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1040" aria-label="Resettlement of quota refugees - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_1042"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/how-are-quota-refugees-selected-" class="mm-listitem__text">How are quota refugees selected?</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3382"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/quota-refugees-information-about-finnish-society" class="mm-listitem__text">Information about Finnish society for quota refugees</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1044"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/detention" class="mm-listitem__text">Detention</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1045"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/assistance-system-for-victims-of-human-trafficking" class="mm-listitem__text">Assistance system for victims of human trafficking</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1772"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/transfer-of-refugee-status-to-finland" class="mm-listitem__text">Transfer of refugee status to Finland</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1046"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/withdrawal-of-refugee-status-and-subsidiary-protection" class="mm-listitem__text">Withdrawal of refugee status and subsidiary protection</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1047"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/cancellation-of-refugee-status-and-subsidiary-protection" class="mm-listitem__text">Cancellation of refugee status and subsidiary protection</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1033"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/return" class="mm-listitem__text">Assisted voluntary return</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1048"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/effect-of-crime-on-the-asylum-process" class="mm-listitem__text">Effect of crime on the asylum process</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2020"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/frequently-asked-questions5" class="mm-listitem__text">Frequently asked questions</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2768"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/info-ar" class="mm-listitem__text">معلومات لطالب اللجوء</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2769"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/lapsi-ar" class="mm-listitem__text">األطفال الذين بدون ويل أمر</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2770"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/info-so" class="mm-listitem__text">Warar loogu talagalay dadka magangelyada codsaday</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2771"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/lapsi-so" class="mm-listitem__text">Caruurta aan lahayn waalid ama ilaaliye</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2775"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/info-dari" class="mm-listitem__text" lang="fa-AF">پروسه پناهندگی در فنلند</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2774"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/lapsi-dari" class="mm-listitem__text" lang="fa-AF">اطفال بدون رسپرست</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2776"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/info-fa" class="mm-listitem__text">درخواست پناهندگی در فنلاند</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2777"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/lapsi-fa" class="mm-listitem__text">کودکان بدون رسپرست فارسی</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2778"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/info-ru" class="mm-listitem__text" lang="ru">Ходатайство об убежище в Финляндии</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2779"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/lapsi-ru" class="mm-listitem__text" lang="ru">дети без родителей</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2780"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/info-fr" class="mm-listitem__text">Demande d’asile en Finlande</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2781"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/lapsi-fr" class="mm-listitem__text">Enfants non accompagnés</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2782"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/info-ti" class="mm-listitem__text">ሕቶ ዕቝባ ኣብ Finland</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2783"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/lapsi-ti" class="mm-listitem__text">ወለዲ ወይ ኣለይቲ ዘይብሎም ቘልዑ</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2784"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/info-kmr" class="mm-listitem__text">Daxwaza penaberiyê ji Fînlanda yê re</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2785"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/lapsi-kmr" class="mm-listitem__text">Zarokên bê dêûbav û sergêrên xwe</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2800"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/info-ur" class="mm-listitem__text">فن لینڈ میں سیاسی پناہ کی درخواست</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2801"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/lapsi-ur" class="mm-listitem__text">جن بچوں کے والدین یا سرپرست نہ ہوں</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2802"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/info-sorani" class="mm-listitem__text" lang="ku">داوای پەنابەری لە فینلەندا</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2803"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/lapsi-sorani" class="mm-listitem__text" lang="ku">منداڵانی بێ سەرپەرشت</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2804"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/info-tr" class="mm-listitem__text">Finlandiya'dan sığınma başvurusunda bulunma</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2805"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/lapsi-tr" class="mm-listitem__text">Yanlarında velileri bulunmayan çocuklar</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2807"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/info-ps" class="mm-listitem__text">په فنلنډ کې د پناه غوښتنه</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2808"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/lapsi-ps" class="mm-listitem__text">ماشومان پرته له مور او پلار یا سرپرست</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1446"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/brexit/en" class="mm-listitem__text has-btn">Brexit</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1446_4"> <span class="sr-only">Brexit - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1446" aria-label="Brexit - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1864"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/right-of-residence-under-the-withdrawal-agreement" class="mm-listitem__text">Right of residence under the withdrawal agreement</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1865"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/application-for-right-of-permanent-residence" class="mm-listitem__text">Application for right of permanent residence</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1867"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/changing-status-of-right-of-permanent-residence" class="mm-listitem__text">Changing status of right of permanent residence</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1861"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/application-for-family-member" class="mm-listitem__text">Application for family member</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_3480"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/brexit-family-members-permanent" class="mm-listitem__text">Brexit family members permanent</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_3481"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/brexit-family-members-change-of-status" class="mm-listitem__text">Brexit family members change of status</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_3487"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/withdrawal-of-brexit-permits" class="mm-listitem__text">Withdrawal of Brexit permits</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_3482"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/renewal-of-brexit-residence-permit-card" class="mm-listitem__text">Renewal of Brexit residence permit card</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1452"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/frequently-asked-questions" class="mm-listitem__text">Frequently asked questions about Brexit</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1208"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/travel-documents" class="mm-listitem__text has-btn">Travel documents</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1208_5"> <span class="sr-only">Travel documents - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1208" aria-label="Travel documents - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1209"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/alien-s-passport" class="mm-listitem__text">Alien’s passport</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1210"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/refugee-travel-document" class="mm-listitem__text">Refugee travel document</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1211"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/identity-not-verified" class="mm-listitem__text">Identity not verified</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1221"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/income-requirement" class="mm-listitem__text">Income requirement</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2421"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/incomes-register" class="mm-listitem__text">Incomes register</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1212"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/processing-of-applications" class="mm-listitem__text has-btn">Processing of applications</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1212_8"> <span class="sr-only">Processing of applications - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1212" aria-label="Processing of applications - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1213"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/applications" class="mm-listitem__text has-btn">Applications</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1213_0"> <span class="sr-only">Applications - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1213" aria-label="Applications - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_1214"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/residence-permit-applications" class="mm-listitem__text">Residence permit applications</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1215"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/eu-registration-applications" class="mm-listitem__text">EU registration applications</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1216"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/citizenship-applications" class="mm-listitem__text">Citizenship applications</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1217"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/other-applications" class="mm-listitem__text">Other applications</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2029"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/frequently-asked-questions14" class="mm-listitem__text">Frequently asked questions</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1218"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/application-processing-stages" class="mm-listitem__text">Application processing stages</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1219"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/processing-times" class="mm-listitem__text has-btn">Processing times</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1219_2"> <span class="sr-only">Processing times - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1219" aria-label="Processing times - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_1291"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/expedited-processing1" class="mm-listitem__text">Expedited processing</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1220"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/processing-fees-and-payment-methods" class="mm-listitem__text has-btn">Processing fees and payment methods</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1220_3"> <span class="sr-only">Processing fees and payment methods - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1220" aria-label="Processing fees and payment methods - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_1940"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/refund-of-a-payment" class="mm-listitem__text">Refund of a payment</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1226"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/answering-a-request-for-additional-information" class="mm-listitem__text has-btn">Answering a request for additional information</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1226_4"> <span class="sr-only">Answering a request for additional information - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1226" aria-label="Answering a request for additional information - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_1439"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/customer-number-and-diary-number" class="mm-listitem__text">Customer number and diary number</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1222"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/handling-your-matters-at-a-finnish-mission" class="mm-listitem__text">Handling your matters at a Finnish mission</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2946"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/automation" class="mm-listitem__text has-btn">Automation</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2946_6"> <span class="sr-only">Automation - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_2946" aria-label="Automation - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_2739"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/automated-decision" class="mm-listitem__text has-btn">Automated decision</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2739_0"> <span class="sr-only">Automated decision - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_2739" aria-label="Automated decision - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_2744"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/implementation-decisions" class="mm-listitem__text">Criteria for automated decisions</a> 
+               </div></li> 
+             </ul></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2138"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/automated-messages" class="mm-listitem__text">Automated messages</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_3426"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/faq-residence-permits#Processing" class="mm-listitem__text">Frequently Asked Questions</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1223"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/changes-and-supplementary-documents" class="mm-listitem__text has-btn">Changes and supplementary documents</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1223_9"> <span class="sr-only">Changes and supplementary documents - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1223" aria-label="Changes and supplementary documents - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1224"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/changing-the-grounds-for-an-application" class="mm-listitem__text">Changing the grounds for an application</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1225"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/cancelling-an-application" class="mm-listitem__text">Cancelling an application</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1320"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/expiration-of-the-application" class="mm-listitem__text">Expiration of the application</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1227"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/requests-and-certificates" class="mm-listitem__text has-btn">Requests and certificates</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1227_10"> <span class="sr-only">Requests and certificates - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1227" aria-label="Requests and certificates - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1228"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/document-and-information-requests" class="mm-listitem__text has-btn">Document and information requests</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1228_0"> <span class="sr-only">Document and information requests - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1228" aria-label="Document and information requests - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_1271"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/authorisation" class="mm-listitem__text">Authorisation</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1229"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/certificate-requests" class="mm-listitem__text">Certificate requests</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1230"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/certificate-of-a-pending-application" class="mm-listitem__text">Certificate of a pending application</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1775"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/disclosure-of-data-for-scientific-research-purposes" class="mm-listitem__text">Disclosure of data for scientific research purposes</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1231"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/legislation" class="mm-listitem__text has-btn">Legislation</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1231_11"> <span class="sr-only">Legislation - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1231" aria-label="Legislation - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_2824"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/legislative-projects" class="mm-listitem__text">Legislative projects</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2678"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/guidelines-for-application-of-law" class="mm-listitem__text">Guidelines for application of law</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1232"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/informing-of-the-decision" class="mm-listitem__text has-btn">Informing of the decision</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1232_13"> <span class="sr-only">Informing of the decision - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1232" aria-label="Informing of the decision - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1243"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/positive-decision" class="mm-listitem__text">Positive decision</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1244"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/negative-decision" class="mm-listitem__text">Negative decision</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1233"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/advice-of-delivery" class="mm-listitem__text">Advice of delivery</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1832"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/service-by-publication" class="mm-listitem__text">Service by publication</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1234"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/appealing-a-decision" class="mm-listitem__text has-btn">Appealing a decision</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1234_14"> <span class="sr-only">Appealing a decision - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1234" aria-label="Appealing a decision - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1235"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/instructions-for-appealing" class="mm-listitem__text">Instructions for appealing</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2644"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/procedural-provisions" class="mm-listitem__text has-btn">Procedural provisions</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2644_15"> <span class="sr-only">Procedural provisions - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_2644" aria-label="Procedural provisions - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_2647"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/correcting-a-material-or-typographical-error" class="mm-listitem__text">Correcting a material or typographical error</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1098"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/administrative-complaint" class="mm-listitem__text">Administrative complaint</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1237"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/cancellation-of-a-permit" class="mm-listitem__text has-btn">Cancellation of a permit</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1237_16"> <span class="sr-only">Cancellation of a permit - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1237" aria-label="Cancellation of a permit - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_3431"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/request-for-permit-withdrawal" class="mm-listitem__text">Request for permit withdrawal</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1238"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/denial-of-admittance-or-stay-deportation-entry-ban" class="mm-listitem__text has-btn">Denial of admittance or stay, deportation, entry ban</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1238_17"> <span class="sr-only">Denial of admittance or stay, deportation, entry ban - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1238" aria-label="Denial of admittance or stay, deportation, entry ban - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1253"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/withdrawal-of-entry-ban" class="mm-listitem__text">Withdrawal of entry ban</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1239"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/work-in-finland" class="mm-listitem__text has-btn">Work in Finland</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1239_18"> <span class="sr-only">Work in Finland - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1239" aria-label="Work in Finland - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1955"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/information-about-right-to-work" class="mm-listitem__text">Information about right to work</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2943"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/business-activities-of-residence-permit-holders" class="mm-listitem__text">Business activities of residence permit holders</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1315"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/working-while-your-extended-permit-application-is-being-processed" class="mm-listitem__text">Working while your extended permit application is being processed</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_628"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/changing-jobs" class="mm-listitem__text">Changing jobs</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_629"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/end-of-employment" class="mm-listitem__text">End of employment</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_632"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/work-without-residence-permit" class="mm-listitem__text">Work without residence permit</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_634"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/problems-at-work-" class="mm-listitem__text">Problems at work?</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2684"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/work-help-finland" class="mm-listitem__text">Work Help Finland mobile application</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_638"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/for-employers" class="mm-listitem__text has-btn">For employers</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_638_19"> <span class="sr-only">For employers - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_638" aria-label="For employers - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_2620"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/role-and-obligations-of-employers" class="mm-listitem__text has-btn">Employer’s role and obligations</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2620_0"> <span class="sr-only">Employer’s role and obligations - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_2620" aria-label="Employer’s role and obligations - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_3495"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/employer-s-announcements-on-employment-relationships" class="mm-listitem__text">Employer’s announcements on employment relationships</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2622"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/filling-in-the-terms-of-employment" class="mm-listitem__text has-btn">Filling in the terms of employment</a> 
+              <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2622_1"> <span class="sr-only">Filling in the terms of employment - submenu</span> 
+               <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+                 
+               <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+             </div> 
+             <ul class="child-menu mm-listview " id="child_menu_2622" aria-label="Filling in the terms of employment - submenu"> 
+              <li class="mm-listitem level-5" id="mobile-layout_2756"> 
+               <div class="nav-item__container"> 
+                <a href="https://migri.fi/en/instructions-for-employers-on-filling-in-the-terms-of-employment" class="mm-listitem__text">Instructions for employers on filling in the terms of employment</a> 
+               </div></li> 
+             </ul></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2641"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/if-an-employer-neglects-their-obligations" class="mm-listitem__text">If an employer neglects their obligations</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3393"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/labour-market-test" class="mm-listitem__text">Labour market test</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1814"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/enter-finland-for-employers" class="mm-listitem__text">Enter Finland for Employers</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2314"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/fast-track-instructions-for-employers" class="mm-listitem__text">Fast track instructions for employers</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1934"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/for-employers-of-seasonal-workers" class="mm-listitem__text has-btn">For employers of seasonal workers</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1934_3"> <span class="sr-only">For employers of seasonal workers - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1934" aria-label="For employers of seasonal workers - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_1936"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/instructions-for-supplementing-the-terms-of-employment" class="mm-listitem__text">Instructions for supplementing the terms of employment</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1952"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/frequently-asked-questions-from-employers" class="mm-listitem__text">Frequently asked questions from employers</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_648"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/useful-links-for-employers" class="mm-listitem__text">Useful links for employers</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2607"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/employer-certification" class="mm-listitem__text has-btn">Employer certification</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2607_6"> <span class="sr-only">Employer certification - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_2607" aria-label="Employer certification - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_2609"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/employers-certification-application" class="mm-listitem__text">Employers certification application</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2610"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/certified-employers" class="mm-listitem__text">Certified employers</a> 
+             </div></li> 
+           </ul></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1240"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/travelling" class="mm-listitem__text">Travelling</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1241"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/visiting-finland" class="mm-listitem__text">Visiting Finland</a> 
+         </div></li> 
+       </ul></li> 
+      <li class="mm-listitem level-1" id="mobile-layout_2491"> 
+       <div class="nav-item__container"> 
+        <a href="https://migri.fi/en/ukraine" class="mm-listitem__text has-btn"> <span>Ukraine</span> </a> 
+        <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false"> <span class="sr-only">Ukraine yja.nav.submenu.title.end</span> 
+         <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+           
+         <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+       </div> 
+       <ul class="child-menu mm-listview " id="child_menu_2491" aria-label="Ukraine - submenu"> 
+        <li class="mm-listitem level-2" id="mobile-layout_2492"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/after-arrival" class="mm-listitem__text has-btn">After arrival</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2492_0"> <span class="sr-only">After arrival - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_2492" aria-label="After arrival - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_2710"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/information-for-pet-owners" class="mm-listitem__text">Information for pet owners</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2493"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/children-who-have-fled-ukraine" class="mm-listitem__text">Children who have fled Ukraine</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2494"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/accommodation" class="mm-listitem__text">Accommodation</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2495"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/work-and-studies" class="mm-listitem__text">Work and studies</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2496"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/family" class="mm-listitem__text">Family</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2497"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/health-and-social-services" class="mm-listitem__text">Health and social services</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2498"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/financial-support" class="mm-listitem__text has-btn">Financial support</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2498_6"> <span class="sr-only">Financial support - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_2498" aria-label="Financial support - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_2511"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/reception-allowance1" class="mm-listitem__text">Reception allowance</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2499"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/traveling-from-finland" class="mm-listitem__text">Traveling from Finland</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2500"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/temporary-protection-and-municipality-of-residence" class="mm-listitem__text has-btn">Municipality of residence</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2500_8"> <span class="sr-only">Municipality of residence - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_2500" aria-label="Municipality of residence - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_2512"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/services-of-a-municipality-of-residence" class="mm-listitem__text">Comparison between reception services and municipal services</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2903"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/finnish-society-course-for-ukrainians" class="mm-listitem__text">Finnish society course for Ukrainians</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2501"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/temporary-protection" class="mm-listitem__text has-btn">Temporary protection</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2501_10"> <span class="sr-only">Temporary protection - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_2501" aria-label="Temporary protection - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_2502"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/extension-of-temporary-protection" class="mm-listitem__text">Extension of temporary protection</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2513"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/residence-permit-card-for-temporary-protection" class="mm-listitem__text">Residence permit card on the basis of temporary protection</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2503"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/other-residence-permits" class="mm-listitem__text">Other residence permits</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2504"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/withdrawal-of-applications-or-permits" class="mm-listitem__text">Withdrawal of applications or permits</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2505"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/faq-russia-s-invasion-of-ukraine" class="mm-listitem__text">Frequently asked questions about Russia’s invasion of Ukraine</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2506"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/contact-information1" class="mm-listitem__text">Contact information</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2507"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/how-can-i-help-ukrainians-" class="mm-listitem__text">How can I help Ukrainians?</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2508"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/for-employers1" class="mm-listitem__text">For employers</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2509"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/for-municipalities" class="mm-listitem__text">For municipalities</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2674"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/printable-instructions" class="mm-listitem__text">Printable instructions</a> 
+         </div></li> 
+       </ul></li> 
+      <li class="mm-listitem level-1" id="mobile-layout_395"> 
+       <div class="nav-item__container"> 
+        <a href="https://migri.fi/en/services" class="mm-listitem__text has-btn"> <span>Services</span> </a> 
+        <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false"> <span class="sr-only">Services yja.nav.submenu.title.end</span> 
+         <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+           
+         <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+       </div> 
+       <ul class="child-menu mm-listview " id="child_menu_395" aria-label="Services - submenu"> 
+        <li class="mm-listitem level-2" id="mobile-layout_1091"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/submit-your-application-in-the-e-service" class="mm-listitem__text has-btn">Online service Enter Finland</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1091_0"> <span class="sr-only">Online service Enter Finland - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1091" aria-label="Online service Enter Finland - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1765"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/online-services" class="mm-listitem__text">Online services</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1109"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/e-service-enter-finland" class="mm-listitem__text">How to use the online service Enter Finland</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1299"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/sufficient-language-and-computer-skills" class="mm-listitem__text">Sufficient language and computer skills</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1801"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/identification" class="mm-listitem__text has-btn">Identification</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1801_3"> <span class="sr-only">Identification - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1801" aria-label="Identification - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_2069"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/identification/ru" class="mm-listitem__text" lang="ru">Идентификация</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2086"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/identification/ar" class="mm-listitem__text" lang="ar">التعريف بالهوية المُوَثّق</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2088"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/identification/zh" class="mm-listitem__text" lang="zh">身份验证</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2089"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/identification/vi" class="mm-listitem__text" lang="vi">Nhận diện</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2090"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/identification/uz" class="mm-listitem__text" lang="uz">Identifikatsiya</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2091"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/identification/uk" class="mm-listitem__text">Ідентифікація</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2093"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/identification/th" class="mm-listitem__text" lang="th">การพิสูจน์ยืนยันตัวตน</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2094"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/identification/sq" class="mm-listitem__text" lang="sq">Identifikimi</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2095"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/identification/fa" class="mm-listitem__text" lang="fa">احراز هويت</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2162"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/enter-finland-for-employers1" class="mm-listitem__text">Enter Finland for Employers</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2462"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/service-breaks-in-enter-finland" class="mm-listitem__text">Technical difficulties and interruptions in Enter Finland</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1092"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/book-an-appointment" class="mm-listitem__text has-btn">Book an appointment at a service point</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1092_1"> <span class="sr-only">Book an appointment at a service point - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1092" aria-label="Book an appointment at a service point - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1364"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/service-points" class="mm-listitem__text">Service points</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1760"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/how-to-book-an-appointment" class="mm-listitem__text">How to book an appointment</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_3485"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/group-appointments" class="mm-listitem__text">Group appointments</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1365"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/handling-matters-at-a-service-point" class="mm-listitem__text has-btn">Handling matters at a service point</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1365_3"> <span class="sr-only">Handling matters at a service point - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1365" aria-label="Handling matters at a service point - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_1426"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/security-checks-at-the-finnish-immigration-service" class="mm-listitem__text">Security checks at the Finnish Immigration Service</a> 
+             </div></li> 
+           </ul></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2166"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/telephone-service1" class="mm-listitem__text">Telephone service</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_3502"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/ask-for-guidance-by-email" class="mm-listitem__text">Ask for guidance by email</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_3404"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/partners-and-stakeholders" class="mm-listitem__text has-btn">Partners and stakeholders</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_3404_4"> <span class="sr-only">Partners and stakeholders - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_3404" aria-label="Partners and stakeholders - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_3405"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/partners-and-stakeholders/resource-library" class="mm-listitem__text">Resource library</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_3605"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/pact" class="mm-listitem__text">Pact on Migration and Asylum</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1096"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/faq" class="mm-listitem__text has-btn">Frequently Asked Questions</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1096_5"> <span class="sr-only">Frequently Asked Questions - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1096" aria-label="Frequently Asked Questions - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1408"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/faq-handling-matters-at-a-service-point" class="mm-listitem__text">Handling matters at a service point</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1778"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/faq-online-service" class="mm-listitem__text">Online service Enter Finland</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1398"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/faq-application-forms" class="mm-listitem__text">Application forms</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1405"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/faq-residence-permits" class="mm-listitem__text has-btn">Residence permits</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1405_3"> <span class="sr-only">Residence permits - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1405" aria-label="Residence permits - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_1411"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/faq-residence-permit-card" class="mm-listitem__text">The residence permit card</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1423"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/faq-family" class="mm-listitem__text">Family</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1420"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/faq-employment" class="mm-listitem__text">Employment</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2329"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/faq-fast-track" class="mm-listitem__text">Fast track</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1436"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/faq-seasonal-work" class="mm-listitem__text">Seasonal work</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1414"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/faq-students" class="mm-listitem__text">Students</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1417"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/faq-returnees" class="mm-listitem__text">Returnees</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3466"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/faq-extended-permit" class="mm-listitem__text">Extended permit</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3547"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/faq-permanent-residence-permits" class="mm-listitem__text">Permanent residence permits</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1395"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/faq-eu-citizens" class="mm-listitem__text">EU citizens</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1401"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/faq-refugees-and-asylum-seekers" class="mm-listitem__text has-btn">Refugees and asylum seekers</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1401_5"> <span class="sr-only">Refugees and asylum seekers - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1401" aria-label="Refugees and asylum seekers - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_1331"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/frequently-asked-questions-about-processing-times-for-asylum-applications" class="mm-listitem__text">Processing times for asylum applications</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_1383"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/interviewing-children" class="mm-listitem__text">Interviewing children</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1392"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/faq-finnish-citizenship" class="mm-listitem__text has-btn">Finnish citizenship</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1392_6"> <span class="sr-only">Finnish citizenship - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1392" aria-label="Finnish citizenship - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_2869"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/faq-finnish-citizenship-application-submitted-before-1-october-2024" class="mm-listitem__text">Finnish citizenship - application submitted before 1 October 2024</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2035"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/brexit3" class="mm-listitem__text">Brexit</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2728"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/changes-in-your-situation" class="mm-listitem__text">Changes in your situation</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2036"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/employers" class="mm-listitem__text">Employers</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2746"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/faq-automation" class="mm-listitem__text">Automation</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2048"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/faq-afghanistan" class="mm-listitem__text has-btn">Current situation in Afghanistan</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2048_11"> <span class="sr-only">Current situation in Afghanistan - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_2048" aria-label="Current situation in Afghanistan - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_2063"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/faq-afghanistan/dari" class="mm-listitem__text" lang="fa-AF">سوالات اغلب پرسیدە شدە در بارە وضعیت افغانستان</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2171"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/faq-ukraine" class="mm-listitem__text">Russia's attack on Ukraine</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2182"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/faq-russias-attack-on-ukraine-and-its-effects-on-russian-citizens" class="mm-listitem__text has-btn">Russia's attack on Ukraine and its effects on Russian citizens</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2182_13"> <span class="sr-only">Russia's attack on Ukraine and its effects on Russian citizens - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_2182" aria-label="Russia's attack on Ukraine and its effects on Russian citizens - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_2196"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/faq-russias-attack-on-ukraine-and-its-effects-on-russian-citizens-russian" class="mm-listitem__text">Часто задаваемые вопросы о нападении России на Украину и его влиянии на россиян</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2759"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/faq-situation-at-finland-s-eastern-border" class="mm-listitem__text">Situation at Finland’s eastern border</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2965"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/updates-about-syria" class="mm-listitem__text has-btn">Updates about Syria</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_2965_15"> <span class="sr-only">Updates about Syria - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_2965" aria-label="Updates about Syria - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_2966"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/updates-about-syria-arabic" class="mm-listitem__text">معلومات حديثة عن وضع سوريا</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2967"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/updates-about-syria-kmr" class="mm-listitem__text">Nûtirîn agahî derbarê rewşa Sûriyê</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_3454"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/situation-in-iran" class="mm-listitem__text has-btn">Situation in Iran</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_3454_16"> <span class="sr-only">Situation in Iran - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_3454" aria-label="Situation in Iran - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_3455"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/situation-in-iran/fa" class="mm-listitem__text" lang="fa">پرسش‌های متداول درباره وضعیت ایران</a> 
+             </div></li> 
+           </ul></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1097"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/instructions" class="mm-listitem__text has-btn">Instructions</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1097_6"> <span class="sr-only">Instructions - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1097" aria-label="Instructions - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1768"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/applying-for-a-residence-permit" class="mm-listitem__text">Applying for a residence permit</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1766"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/booking-an-appointment" class="mm-listitem__text">Booking an appointment</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1767"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/visiting-a-service-point" class="mm-listitem__text">Visiting a service point</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1904"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/language-analysis" class="mm-listitem__text">Language analysis</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1598"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/asyluminterview" class="mm-listitem__text">Asylum interview</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1264"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/interpretation-translation-and-legalisation" class="mm-listitem__text">Interpretation, translation and legalisation</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1837"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/positive-decision-for-an-asylum-seeker" class="mm-listitem__text">Positive decision for an asylum seeker</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1838"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/negative-decision-for-an-asylum-seeker" class="mm-listitem__text">Negative decision for an asylum seeker</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1994"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/instructions/seasonal-work" class="mm-listitem__text">Seasonal work</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1987"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/instructions/family-reunification" class="mm-listitem__text">Family reunification</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1371"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/videos" class="mm-listitem__text has-btn">Videos</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1371_10"> <span class="sr-only">Videos - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1371" aria-label="Videos - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_1742"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/videos-for-asylum-seekers" class="mm-listitem__text">Videos for asylum seekers</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2952"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/videos-for-quota-refugees" class="mm-listitem__text">Videos for quota refugees</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1990"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/instructions/information-about-finland" class="mm-listitem__text">Information about Finland</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2123"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/instructions/health" class="mm-listitem__text">Health</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2332"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/starting-work" class="mm-listitem__text">Starting work</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_3624"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/euaa-instructions" class="mm-listitem__text has-btn">EUAA's instructions</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_3624_14"> <span class="sr-only">EUAA's instructions - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_3624" aria-label="EUAA's instructions - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_3634"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/euaa-asylum-application" class="mm-listitem__text">Asylum application</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3635"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/euaa-border-procedure" class="mm-listitem__text">Border procedure</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3636"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/euaa-subsequent-application" class="mm-listitem__text">Subsequent application</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3637"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/euaa-subsequent-application-in-border-procedure" class="mm-listitem__text">Subsequent application in border procedure</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3638"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/euaa-unaccompanied-child" class="mm-listitem__text">Unaccompanied child</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3639"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/euaa-child-accompanying-family" class="mm-listitem__text">Child accompanying a family</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3640"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/euaa-illegal-stay" class="mm-listitem__text">Illegal stay in Finland</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3641"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/eurodac-en" class="mm-listitem__text">Eurodac</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3642"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/istructions-temprorary-protection" class="mm-listitem__text">Temprorary protection</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_3645"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/euaa-finnish-immigration-service" class="mm-listitem__text">Application submitted to the Finnish Immigration Service</a> 
+             </div></li> 
+           </ul></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1125"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/brochures-and-publications" class="mm-listitem__text">Brochures and publications</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1094"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/check-the-processing-time-of-your-application" class="mm-listitem__text">Check the processing time of your application</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2735"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/give-feedback" class="mm-listitem__text">Give feedback</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_448"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/about-us" class="mm-listitem__text has-btn">About us</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_448_10"> <span class="sr-only">About us - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_448" aria-label="About us - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_494"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/contact-information" class="mm-listitem__text">Contact information</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1113"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/working-for-the-finnish-immigration-service" class="mm-listitem__text">Working for the Finnish Immigration Service</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1116"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/operations-and-finances" class="mm-listitem__text">Operations and finances</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2751"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/projects" class="mm-listitem__text">Projects</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1117"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/division-of-tasks-in-immigration-affairs" class="mm-listitem__text has-btn">Division of tasks in immigration affairs</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1117_4"> <span class="sr-only">Division of tasks in immigration affairs - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1117" aria-label="Division of tasks in immigration affairs - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_1118"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/integration/en" class="mm-listitem__text">Integration</a> 
+             </div></li> 
+           </ul></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2341"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/ethical-reporting-channel" class="mm-listitem__text">Ethical reporting channel</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1126"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/data-protection" class="mm-listitem__text has-btn">Data protection</a> 
+            <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1126_6"> <span class="sr-only">Data protection - submenu</span> 
+             <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+               
+             <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+           </div> 
+           <ul class="child-menu mm-listview " id="child_menu_1126" aria-label="Data protection - submenu"> 
+            <li class="mm-listitem level-4" id="mobile-layout_1918"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/your-rights-related-to-the-processing-personal-data" class="mm-listitem__text">Your rights related to the processing personal data</a> 
+             </div></li> 
+            <li class="mm-listitem level-4" id="mobile-layout_2117"> 
+             <div class="nav-item__container"> 
+              <a href="https://migri.fi/en/description-of-document-publicity" class="mm-listitem__text">Description of document publicity</a> 
+             </div></li> 
+           </ul></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2697"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/newsroom1" class="mm-listitem__text">Newsroom</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1123"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/emn/en" class="mm-listitem__text">EMN</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1119"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/country-information-service" class="mm-listitem__text has-btn">Country Information Service</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_1119_13"> <span class="sr-only">Country Information Service - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_1119" aria-label="Country Information Service - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1120"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/organisation-and-contact-information" class="mm-listitem__text">Organisation and contact information</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1121"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/reports" class="mm-listitem__text">Reports</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1122"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/tellus-electronic-database-for-country-of-origin-information" class="mm-listitem__text">Tellus electronic database for country of origin information</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1277"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/reception-centres" class="mm-listitem__text">Reception centres</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_1318"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/detention-units" class="mm-listitem__text">Detention units</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_454"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/social-media" class="mm-listitem__text">Social media</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_2720"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/safe-use-of-online-services" class="mm-listitem__text">Safe use of online services</a> 
+         </div></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_463"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/press-releases-and-bulletins" class="mm-listitem__text has-btn">Press releases and bulletins</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_463_18"> <span class="sr-only">Press releases and bulletins - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_463" aria-label="Press releases and bulletins - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_464"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/customer-bulletins" class="mm-listitem__text">Customer bulletins</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_465"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/press-releases" class="mm-listitem__text">Press releases</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_466"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/rss-feeds" class="mm-listitem__text">RSS feeds</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_560"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/sign-up-for-news" class="mm-listitem__text">Sign up for news</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1921"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/newsletters" class="mm-listitem__text">Newsletters</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_555"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/statistics" class="mm-listitem__text has-btn">Statistics</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_555_19"> <span class="sr-only">Statistics - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_555" aria-label="Statistics - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_1584"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/using-the-statistical-service" class="mm-listitem__text">Using the statistical service</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2714"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/situation-picture-of-immigration-in-finland" class="mm-listitem__text">Situation picture of immigration in Finland</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_2449"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/forecasts" class="mm-listitem__text">Forecasts</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1368"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/terminated-reception-services" class="mm-listitem__text">Terminated reception services</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1443"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/quota-refugee-statistics" class="mm-listitem__text">Quota refugee statistics</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1586"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/assistance-system-statistics" class="mm-listitem__text">Assistance system statistics</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1587"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/old-statistics" class="mm-listitem__text">Old statistics</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_1585"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/key-figures-on-immigration" class="mm-listitem__text">Annual publications on immigration</a> 
+           </div></li> 
+          <li class="mm-listitem level-3" id="mobile-layout_558"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/statistics-by-other-authorities" class="mm-listitem__text">Statistics by other authorities</a> 
+           </div></li> 
+         </ul></li> 
+        <li class="mm-listitem level-2" id="mobile-layout_450"> 
+         <div class="nav-item__container"> 
+          <a href="https://migri.fi/en/glossary" class="mm-listitem__text has-btn">Glossary</a> 
+          <button class="yja-mobile-navigation__button yja-mobile-navigation__button--toggler" aria-expanded="false" controls="child_menu_450_20"> <span class="sr-only">Glossary - submenu</span> 
+           <svg class="lexicon-icon lexicon-icon-angle-right" role="presentation" viewBox="0 0 512 512"> 
+             
+           <g>
+	<path class="lexicon-icon-outline" d="M375.2,239.2L173.3,37c-23.6-23-59.9,11.9-36,35.1l183,183.9L137.4,439.8c-24,23.5,12.5,58.2,36.1,35.2l201.7-202.1C385.4,262.8,384.5,248.5,375.2,239.2z"></path>
+</g></svg> </button> 
+         </div> 
+         <ul class="child-menu mm-listview " id="child_menu_450" aria-label="Glossary - submenu"> 
+          <li class="mm-listitem level-3" id="mobile-layout_451"> 
+           <div class="nav-item__container"> 
+            <a href="https://migri.fi/en/our-name-and-translations" class="mm-listitem__text">Our name and translations</a> 
+           </div></li> 
+         </ul></li> 
+       </ul></li> 
+     </ul> 
+    </div> 
+    <button class="yja-mobile-navigation__button sr-only" id="yjaMenuBottomButton">Close menu</button> 
+   </div> 
+  </nav> 
+  <script src="    https://migri.fi/o/yja-site-template-theme/js/flickity.pkgd.min.js?browserId=chrome&amp;languageId=en_US&amp;t=1780930970000
+"></script> 
+  <script src="/o/common-ui-resources/standalone/mobile-navigation/js/main.js?browserId=chrome&amp;languageId=en_US&amp;t=1780930970000
+"></script> 
+  <script src="    https://migri.fi/o/yja-site-template-theme/js/lazysizes.js?browserId=chrome&amp;languageId=en_US&amp;t=1780930970000
+"></script> 
+  <script src="    https://migri.fi/o/yja-site-template-theme/js/jquery.matchHeight-min.js?browserId=chrome&amp;languageId=en_US&amp;t=1780930970000
+"></script> 
+  <script src="    https://migri.fi/o/yja-site-template-theme/js/js.cookie.js?browserId=chrome&amp;languageId=en_US&amp;t=1780930970000
+"></script> 
+  <script src="    https://migri.fi/o/yja-site-template-theme/js/a11y-dialog.min.js?browserId=chrome&amp;languageId=en_US&amp;t=1780930970000
+"></script> 
+  <script src="    https://migri.fi/o/yja-site-template-theme/js/app.js?browserId=chrome&amp;languageId=en_US&amp;t=1780930970000
+"></script> 
+  <script src="/o/common-ui-resources/standalone/owl/js/owl.carousel.min.js?browserId=chrome&amp;languageId=en_US&amp;t=1780930970000
+"></script> 
+  <script src="/o/common-ui-resources/standalone/a11y/js/a11y-navigation.js?browserId=chrome&amp;languageId=en_US&amp;t=1780930970000
+"></script> 
+  <script>
+		const mobileNavConfig = {
+			elementsToHide: '.page-wrapper'
+		}
+		yjaMobileNavigation(mobileNavConfig);
+
+	/* Check if there exists #content-main element, if not add one */
+	var contentMain = document.getElementById("content-main");
+
+	if (contentMain === null) {
+		var span = document.createElement('span');
+		var mainContent = document.getElementById('main-content');
+
+		if (mainContent !== null) {
+			span.id = 'content-main';
+			mainContent.insertBefore(span, mainContent.firstChild)
+		}
+	}
+</script> 
+  <script src="https://migri.fi/o/fi.yja.sitetemplatesettings.web/js/header.js?browserId=chrome&amp;languageId=en_US&amp;t=1780930968000" type="text/javascript"></script> 
+  <script src="https://migri.fi/o/fi.yja.sitetemplatesettings.web/js/footer.js?browserId=chrome&amp;languageId=en_US&amp;t=1780930968000" type="text/javascript"></script> 
+  <script src="https://migri.fi/o/common-ui-resources/standalone/jquery/js/chosen.jquery.min.js?browserId=chrome&amp;languageId=en_US&amp;t=1780637642000" type="text/javascript"></script> 
+  <script src="https://migri.fi/o/fi.yja.language.version.tool.web/js/main.js?browserId=chrome&amp;languageId=en_US&amp;t=1780637642000" type="text/javascript"></script> 
+  <script type="text/javascript">
+// <![CDATA[
+
+	
+		
+
+			
+
+			
+		
+	
+
+// ]]>
+</script> 
+  <script type="text/javascript">
+	// <![CDATA[
+
+		
+
+		Liferay.currentURL = '\x2fen\x2finsurance';
+		Liferay.currentURLEncoded = '\x252Fen\x252Finsurance';
+
+	// ]]>
+</script> 
+  <script type="text/javascript">
+		// <![CDATA[
+			
+				$('body').addClass('migri-1234');
+
+var siteCurrentLang = $('html').attr('lang');
+
+var siteLangVars = {
+    'fi-FI' : {
+        'openMenu' : 'Avaa alavalikko',
+        'closeMenu' : 'Sulje alavalikko'
+    },
+    'sv-SE' : {
+        'openMenu' : 'Öppna undermenyn',
+        'closeMenu' : 'Stäng undermenyn'
+    },
+    'en-US' : {
+        'openMenu' : 'Open submenu',
+        'closeMenu' : 'Close submenu'
+    }
+};
+
+if(siteCurrentLang !== 'fi-FI' && siteCurrentLang !== 'sv-SE' && siteCurrentLang !== 'en-US') {
+    siteCurrentLang = 'en-US';
+}
+
+// NEWSROOM Feeds
+$('.feeds__wrapper .feed--newsroom').each(function() {
+    var state = $(this).hasClass('feeds__lift--hidden') === true;
+    if(state){
+        $(this).attr("style", "visibility:hidden");
+    } else {
+        $(this).attr("style", "visibility:visible");
+    }
+});
+
+// ACCORDION
+$('.collapsible h3').each(function() {
+    var $this = $(this);
+
+    // wrap the content and make it focusable
+    var panel = $this.next();
+    var button = $this.children('button');
+
+    // Pointer
+    $this.on('click', function() {
+        var state = $(this).attr('aria-expanded') === 'false' ? true : false;
+        $(this).attr('aria-expanded', state); // commands the parent of the button
+        button.attr('aria-expanded', state); // commands the button
+        panel.attr('aria-hidden', !state);
+    });
+    
+    // Keypress
+    $this.on('keypress',function(evt) {
+
+      if(evt.which == 13) {
+        var state = $(this).attr('aria-expanded') === 'false' ? true : false;
+        $this.attr('aria-expanded', state); // commands the parent of the button
+        button.attr('aria-expanded', state); // commands the button
+        panel.attr('aria-hidden', !state);
+      }
+  })
+});
+
+
+document.addEventListener('DOMContentLoaded', function(event){
+    var d = document;
+
+    var body = d.querySelector('body:not(.portal-popup)');
+
+    if (body != null) {
+        var dl_portlet = body.querySelectorAll('.portlet-document-library-display');
+
+        if (typeof(dl_portlet) != 'undefined' ) {
+            checkLinks(dl_portlet);
+        }
+    }
+}, false);
+
+function checkLinks(p) {
+    for (var i=0;i<p.length;i++) {
+        var el = p[i];
+        var l = el.querySelectorAll('a');
+        for (var j=0;j<l.length;j++) {
+            var t = l[j];
+            var u = t.href;
+            if ( u.startsWith('http') ) {
+                addExternalLink(t);
+            }
+        }
+    }
+}
+
+function addExternalLink(e) {
+//e.classList.add('external-link');
+    if (e.getAttribute('target') === null ) {
+        e.setAttribute('target','_blank');
+    }
+}
+
+
+function onDemandScript(url, callback) {
+    callback = (typeof callback != 'undefined') ? callback : {};
+
+    jQuery.ajax({
+        type: "GET",
+        url: url,
+        success: callback,
+        dataType: "script",
+        cache: true
+    });
+}
+//
+// NEWSROOM
+//
+var d = document;
+var nrShowMoreButton = d.querySelector('.js-showMoreItems');
+
+if (nrShowMoreButton !== null) {
+    nrShowMoreButton.addEventListener('click', function(evt){
+        var btn = evt.target;
+        var feedWrapper = btn.parentElement.previousElementSibling;
+
+        btn.classList.add('u-isHidden');
+
+        var feeds = feedWrapper.querySelectorAll('.feeds__lift--hidden');
+        if (feeds.length > 0) {
+            for (var i=0;feeds.length;i++) {
+                var feed = feeds[i];
+                feed.classList.remove('feeds__lift--hidden');
+                feed.setAttribute("style", "visibility:visible");
+            }
+        }
+
+    },false);
+}
+
+if (document.body.classList.contains('newsroom')) {
+    var url = window.location;
+    var urlPath = url.pathname;
+    var navElem = document.querySelector('.navigation--inline');
+
+    if (navElem != null) {
+        var navElemTitle = navElem.querySelector('h2');
+        if (navElemTitle != null) {
+            if (urlPath.indexOf('uutishuone') != -1) {
+                navElemTitle.classList.add('selected');
+            } else {
+                navElemTitle.classList.remove('selected');
+            }
+        }
+    }
+
+
+
+}
+
+// Newsroom accordion
+var accordions = document.querySelectorAll('.collapsibles');
+if (accordions.length > 0) {
+    for (var i=0; i < accordions.length; i++) {
+        var accordion = accordions[i];
+        var items = accordion.querySelectorAll('.collapsible__item');
+        if (items.length > 0) {
+            for (var j=0; j < items.length;j++) {
+                var item = items[j];
+                var itemButton = item.querySelector('button');
+                console.log(itemButton.getAttribute('aria-expanded'));
+
+                itemButton.addEventListener('click',function(evt) {
+
+                   var target = evt.target;
+                   var id = target.getAttribute('aria-controls');
+
+                   var parent = target.parentElement;
+                   var content = parent.nextElementSibling;
+
+                    console.log('before change: ',target.getAttribute('aria-expanded'));
+                    target.setAttribute('aria-expanded', target.getAttribute('aria-expanded') ===  'false' ? 'true'  : 'false');
+                    content.setAttribute('aria-hidden', content.getAttribute('aria-hidden') ===  'true' ? 'false'  : 'true');
+                    console.log('after change: ',target.getAttribute('aria-expanded'));
+                });
+            }
+        }
+    }
+}
+
+// Youtube-video player
+document.addEventListener("DOMContentLoaded", function() {
+    var vPlayers = d.querySelectorAll('.video__listing');
+    if (vPlayers.length > 0) {
+        for (var i = 0; i < vPlayers.length; i++) {
+            var vPlayer = vPlayers[i];
+            var videoItems = vPlayer.querySelectorAll('.video__item');
+            if (videoItems.length > 0) {
+                for (var j = 0; i < videoItems.length; i++) {
+                    var videoData = [];
+                    var video = videoItems[j];
+                    var player = video.querySelector('.video__placeholder');
+                    var videoId = player.dataset.id;
+                    if (videoId !== undefined) {
+                        getJSON('https://cors-anywhere.herokuapp.com/https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=' + videoId + '&format=json',
+                            function (err, data) {
+                                if (err !== null) {
+                                    console.log('Something went wrong: ' + err);
+                                } else {
+                                 // populateVideo(data, player);
+                                }
+                            });
+
+                    }
+
+                }
+            }
+
+        }
+
+    }
+});
+
+function populateVideo(data, elem) {
+    var imageContainer = elem.querySelector('.video__placeholder');
+    var img = elem.querySelector('img');
+    img.src = data.thumbnail_url;
+}
+
+function getJSON( url, callback) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', url, true);
+    xhr.responseType = 'json';
+    xhr.onload = function() {
+        var status = xhr.status;
+        if (status === 200) {
+            callback(null, xhr.response);
+        } else {
+            callback(status, xhr.response);
+        }
+    };
+    xhr.send();
+};
+
+/*
+* Infographics, draw infographic connectors
+*/
+var infographImageFolder = '/documents/5202425/15345026/';
+
+var infoPaths = function infoPaths() {
+
+    // Loop thru infographics
+    var infographs = jQuery('.infograph-wrapper');
+
+    infographs.each(function(igElementIndex) {
+
+        var igWrapper = jQuery(infographs[igElementIndex]);
+        var igWrapperID = jQuery(infographs[igElementIndex]).attr("id");
+
+        var infographWrapperWidth = igWrapper.width(),
+            containerWidth = 770;
+        if (infographWrapperWidth < containerWidth) {
+            igWrapper.css({
+                'font-size': infographWrapperWidth / containerWidth + 'em'
+            });
+            igWrapper.attr('data-font-size', infographWrapperWidth / containerWidth);
+            jQuery('.infopath').fadeIn();
+            fontBaseSize = 15;
+        } else {
+
+            igWrapper.css({
+                'font-size': '1em'
+            });
+            igWrapper.attr('data-font-size', '1');
+            jQuery('.infopath').fadeIn();
+
+            fontBaseSize = 15;
+        }
+
+        var steps = igWrapper.find('.infograph-step');
+        var stepCount = steps.length;
+        steps.each(function(stepIndex) {
+            if (stepCount > stepIndex + 1) {
+                var element = jQuery(this).closest('.infograph-grid-item'),
+                    elementWidth = element.outerWidth(),
+                    innerElementHeight = element.find('.infograph-step').height();
+                    elementHeight = element.outerHeight(),
+                    nextElementHeight = jQuery('#' + igWrapperID + ' #block-grid-item-' + (stepIndex + 1)).outerHeight(),
+                    iconElement = jQuery('#' + igWrapperID + ' #step-' + stepIndex),
+                    elementOffsetTop = iconElement.offset().top,
+                    nextElementOffsetTop = jQuery('#' + igWrapperID + ' #step-' + (stepIndex + 1)).offset().top,
+                    line = element.find('.infopath'),
+                    posTop1 = iconElement.position().top + 15,
+                    posTop2 = jQuery('#' + igWrapperID + ' #step-' + (stepIndex + 1)).position().top + 15,
+                    posTopMax = Math.max(posTop1, posTop2),
+                    posTopMin = Math.min(posTop1, posTop2),
+                    flipArrow = false,
+                    mobile = false,
+                    fontsizeAdjust = jQuery('#' + igWrapperID + ' .infograph-wrapper').attr('data-font-size');
+
+                var linePosTop, linePosRight, lineHeight;
+
+                if (jQuery(window).width() > 767) {
+                    if (stepIndex > 3 && stepIndex < 7) {
+                        flipArrow = true;
+                        setAngleAndPostion(elementOffsetTop, nextElementOffsetTop, elementWidth, posTop1, line, flipArrow, mobile, fontBaseSize);
+                    } else if (stepIndex == 3) {
+                        var height = nextElementOffsetTop - elementOffsetTop;
+                        if (height < 100) {
+                            lineHeight = height;
+                            lineWidth = height * 0.3;
+                            styles =
+                                'background-image: url(' + infographImageFolder + '/infopath-down-small.png?t=1649754594688);' +
+                                '-moz-transform: rotate(0);' +
+                                '-webkit-transform: rotate(0);' +
+                                '-o-transform: rotate(0);' +
+                                '-ms-transform: rotate(0);' +
+                                '-ms-transform: rotate(0);' +
+                                'transform: rotate(0);' +
+                                'height:' + lineHeight + 'px;' +
+                                'width:' + lineWidth + 'px;' +
+                                'left:105%;'
+                            if (iconElement.hasClass('info-icon-top')) {
+                                styles = styles + 'top:' + 35 / fontBaseSize + 'em';
+                            } else {
+                                styles = styles + 'top:50%;';
+                            }
+                            line.attr('style', styles);
+                        } else {
+                            lineHeight = height;
+                            lineWidth = height * 0.4;
+                            styles =
+                                '-moz-transform: rotate(0);' +
+                                '-webkit-transform: rotate(0);' +
+                                '-o-transform: rotate(0);' +
+                                '-ms-transform: rotate(0);' +
+                                '-ms-transform: rotate(0);' +
+                                'transform : rotate(0);' +
+                                'height:' + lineHeight + 'px;' +
+                                'width:' + lineWidth + 'px;' +
+                                'left:105%;'
+                            if (iconElement.hasClass('info-icon-top')) {
+                                styles = styles + 'top:' + 35 / fontBaseSize + 'em';
+                            } else {
+                                styles = styles + 'top:50%;';
+                            }
+
+                            line.attr('style', styles);
+                        }
+                    } else if (stepIndex == 7) {
+                        var height = nextElementOffsetTop - elementOffsetTop;
+                        if (height < 100) {
+                            linePosTop = (posTop1 + 10) / fontBaseSize;
+                            linePosLeft = 8 / fontBaseSize * -1;
+                            lineHeight = height;
+                            lineWidth = height * 0.25;
+                            styles =
+                                'background-image: url(' + infographImageFolder + '/infopath-down-small.png?t=1649754594688);' +
+                                '-moz-transform: scaleX(-1);' +
+                                '-webkit-transform: scaleX(-1);' +
+                                '-o-transform: scaleX(-1);' +
+                                '-ms-transform: scaleX(-1);' +
+                                '-ms-transform: scaleX(-1);' +
+                                'transform: scaleX(-1);' +
+                                'height:' + lineHeight + 'px;' +
+                                'width:' + lineWidth + 'px;' +
+                                'left:-90%;'
+                            if (iconElement.hasClass('info-icon-top')) {
+                                styles = styles + 'top:' + 35 / fontBaseSize + 'em';
+                            } else {
+                                styles = styles + 'top:50%;';
+                            }
+                            line.attr('style', styles);
+                        } else {
+                            linePosTop = 35 / fontBaseSize;
+                            lineHeight = height;
+                            lineWidth = height * 0.4;
+                            linePosRight = (elementWidth / 2) / fontBaseSize;
+                            styles =
+                                '-moz-transform: scaleX(-1);' +
+                                '-webkit-transform: scaleX(-1);' +
+                                '-o-transform: scaleX(-1);' +
+                                '-ms-transform: scaleX(-1);' +
+                                '-ms-transform: scaleX(-1);' +
+                                'transform: scaleX(-1);' +
+                                '-webkit-transform-origin: 0 100%;' +
+                                '-o-transform-origin: 0 100%;' +
+                                '-ms-transform-origin: 0 100%;' +
+                                'transform-origin: 0 100%;' +
+                                'height:' + lineHeight + 'px;' +
+                                'width:' + lineWidth + 'px;' +
+                                'left:-5%;'
+                            if (iconElement.hasClass('info-icon-top')) {
+                                styles = styles + 'top:' + 35 / fontBaseSize + 'em';
+                            } else {
+                                styles = styles + 'top:50%;';
+                            }
+                            line.attr('style', styles);
+                        }
+                    } else {
+                        flipArrow = false;
+                        setAngleAndPostion(elementOffsetTop, nextElementOffsetTop, elementWidth, posTop1, line, flipArrow, mobile, fontBaseSize);
+                    }
+
+                } else {
+                    mobile = true;
+                    if (stepIndex % 2 == 0) {
+                        flipArrow = false;
+                        setAngleAndPostion(elementOffsetTop, nextElementOffsetTop, elementWidth, posTop1, line, flipArrow, mobile, fontBaseSize);
+                    } else {
+                        flipArrow = true;
+                        setAngleAndPostion(elementOffsetTop, nextElementOffsetTop, elementWidth, posTop1, line, flipArrow, mobile, fontBaseSize);
+                    }
+                }
+            }
+        });
+    });
+};
+
+var setAngleAndPostion = function setAngleAndPostion(elementOffsetTop, nextElementOffsetTop, elementWidth, posTop1, line, flipArrow, mobile, fontBaseSize) {
+    var opposite = Math.abs(elementOffsetTop - nextElementOffsetTop),
+        hypotenuse = Math.sqrt(opposite * opposite + elementWidth * elementWidth),
+        sinOfAngleX = opposite / hypotenuse,
+        bg = "",
+        angle = Math.asin(sinOfAngleX) * 180 / Math.PI;
+    if (flipArrow) {
+        hpos = 'right: ' + ((elementWidth / 2) / fontBaseSize) + 'em;'
+
+        if (elementOffsetTop - nextElementOffsetTop > 0) {
+            angle = angle * 1.2;
+            hpos = 'right: 105%;';
+            vpos = 'bottom: 22%;';
+            origin = '-webkit-transform-origin: 100% 0; -o-transform-origin: 100% 0;-ms-transform-origin: 100% 0;transform-origin: 100% 0;';
+        } else {
+            angle = (angle * 1.2) * -1;
+            hpos = 'right: 103%;';
+            vpos = 'top: 22%;';
+            origin = '-webkit-transform-origin:100% 100%; -o-transform-origin: 100% 100%;-ms-transform-origin: 100% 100%;transform-origin: 100% 100%;';
+            bg = 'background-image: url(' + infographImageFolder + '/infopath-left2.png?t=1649754594688);'
+        }
+
+        if (mobile) {
+            vpos = 'bottom: 1em; ';
+            hpos = 'right: ' + ((elementWidth / 2 + 25) / fontBaseSize) + 'em;';
+            angle = angle;
+            hypotenuse = hypotenuse / 1.3;
+            height = hypotenuse * 0.18;
+
+        }
+    } else {
+        hpos = 'left: 105%;';
+        vpos = 'top: 40%;';
+        origin = '-webkit-transform-origin: 0 100%; -o-transform-origin: 0 100%;-ms-transform-origin: 0 100%;transform-origin: 0 100%;';
+
+        if (elementOffsetTop - nextElementOffsetTop > 0) {
+            angle = (angle * 1.2) * -1;
+            vpos = 'bottom: 35%;';
+            origin = '-webkit-transform-origin: 0 0; -o-transform-origin: 0 0;-ms-transform-origin: 0 0;transform-origin: 0 0;';
+            hpos = 'left: 105%;';
+            bg = 'background-image: url(' + infographImageFolder + '/infopath2.png?t=1649754594688);'
+        } else {
+            angle = angle * 1.2;
+        }
+
+        if (mobile) {
+            hpos = 'left: ' + ((elementWidth / 2 + 35) / fontBaseSize) + 'em;',
+                hypotenuse = hypotenuse / 1.3,
+                height = hypotenuse * 0.18;
+            vpos = 'top: 1.33em; ';
+
+        }
+    }
+
+
+    var styles = 'width:' + (hypotenuse - 35) + 'px;' +
+        '-moz-transform: rotate(' + angle + 'deg); ' +
+        '-webkit-transform: rotate(' + angle + 'deg); ' +
+        '-o-transform: rotate(' + angle + 'deg); ' +
+        '-ms-transform: rotate(' + angle + 'deg); ' +
+        '-ms-transform: rotate(' + angle + 'deg); ' +
+        'transform: rotate(' + angle + 'deg); ' +
+        vpos +
+        bg +
+        origin +
+        hpos;
+    if (mobile) {
+        styles = styles + 'height:' + height / fontBaseSize + 'em';
+    } else {
+        styles = styles + 'height:' + hypotenuse * 0.09 / fontBaseSize + 'em';
+    }
+
+    line.attr('style', styles);
+
+
+};
+
+jQuery('.close-tooltip').on('click', function(e) {
+    e.preventDefault();
+    jQuery('.infograph-tooltip').hide();
+});
+
+jQuery('.js-open-tooltip, .close-tooltip').on('click', function(e) {
+    e.preventDefault();
+    var elem = jQuery(this),
+        parent = elem.closest('.infograph-step'),
+        elementHeight = parent.outerHeight(),
+        tooltipPos = Math.abs(elem.position().top),
+        tooltipVertical = parent.find('.step-holder').position().top,
+        offset = parent.find('.step-holder').offset().top,
+        tooltip = parent.find('.infograph-tooltip');
+
+    jQuery('.infograph-tooltip').hide();
+
+    if (tooltip.hasClass('active-tooltip')) {
+        tooltip.removeClass('active-tooltip').hide();
+
+    } else {
+        jQuery('.infograph-tooltip').removeClass('active-tooltip');
+
+        if (offset < 800) {
+            tooltip.css({
+                'top': tooltipVertical + 60
+            });
+            tooltip.addClass('top-arrow active-tooltip');
+        } else {
+            if (parent.find('.step-holder').hasClass('info-icon-bottom')) {
+                tooltip.css({
+                    'bottom': 95
+                });
+            } else {
+                tooltip.css({
+                    'bottom': elementHeight + 25
+                });
+            }
+
+            tooltip.addClass('bottom-arrow active-tooltip');
+        }
+
+        tooltip.show();
+
+    }
+});
+
+var cachedWidth = jQuery(window).width();
+
+jQuery(window).resize(function() {
+    var newWidth = jQuery(window).width();
+    if (newWidth !== cachedWidth) {
+        jQuery('.infopath').hide();
+        waitForFinalEvent(function() {
+            infoPaths();
+        }, 400, "infopaths20192109");
+
+        cachedWidth = newWidth;
+    }
+});
+
+jQuery(document).ready(function() {
+    /** Init infopaths **/
+   infoPaths();
+});
+
+
+jQuery('.infographs a.step-holder').on('click', function(e){
+    if( jQuery(this).attr('href') == '' || jQuery(this).attr('href') == '#'){
+        e.preventDefault();
+    }
+});
+
+// -------------------------------------------------------------
+// Lang attribute handling
+function getLastPart(url) {
+    var parts = url.split("/");
+    return (url.lastIndexOf('/') !== url.length - 1 ? parts[parts.length - 1] : parts[parts.length - 2]);
+}
+function getLastDashPart(url) {
+    var parts = url.split("-");
+    return (url.lastIndexOf('-') !== url.length - 1 ? parts[parts.length - 1] : parts[parts.length - 2]);
+}
+$( document ).ready(function() {
+
+    if ($( ".journal-content-article" ).length){
+        var langCode = '';
+        var lastPartAfterSlash = getLastPart(window.location.href);
+        switch(lastPartAfterSlash)
+        {
+            case 'ru':
+                langCode = 'ru';
+                break;
+            case 'ku':
+                langCode = 'ku';
+                break;
+            case 'ar':
+                langCode = 'ar';
+                break;
+            case 'dari':
+                langCode = 'fa-AF';
+                break;
+            case 'fa':
+                langCode = 'fa';
+                break;
+            case 'so':
+                langCode = 'so';
+                break;
+            case 'ukr':
+                langCode = 'uk';
+                break;
+            case 'zh':
+                langCode = 'zh';
+                break;
+            case 'sq':
+                langCode = 'sq';
+                break;
+            case 'vi':
+                langCode = 'vi';
+                break;
+            case 'uz':
+                langCode = 'uz';
+                break;
+            default:
+                break;
+        }
+
+        var lastPartAfterDash = getLastDashPart(window.location.href);
+        switch(lastPartAfterDash)
+        {
+            case 'ubezisa':
+                langCode = 'ru';
+                break;
+            case 'ubezisa1':
+                langCode = 'ru';
+                break;
+            case 'ubezisa2':
+                langCode = 'ru';
+                break;
+            case 'sorani':
+                langCode = 'ku';
+                break;
+            case 'arabia':
+                langCode = 'ar';
+                break;
+            case 'dari':
+                langCode = 'fa-AF';
+                break;
+            case 'penaberiye':
+                langCode = 'ku';
+                break;
+            case 'penaberiye1':
+                langCode = 'ku';
+                break;
+            case 'penaberiye2':
+                langCode = 'ku';
+                break;
+            case 'persia':
+                langCode = 'fa';
+                break;
+            case 'qaxootinimo':
+                langCode = 'so';
+                break;
+            case 'qaxootinimo1':
+                langCode = 'so';
+                break;
+            case 'qaxootinimo2':
+                langCode = 'so';
+                break;
+            case 'ukr':
+                langCode = 'uk';
+                break;
+            case 'ukraini':
+                langCode = '';
+                langCode = 'uk';
+                break;
+            case 'ukrainian':
+                langCode = 'uk';
+                break;
+            case 'zh':
+                langCode = 'zh';
+                break;
+            case 'sq':
+                langCode = 'sq';
+                break;
+            case 'vi':
+                langCode = 'vi';
+                break;
+            case 'uz':
+                langCode = 'uz';
+                break;
+            case 'so':
+                langCode = 'so';
+                break;
+            default:
+                break;
+        }
+        if (langCode !== ''){
+            $(".breadcrumb .active").attr('lang', langCode);
+            $(".journal-content-article:not(:first, :last)").attr('lang', langCode);
+        }
+    }
+
+    jQuery('.list-menu, .mm-listview').find('a').each(function(){
+        var link = $(this).attr('href');
+        var lastPartAfterDash = getLastDashPart(link);
+        var lastPartAfterSlash = getLastPart(link);
+        if(lastPartAfterSlash === 'sorani' || lastPartAfterDash === 'sorani') {
+            $(this).attr('lang', 'ku');
+        }
+        if(lastPartAfterSlash === 'ar' || lastPartAfterDash === 'arabia') {
+            $(this).attr('lang', 'ar');
+        }
+        if(lastPartAfterSlash === 'dari' || lastPartAfterDash === 'dari') {
+            $(this).attr('lang', 'fa-AF');
+        }
+        if(lastPartAfterSlash === 'ku' || lastPartAfterDash === 'penaberiye' || lastPartAfterDash === 'penaberiye1' || lastPartAfterDash === 'penaberiye2') {
+            $(this).attr('lang', 'ku');
+        }
+        if(lastPartAfterSlash === 'fa' || lastPartAfterDash === 'persia') {
+            $(this).attr('lang', 'fa');
+        }
+        if(lastPartAfterSlash === 'so' || lastPartAfterDash === 'qaxootinimo' || lastPartAfterDash === 'qaxootinimo1' || lastPartAfterDash === 'qaxootinimo2') {
+            $(this).attr('lang', 'so');
+        }
+        if(lastPartAfterSlash === 'ukr' || lastPartAfterDash === 'ukr' || lastPartAfterDash === 'ukrainian'|| lastPartAfterDash === 'ukraini') {
+            $(this).attr('lang', 'uk');
+        }
+        if(lastPartAfterSlash === 'russian' || lastPartAfterSlash === 'ru' || lastPartAfterDash === 'ru' || lastPartAfterDash === 'ubezisa' || lastPartAfterDash === 'ubezisa1' || lastPartAfterDash === 'ubezisa2') {
+            $(this).attr('lang', 'ru');
+        }
+        if(lastPartAfterSlash === 'zh') {
+            $(this).attr('lang', 'zh');
+        }
+        if(lastPartAfterSlash === 'th') {
+            $(this).attr('lang', 'th');
+        }
+        if(lastPartAfterSlash === 'sq') {
+            $(this).attr('lang', 'sq');
+        }
+        if(lastPartAfterSlash === 'vi') {
+            $(this).attr('lang', 'vi');
+        }
+        if(lastPartAfterSlash === 'uz') {
+            $(this).attr('lang', 'uz');
+        }
+    });
+  });
+// -------------------------------------------------------------
+
+
+// -------------------------------------------------------------
+var lang = $("html").attr("lang");
+var legendText = '';
+
+$(document).ready(function() {
+    jQuery('.icons__direction--rtl').find('li').each(function(){
+        var link = $(this).children('a');
+        if(link.attr('title') === 'Facebook') {
+            link.children('span').html('Facebook');
+        }
+        if(link.attr('title') === 'Instagram') {
+            link.children('span').html('Instagram');
+        }
+        if(link.attr('title') === 'X') {
+            link.children('span').html('X');
+        }
+        if(link.attr('title') === 'YouTube') {
+            link.children('span').html('YouTube');
+        }
+        if(link.attr('title') === 'LinkedIn') {
+            link.children('span').html('LinkedIn');
+        }
+    });
+    jQuery('.lang-nav, .lang-text').removeAttr("aria-haspopup");
+    jQuery('.lang-nav, #languageSelectionMenu').removeAttr("role");
+    jQuery('.lang-nav, #languageSelectionMenu').find('li').each(function(){
+        $(this).removeAttr("role");
+    });
+
+    if($(".header-top-bar-links-right button span").length === 0) {
+        $(".header-top-bar-links-right button").append('<span class="sr-only">' + siteLangVars[siteCurrentLang].openMenu + '</span>')
+    }
+
+    if($('#main-content').length > 0 && ($('#content-main').length === 1 || $('#content-main').length === 0)) {
+        $('#main-content').prepend('<span id="content-main"></span>');
+    }
+
+    if($('.hero__themeHeading__text').length > 0){
+        $('.hero__themeHeading__text').wrap('<h1 class="hero-heading-migri"></h1>');
+    }
+
+    if(lang == 'fi-FI'){
+        legendText = "Hakemustyyppi";
+    }else if( lang == 'sv-SE'){
+        legendText = "Applikationstyp";
+    }else{
+        legendText = "Application type";
+    }
+
+    if($('.processTypeRadioContainer').length > 0){
+        $('.processTypeRadioContainer').children().wrapAll('<fieldset></fieldset>');
+        $('fieldset').css("display", "contents");
+
+        jQuery('.processTypeRadioContainer').find('fieldset').prepend('<legend class="sr-only">' + legendText + '</legend>');
+    }
+});
+
+// Haluan Hakea responsive block
+$(document).ready(function() {
+    var numItems = $('.haluan-hakea__category-list__category-wrapper').length;
+    
+    for (k = 1; k <= numItems; k++) {
+        var numDivs = $('.calcMe_' + k + ' .haluan-hakea__category-list__block').length;
+        $(".calcMe_" + k).addClass("has_" + numDivs);
+    }
+});
+
+
+
+
+// Ukrainan haku käännökset production data fix
+document.addEventListener("DOMContentLoaded", () => {
+	const bodyElement = document.body;
+	const hasUKClass = bodyElement.classList.contains('uk');
+	const translations = {
+		uk: {
+			label: 'Пошук на сайті',
+			link: 'На сторінку пошуку',
+			formservice: 'Пошук сервісу',
+		}
+	};
+	let currentLanguage = 'uk';
+
+	if (hasUKClass) {
+		function translate(key) {
+			return translations[currentLanguage][key] || key;
+		}
+
+		const placeholderElement = document.getElementById('_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb_search-keywords');
+		if (placeholderElement) {
+			placeholderElement.placeholder = translate('label');
+		}
+
+		const labelElements = document.querySelectorAll("[for='_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb_search-keywords']");
+		if (labelElements.length > 0) {
+			labelElements[0].textContent = translate('link');
+		}
+
+		const linkElement = document.getElementsByClassName('header-advanced-search-link')[0];
+		if (linkElement) {
+			linkElement.textContent = translate('link');
+		}
+
+		const formServiceElement = document.querySelectorAll("[for='yjaFessSearchField']")[0];
+		if (formServiceElement) {
+			formServiceElement.textContent = translate('formservice');
+		}
+	}
+});
+
+				
+
+				
+			
+		// ]]>
+	</script> 
+  <script type="text/javascript">
+// <![CDATA[
+(function() {var $ = AUI.$;var _ = AUI._;
+	var onVote = function (event) {
+		if (window.Analytics) {
+			Analytics.send('VOTE', 'Ratings', {
+				className: event.className,
+				classPK: event.classPK,
+				ratingType: event.ratingType,
+				score: event.score,
+			});
+		}
+	};
+
+	var onDestroyPortlet = function () {
+		Liferay.detach('ratings:vote', onVote);
+		Liferay.detach('destroyPortlet', onDestroyPortlet);
+	};
+
+	Liferay.on('ratings:vote', onVote);
+	Liferay.on('destroyPortlet', onDestroyPortlet);
+})();(function() {var $ = AUI.$;var _ = AUI._;
+	var onDestroyPortlet = function () {
+		Liferay.detach('messagePosted', onMessagePosted);
+		Liferay.detach('destroyPortlet', onDestroyPortlet);
+	};
+
+	Liferay.on('destroyPortlet', onDestroyPortlet);
+
+	var onMessagePosted = function (event) {
+		if (window.Analytics) {
+			Analytics.send('posted', 'Comment', {
+				className: event.className,
+				classPK: event.classPK,
+				commentId: event.commentId,
+				text: event.text,
+			});
+		}
+	};
+
+	Liferay.on('messagePosted', onMessagePosted);
+})();
+	var pathnameRegexp = /\/documents\/(\d+)\/(\d+)\/(.+?)\/([^&]+)/;
+
+	function sendAnalyticsEvent(anchor) {
+		var fileEntryId =
+			anchor.dataset.analyticsFileEntryId ||
+			(anchor.parentElement &&
+				anchor.parentElement.dataset.analyticsFileEntryId);
+
+		var title =
+			anchor.dataset.analyticsFileEntryTitle ||
+			(anchor.parentElement &&
+				anchor.parentElement.dataset.analyticsFileEntryTitle);
+
+		var getParameterValue = (parameterName) => {
+			var result = null;
+
+			anchor.search
+				.substr(1)
+				.split('&')
+				.forEach((item) => {
+					var tmp = item.split('=');
+
+					if (tmp[0] === parameterName) {
+						result = decodeURIComponent(tmp[1]);
+					}
+				});
+
+			return result;
+		};
+
+		var match = pathnameRegexp.exec(anchor.pathname);
+
+		if (fileEntryId && match) {
+			Analytics.send('documentDownloaded', 'Document', {
+				groupId: match[1],
+				fileEntryId,
+				preview: !!window._com_liferay_document_library_analytics_isViewFileEntry,
+				title: title || decodeURIComponent(match[3].replace(/\+/gi, ' ')),
+				version: getParameterValue('version'),
+			});
+		}
+	}
+
+	function handleDownloadClick(event) {
+		if (window.Analytics) {
+			if (event.target.nodeName.toLowerCase() === 'a') {
+				sendAnalyticsEvent(event.target);
+			}
+			else if (
+				event.target.parentNode &&
+				event.target.parentNode.nodeName.toLowerCase() === 'a'
+			) {
+				sendAnalyticsEvent(event.target.parentNode);
+			}
+			else if (
+				event.target.querySelector('.lexicon-icon-download') ||
+				event.target.classList.contains('lexicon-icon-download') ||
+				(event.target.parentNode &&
+					(event.target.parentNode.classList.contains(
+						'lexicon-icon-download'
+					) ||
+						event.target.parentNode.dataset.action === 'download'))
+			) {
+				var selectedFiles = document.querySelectorAll(
+					'.portlet-document-library .entry-selector:checked'
+				);
+
+				selectedFiles.forEach(({value}) => {
+					var selectedFile = document.querySelector(
+						'[data-analytics-file-entry-id="' + value + '"]'
+					);
+
+					sendAnalyticsEvent(selectedFile);
+				});
+			}
+		}
+	}
+
+	Liferay.once('destroyPortlet', () => {
+		document.body.removeEventListener('click', handleDownloadClick);
+	});
+
+	Liferay.once('portletReady', () => {
+		document.body.addEventListener('click', handleDownloadClick);
+	});
+(function() {var $ = AUI.$;var _ = AUI._;
+	var onShare = function (data) {
+		if (window.Analytics) {
+			Analytics.send('shared', 'SocialBookmarks', {
+				className: data.className,
+				classPK: data.classPK,
+				type: data.type,
+				url: data.url,
+			});
+		}
+	};
+
+	var onDestroyPortlet = function () {
+		Liferay.detach('socialBookmarks:share', onShare);
+		Liferay.detach('destroyPortlet', onDestroyPortlet);
+	};
+
+	Liferay.on('socialBookmarks:share', onShare);
+	Liferay.on('destroyPortlet', onDestroyPortlet);
+})();
+	if (window.svg4everybody && Liferay.Data.ICONS_INLINE_SVG) {
+		svg4everybody(
+			{
+				polyfill: true,
+				validate: function (src, svg, use) {
+					return !src || !src.startsWith('#');
+				}
+			}
+		);
+	}
+
+	
+		Liferay.Portlet.register('fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 0,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb_',
+			portletId: 'fi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d5844369\x26p_p_id\x3dfi_yja_sitetemplatesettings_web_SiteTemplateSettingsHeader_WAR_fiyjasitetemplatesettingsweb\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3dnull\x26p_p_col_pos\x3dnull\x26p_p_col_count\x3dnull\x26p_p_static\x3d1\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Finsurance',
+			refreshURLData: {}
+		}
+	);
+(function() {var $ = AUI.$;var _ = AUI._;
+	var assetEntryId =
+		'';
+
+	if (assetEntryId) {
+		window.location.hash = assetEntryId;
+	}
+})();
+	
+		Liferay.Portlet.register('com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_mhuLal9iWw3I');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 1,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_mhuLal9iWw3I_',
+			portletId: 'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_mhuLal9iWw3I',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d5844369\x26p_p_id\x3dcom_liferay_asset_publisher_web_portlet_AssetPublisherPortlet_INSTANCE_mhuLal9iWw3I\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3d_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3__column-2\x26p_p_col_pos\x3d1\x26p_p_col_count\x3d3\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Finsurance',
+			refreshURLData: {}
+		}
+	);
+
+	
+		Liferay.Portlet.register('com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_EvX4qMMxVCAa');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 0,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_EvX4qMMxVCAa_',
+			portletId: 'com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_EvX4qMMxVCAa',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d5844369\x26p_p_id\x3dcom_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_EvX4qMMxVCAa\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3d_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3__column-1\x26p_p_col_pos\x3d0\x26p_p_col_count\x3d1\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Finsurance',
+			refreshURLData: {}
+		}
+	);
+
+	
+		Liferay.Portlet.register('com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_5844369_rs');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 0,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_5844369_rs_',
+			portletId: 'com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_5844369_rs',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d5844369\x26p_p_id\x3dcom_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_5844369_rs\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3dnull\x26p_p_col_pos\x3dnull\x26p_p_col_count\x3dnull\x26p_p_static\x3d1\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Finsurance',
+			refreshURLData: {}
+		}
+	);
+
+	
+		Liferay.Portlet.register('com_liferay_site_navigation_breadcrumb_web_portlet_SiteNavigationBreadcrumbPortlet_INSTANCE_g4caL14LC89m');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 1,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_com_liferay_site_navigation_breadcrumb_web_portlet_SiteNavigationBreadcrumbPortlet_INSTANCE_g4caL14LC89m_',
+			portletId: 'com_liferay_site_navigation_breadcrumb_web_portlet_SiteNavigationBreadcrumbPortlet_INSTANCE_g4caL14LC89m',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d5844369\x26p_p_id\x3dcom_liferay_site_navigation_breadcrumb_web_portlet_SiteNavigationBreadcrumbPortlet_INSTANCE_g4caL14LC89m\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3dcolumn-5\x26p_p_col_pos\x3d1\x26p_p_col_count\x3d2\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Finsurance',
+			refreshURLData: {}
+		}
+	);
+
+	var nestedPortlet = document.getElementById(
+		'_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3__main-content'
+	);
+
+	if (nestedPortlet != null) {
+		nestedPortlet.removeAttribute('role');
+	}
+
+	
+		Liferay.Portlet.register('com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 0,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3_',
+			portletId: 'com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d5844369\x26p_p_id\x3dcom_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3dcolumn-1\x26p_p_col_pos\x3d0\x26p_p_col_count\x3d1\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Finsurance',
+			refreshURLData: {}
+		}
+	);
+
+	
+		Liferay.Portlet.register('fi_yja_sitetemplatesettings_web_SiteTemplateSettingsFooter_WAR_fiyjasitetemplatesettingsweb_INSTANCE_sitetemplateFooter');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 0,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_fi_yja_sitetemplatesettings_web_SiteTemplateSettingsFooter_WAR_fiyjasitetemplatesettingsweb_INSTANCE_sitetemplateFooter_',
+			portletId: 'fi_yja_sitetemplatesettings_web_SiteTemplateSettingsFooter_WAR_fiyjasitetemplatesettingsweb_INSTANCE_sitetemplateFooter',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d5844369\x26p_p_id\x3dfi_yja_sitetemplatesettings_web_SiteTemplateSettingsFooter_WAR_fiyjasitetemplatesettingsweb_INSTANCE_sitetemplateFooter\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3dnull\x26p_p_col_pos\x3dnull\x26p_p_col_count\x3dnull\x26p_p_static\x3d1\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Finsurance',
+			refreshURLData: {}
+		}
+	);
+
+	
+		Liferay.Portlet.register('com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_SSKDNE5ODInk');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 0,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_SSKDNE5ODInk_',
+			portletId: 'com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_SSKDNE5ODInk',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d5844369\x26p_p_id\x3dcom_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_SSKDNE5ODInk\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3dcolumn-5\x26p_p_col_pos\x3d0\x26p_p_col_count\x3d2\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Finsurance',
+			refreshURLData: {}
+		}
+	);
+
+	
+		Liferay.Portlet.register('com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_JNydRvax7GSY');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 0,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_JNydRvax7GSY_',
+			portletId: 'com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_JNydRvax7GSY',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d5844369\x26p_p_id\x3dcom_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_JNydRvax7GSY\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3d_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3__column-2\x26p_p_col_pos\x3d0\x26p_p_col_count\x3d3\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Finsurance',
+			refreshURLData: {}
+		}
+	);
+
+	var nestedPortlet = document.getElementById(
+		'_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm__main-content'
+	);
+
+	if (nestedPortlet != null) {
+		nestedPortlet.removeAttribute('role');
+	}
+
+	
+		Liferay.Portlet.register('com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 2,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm_',
+			portletId: 'com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d5844369\x26p_p_id\x3dcom_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_9TFyUMkZKTJm\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3d_com_liferay_nested_portlets_web_portlet_NestedPortletsPortlet_INSTANCE_7w7lGWyz4pj3__column-2\x26p_p_col_pos\x3d2\x26p_p_col_count\x3d3\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Finsurance',
+			refreshURLData: {}
+		}
+	);
+
+	
+		Liferay.Portlet.register('fi_yja_language_version_tool_web_portlet_LanguageVersionToolSelectionPortlet');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 0,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_fi_yja_language_version_tool_web_portlet_LanguageVersionToolSelectionPortlet_',
+			portletId: 'fi_yja_language_version_tool_web_portlet_LanguageVersionToolSelectionPortlet',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d5844369\x26p_p_id\x3dfi_yja_language_version_tool_web_portlet_LanguageVersionToolSelectionPortlet\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3dnull\x26p_p_col_pos\x3dnull\x26p_p_col_count\x3dnull\x26p_p_static\x3d1\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Finsurance',
+			refreshURLData: {}
+		}
+	);
+Liferay.Loader.require('metal-dom/src/all/dom', 'frontend-js-web/liferay/toast/commands/OpenToast.es', function(metalDomSrcAllDom, frontendJsWebLiferayToastCommandsOpenToastEs) {
+try {
+(function() {
+var dom = metalDomSrcAllDom;
+var $ = AUI.$;var _ = AUI._;
+	var focusInPortletHandler = dom.delegate(
+		document,
+		'focusin',
+		'.portlet',
+		function(event) {
+			dom.addClasses(dom.closest(event.delegateTarget, '.portlet'), 'open');
+		}
+	);
+
+	var focusOutPortletHandler = dom.delegate(
+		document,
+		'focusout',
+		'.portlet',
+		function(event) {
+			dom.removeClasses(dom.closest(event.delegateTarget, '.portlet'), 'open');
+		}
+	);
+
+})();
+(function() {
+var toastCommands = frontendJsWebLiferayToastCommandsOpenToastEs;
+var $ = AUI.$;var _ = AUI._;
+			AUI().use(
+				'liferay-session',
+				function() {
+					Liferay.Session = new Liferay.SessionBase(
+						{
+							autoExtend: true,
+							redirectOnExpire: false,
+							redirectUrl: 'https\x3a\x2f\x2fmigri\x2efi\x2f',
+							sessionLength: 10800,
+							sessionTimeoutOffset: 70,
+							warningLength: 0
+						}
+					);
+
+					
+				}
+			);
+		
+})();
+} catch (err) {
+	console.error(err);
+}
+});AUI().use('liferay-menu', 'aui-base', function(A) {(function() {var $ = AUI.$;var _ = AUI._;
+	if (A.UA.mobile) {
+		Liferay.Util.addInputCancel();
+	}
+})();(function() {var $ = AUI.$;var _ = AUI._;
+	new Liferay.Menu();
+
+	var liferayNotices = Liferay.Data.notices;
+
+	for (var i = 0; i < liferayNotices.length; i++) {
+		Liferay.Util.openToast(liferayNotices[i]);
+	}
+
+})();});
+// ]]>
+</script> 
+  <script src="https://migri.fi/o/yja-site-template-theme/js/main.js?browserId=chrome&amp;languageId=en_US&amp;t=1780930970000" type="text/javascript"></script> 
+  <script type="text/javascript">
+// YJALR73-1775 replace iterator dropdow-toggle class with LR71 version to prevent visual changes
+const iteratorDropdown = document.querySelectorAll('.taglib-page-iterator .lfr-pagination-page-selector .dropdown-toggle.btn-secondary');
+iteratorDropdown.forEach(iter => {
+    iter.classList.remove('btn-secondary');
+    if (!iter.classList.contains('btn-default')) {
+        iter.classList.add('btn-default');
+    }
+})
+</script> 
+  <script type="text/javascript">
+	// <![CDATA[
+		AUI().use(
+			'aui-base',
+			function(A) {
+				var frameElement = window.frameElement;
+
+				if (frameElement && frameElement.getAttribute('id') === 'simulationDeviceIframe') {
+					A.getBody().addClass('lfr-has-simulation-panel');
+				}
+			}
+		);
+	// ]]>
+</script> 
+  <script type="text/javascript">
+// <![CDATA[
+Liferay.Loader.require('remote-app-support-web@1.0.8/index', function(remoteAppSupportWeb108Index) {
+try {
+(function() {
+var RemoteAppSupport = remoteAppSupportWeb108Index;
+RemoteAppSupport.default()
+})();
+} catch (err) {
+	console.error(err);
+}
+});
+// ]]>
+</script> 
+  <script type="text/javascript">
+// <![CDATA[
+Liferay.Loader.require('frontend-js-collapse-support-web@1.0.15/index', function(frontendJsCollapseSupportWeb1015Index) {
+try {
+(function() {
+var CollapseProvider = frontendJsCollapseSupportWeb1015Index;
+CollapseProvider.default()
+})();
+} catch (err) {
+	console.error(err);
+}
+});
+// ]]>
+</script> 
+  <script type="text/javascript">
+// <![CDATA[
+Liferay.Loader.require('frontend-js-tooltip-support-web@3.0.7/index', function(frontendJsTooltipSupportWeb307Index) {
+try {
+(function() {
+var TooltipSupport = frontendJsTooltipSupportWeb307Index;
+TooltipSupport.default()
+})();
+} catch (err) {
+	console.error(err);
+}
+});
+// ]]>
+</script> 
+  <script type="text/javascript">
+// <![CDATA[
+Liferay.Loader.require('frontend-js-tabs-support-web@1.0.11/index', function(frontendJsTabsSupportWeb1011Index) {
+try {
+(function() {
+var TabsProvider = frontendJsTabsSupportWeb1011Index;
+TabsProvider.default()
+})();
+} catch (err) {
+	console.error(err);
+}
+});
+// ]]>
+</script> 
+  <script type="text/javascript">
+// <![CDATA[
+Liferay.Loader.require('frontend-js-alert-support-web@1.0.10/index', function(frontendJsAlertSupportWeb1010Index) {
+try {
+(function() {
+var AlertProvider = frontendJsAlertSupportWeb1010Index;
+AlertProvider.default()
+})();
+} catch (err) {
+	console.error(err);
+}
+});
+// ]]>
+</script> 
+  <script type="text/javascript">
+// <![CDATA[
+Liferay.Loader.require('frontend-js-dropdown-support-web@1.0.11/index', function(frontendJsDropdownSupportWeb1011Index) {
+try {
+(function() {
+var DropdownProvider = frontendJsDropdownSupportWeb1011Index;
+DropdownProvider.default()
+})();
+} catch (err) {
+	console.error(err);
+}
+});
+// ]]>
+</script> 
+  <script>
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('a.attachment.pdf').forEach(link => {
+        link.removeAttribute('target');
+    });
+});
+
+    $(document).ready(function () {
+
+// Check if is Employer page
+modifyEmployerPages();
+
+        $(".header-top-bar-links-right button").on("click tap", function () {
+            $(this).next("ul").toggle();
+            $(this).parent("li").toggleClass("opened");
+
+            var openMenu = {"fi-FI": "Avaa alavalikko", "sv-SE": "Öppna undermenyn", "en-US": "Open submenu"};
+            var closeMenu = {"fi-FI": "Sulje alavalikko", "sv-SE": "Stäng undermenyn", "en-US": "Close submenu"};
+            var langCode = document.documentElement.lang;
+            if( $(this).parent("li").hasClass("opened")) {
+                $(this).attr('aria-expanded', 'true');
+                $(this).attr('aria-haspopup', 'false');
+                $(this).parent("li").attr('aria-expanded', 'true');
+                if (closeMenu[langCode] !== undefined && closeMenu[langCode] !== "") {
+                    $(this).children('span').html(closeMenu[langCode]);
+                }
+            } else {
+                $(this).parent("li").attr('aria-expanded', 'false')
+                $(this).attr('aria-expanded', 'false')
+                $(this).attr('aria-haspopup', 'true');
+                if (openMenu[langCode] !== undefined && openMenu[langCode] !== "") {
+                    $(this).children('span').html(openMenu[langCode]);
+                }
+            }
+        });
+
+        $("#languageSelectionMenu li.uk a").html("Українська");
+        $(".main-nav li#layout_2430").attr('lang', 'uk');
+        $(".main-nav li#layout_2491").attr('lang', 'uk');
+        $(".main-nav li#layout_2514").attr('lang', 'uk');
+        $(".header-top-bar-links-right ul").find('li:first button').attr('aria-expanded', 'false');
+        $(".header-top-bar-links-right ul").find('li:first button').attr('aria-haspopup', 'true');
+
+        $("#footer div.footer-bottom-col-logo").attr('aria-label', 'Maahanmuuttovirasto');
+        $("#footer div.footer-bottom-col-logo img").attr('alt', 'Maahanmuuttovirasto');
+        $("#content").attr('role', 'main');
+    });
+    document.addEventListener(
+        "DOMContentLoaded",
+        function () {
+            // Newsroom navigation additions
+            // Add newsroom link as 1. element to newsroom navigation
+
+            var newsroomContainer = document.querySelector(".navigation--inline");
+
+            if (newsroomContainer != undefined) {
+                var navTitles = { "fi-FI": "Uutishuone", "sv-SE": "Nyhetsrummet", "en-US": "Newsroom" };
+                var urlPath = { "fi-FI": "/uutishuone", "sv-SE": "/sv/nyhetsrummet", "en-US": "/en/newsroom" };
+                var langCode = document.documentElement.lang;
+
+                if (navTitles[langCode] !== undefined && navTitles[langCode] !== "") {
+                    var title = navTitles[langCode];
+                    var url = urlPath[langCode];
+                    var navigationElem = newsroomContainer.querySelector(".list-menu");
+                    var navigationElemUl = navigationElem.querySelector(".level-1");
+                    var titleElement = navigationElem.querySelector(".list-menu__header");
+
+                    if (titleElement === null) {
+                        navTitleHTML = document.createElement("div");
+                        navTitleHTML.classList.add("list-menu__header");
+                        navTitleHTML.innerHTML = '<h3 class="list-menu__title"><a href="' + url + '">' + title + "</a></h3>";
+                        navigationElem.insertBefore(navTitleHTML, navigationElem.firstChild);
+                        console.log("added navigation title");
+                    }
+                }
+            }
+        },
+        false
+    );
+
+    // Functions
+    var getClosestId = function (elem) {
+        for (; elem && elem !== document; elem = elem.parentNode) {
+            if (elem.hasAttribute("id") && (elem.id.indexOf("layout-column") != -1 || elem.id.indexOf("_com_liferay_nested_portlets") != -1)) return elem;
+        }
+        return null;
+    };
+
+    var fiText = $("body.fi #languageSelectionMenu li.fi a").html();
+
+    var enText = $("body.en #languageSelectionMenu li.en a").html();
+
+    var svText = $("body.sv #languageSelectionMenu li.sv a").html();
+
+    var ukText = "Українська";
+
+    var locale = Liferay.ThemeDisplay.getLanguageId(locale);
+
+    $(document).ready(function () {
+        if (locale == "sv_SE") {
+            $("ul.lang-nav li.lang-text > a").html(svText);
+        } else if (locale == "en_US") {
+            $("ul.lang-nav li.lang-text > a").html(enText);
+        } else if (locale == "uk_UA") {
+            $("ul.lang-nav li.lang-text > a").html(ukText);
+        } else {
+            $("ul.lang-nav li.lang-text > a").html(fiText);
+        }
+    });
+
+
+ 
+    function urlEndsWith(url, ending) {
+        return url.endsWith(ending);
+    }
+
+
+    function modifyEmployerPages() {
+        const urls = ["/tyonantajalle","/sv/for-arbetsgivare", "/en/for-employers"];
+
+        const isEmployerPage = urls.some(url => urlEndsWith(window.location.href, url));
+
+        if (!isEmployerPage) return;
+        document.body.classList.add('section--employer');
+    } 
+</script> 
+  <script src="    /o/fi.yja.sitetemplatesettings.web/js/a11y-dropdown.js?browserId=chrome&amp;languageId=en_US&amp;t=1780930970000
+"></script> 
+  <script>initLangDropdown('Change language')</script> 
+  <script type="text/javascript">
+
+    var fixed = jQuery('.main-nav').position().top;
+
+
+</script> 
+  <script src="/o/yja-cookie-consent-web/js/cookie-consent.js?browserId=chrome&amp;languageId=en_US&amp;t=1780930970000" type="text/javascript" id="yja-cookie-consent" data-style="two" data-uuid="92868436-ba69-0d94-f840-f28275c59800" data-lang="en_US" data-check-cookie="true"></script>  
+ 
+<div id="yui3-css-stamp" style="position: absolute !important; visibility: hidden !important" class=""></div><div id="tooltipContainer"></div></body></html>

--- a/sources/FI_STUDY_MIGRI_2026-06-15.html.meta.json
+++ b/sources/FI_STUDY_MIGRI_2026-06-15.html.meta.json
@@ -1,0 +1,7 @@
+{
+  "source_id": "FI_STUDY_MIGRI_2026",
+  "url": "https://migri.fi/en/insurance",
+  "retrieved_at": "2026-06-15T00:00:00Z",
+  "sha256": "c38ff6a79dd8d148339541a4f30b447b2d2102866dc062254b5165eeafcc7925",
+  "local_path": "sources/FI_STUDY_MIGRI_2026-06-15.html"
+}

--- a/tools/build_content_hubs.py
+++ b/tools/build_content_hubs.py
@@ -405,6 +405,20 @@ VISA_FAQS = {
             "answer": "Because the only modeled requirement is that insurance is mandatory, every tracked product that provides health or travel insurance shows GREEN. Confirm the specific terms with the Ministry, as the published page gives no further detail.",
         },
     ],
+    "FI_STUDY_MIGRI_2026": [
+        {
+            "question": "What insurance does a Finnish study residence permit require?",
+            "answer": "The Finnish Immigration Service requires private insurance covering medical and drug expenses, valid throughout your entire stay. For studies under two years the insurance must cover medical expenses up to EUR 120,000.",
+        },
+        {
+            "question": "Why does the amount depend on study length?",
+            "answer": "Migri requires up to EUR 120,000 for studies under two years and up to EUR 40,000 for studies of at least two years. This route models the under-two-years threshold; the post discloses the longer-studies figure.",
+        },
+        {
+            "question": "Why is SafetyWing YELLOW?",
+            "answer": "The insurance must be valid throughout your entire stay. A month-to-month subscription that can lapse does not assure that, so it is YELLOW; full-period policies meeting the EUR 120,000 threshold are GREEN.",
+        },
+    ],
 }
 
 RELATED_POSTS = {
@@ -539,6 +553,11 @@ RELATED_POSTS = {
     ],
     "ME_DNV_GOVME_2026": [
         ("/posts/montenegro-dnv-insurance/", "Montenegro digital nomad insurance requirements"),
+        ("/posts/digital-nomad-insurance-europe/", "Digital nomad insurance in Europe"),
+        ("/guides/how-to-read-results/", "How to read compliance results"),
+    ],
+    "FI_STUDY_MIGRI_2026": [
+        ("/posts/finland-study-insurance/", "Finland study residence insurance requirements"),
         ("/posts/digital-nomad-insurance-europe/", "Digital nomad insurance in Europe"),
         ("/guides/how-to-read-results/", "How to read compliance results"),
     ],

--- a/tools/editorial_targets.json
+++ b/tools/editorial_targets.json
@@ -274,5 +274,13 @@
   "content/posts/montenegro-dnv-insurance.md": [
     450,
     1200
+  ],
+  "content/visas/finland/residence-permit-for-studies/student-residence-permit-studies-under-two-years-migri/index.md": [
+    900,
+    1400
+  ],
+  "content/posts/finland-study-insurance.md": [
+    450,
+    1250
   ]
 }


### PR DESCRIPTION
## Summary
- New route **FI_STUDY_MIGRI_2026** — Finland Residence Permit for Studies (studies under two years)
- Primary source (byte-exact, sha256-validated; browser-captured past Cloudflare): Finnish Immigration Service insurance page (migri.fi/en/insurance)
- Rules encoded verbatim only: `insurance.mandatory`, `insurance.min_coverage >= 120000 EUR` (under-two-years threshold), `insurance.must_cover_full_period`
- Disclosed but NOT modeled: conditional amount (>=2 years requires EUR 40,000 pharmaceutical), EUR 300 max excess, EHIC/GHIC/Kela alternatives

## Mapping outcomes
Genki Traveler / Genki Native / World Nomads **GREEN**; SafetyWing **YELLOW**; Spanish products **UNKNOWN**. No existing mapping changed.

## Content
- Hub: /visas/finland/residence-permit-for-studies/student-residence-permit-studies-under-two-years-migri/
- Post: /posts/finland-study-insurance/ (dated 2026-06-13, past in UTC)
- Affiliate: Genki Traveler paid link, after results only

## Gates
All gates + ui_compliance_tests.ps1 + mapping_engine_tests.ps1 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)