### PR TITLE
feat(route): add Mauritius Premium Visa route (evidence-based)

### DIFF
--- a/content/posts/mauritius-premium-visa-insurance.md
+++ b/content/posts/mauritius-premium-visa-insurance.md
@@ -1,0 +1,99 @@
+---
+title: "Mauritius Premium Visa insurance requirements (evidence-based)"
+date: 2026-06-13
+description: "Evidence-based summary of the insurance requirement for the Mauritius Premium Visa, based on the Economic Development Board eligibility statement."
+tags: ["mauritius", "premium-visa", "long-stay", "insurance", "compliance"]
+faq:
+  - question: "What insurance does the Mauritius Premium Visa require?"
+    answer: "The Economic Development Board states that to qualify for the Premium Visa, the applicant must have proof of long stay plans and travel and health insurance for the initial period of stay."
+  - question: "Is there a minimum amount or territory requirement?"
+    answer: "The published eligibility statement names travel and health insurance but states no coverage amount or territory, so the engine models only that insurance is mandatory."
+  - question: "Which products show GREEN?"
+    answer: "Because the only modeled requirement is that insurance is mandatory, every tracked product that provides travel or health insurance shows GREEN. Confirm the specific terms with the Economic Development Board."
+---
+
+## Short answer
+
+To qualify for the Mauritius Premium Visa, the applicant must have proof of long stay plans and travel and health insurance for the initial period of stay (Source: `MU_PREMIUM_EDB_2026`, Economic Development Board of Mauritius; verified 2026-06-13). The published eligibility statement names insurance but states no coverage amount or territory, so the engine models a single rule: insurance is mandatory.
+
+## Key findings at a glance
+
+| Item | Value |
+|---|---|
+| Route | Mauritius Premium Visa |
+| Authority | Economic Development Board of Mauritius (EDB) |
+| Evidence verified | 2026-06-13 |
+| Snapshot | 2026-06-13 |
+| Modeled rules | Insurance mandatory |
+
+## What the authority requires
+
+- The applicant must have travel and health insurance for the initial period of stay. (Source: `MU_PREMIUM_EDB_2026`; verified 2026-06-13)
+- The published statement gives no coverage amount and no territory, so those stay UNKNOWN and are not modeled.
+
+Normalized requirements table:
+
+| Requirement | Source URL | Locator | Verified date |
+|---|---|---|---|
+| Insurance is mandatory | https://news.edbmauritius.org/2021-january-the-new-premium-visa/ | Premium Visa eligibility | 2026-06-13 |
+
+## Verified requirements (PASS/FAIL/UNKNOWN)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Insurance is mandatory | PASS | EDB: "the applicant must have proof of his/her long stay plans and travel and health insurance" |
+| Minimum coverage amount | UNKNOWN | Not stated by the EDB |
+| Coverage period / territory | UNKNOWN | Not stated by the EDB |
+
+## How we evaluate
+
+The checker compares each modeled requirement against product evidence. Only one rule is encoded from the EDB eligibility statement: insurance is mandatory. The statement refers to insurance "for the initial period of stay" but gives no amount, no full-period rule and no territory, so the engine encodes only the mandatory requirement, following the UNKNOWN > Wrong principle. As a result, every tracked product that provides travel or health insurance satisfies the single modeled requirement and shows GREEN. Because the published detail is minimal, confirm the specific policy terms with the Economic Development Board before you apply. See /methodology/ for the full logic.
+
+## Proof package checklist
+
+- Travel and health insurance for the initial period of stay.
+- Proof of long stay plans, per the EDB eligibility statement.
+- Confirmation of any further terms the EDB may request, since the published statement is brief.
+
+## FAQ
+
+**Q: What is required?**
+**A:** Travel and health insurance for the initial period of stay (Source: `MU_PREMIUM_EDB_2026`; verified 2026-06-13).
+
+**Q: Is there a minimum amount?**
+**A:** The EDB states none, so the engine encodes no figure.
+
+**Q: Which products are GREEN?**
+**A:** With only the mandatory rule modeled, every tracked product providing insurance is GREEN; confirm specific terms with the EDB.
+
+## Check in the engine
+
+Use [the compliance checker](/ui/) with the current snapshot for this route:
+
+{{< checker_cta visa="MU_PREMIUM_EDB_2026" product="GENKI_TRAVELER_2026" snapshot="2026-06-13" >}}
+
+## Related reading
+
+- [Mauritius Premium Visa requirements (route page)](/visas/mauritius/premium-visa/premium-visa-economic-development-board/)
+- [Digital nomad insurance in Asia and beyond](/posts/digital-nomad-insurance-asia/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## Where to find compliant insurance for the Mauritius Premium Visa
+
+The EDB statement asks for travel and health insurance for the initial period of stay, with no amount or territory specified, so most travel and health policies will meet the stated requirement. In the current snapshot, the tracked products show GREEN, including Genki Traveler and Genki Native. Because the published detail is minimal, confirm the exact terms with the Economic Development Board before applying.
+
+- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+
+> Use the compliance checker to confirm the current GREEN products for this route before you buy.
+
+## Disclaimer + Affiliate disclosure
+
+Not legal advice. Compliance results are evidence-based snapshots.
+
+If an affiliate link is present, it appears only after results and does not change the compliance outcome. The Genki link above is a paid affiliate link.
+
+Last updated: 2026-06-13
+
+## Evidence log
+
+- Source: MU_PREMIUM_EDB_2026

--- a/content/visas/mauritius/premium-visa/_index.md
+++ b/content/visas/mauritius/premium-visa/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Mauritius Premium Visa"
+visa_group: "mauritius-premium-visa"
+description: "Insurance requirements for Mauritius Premium Visa - evidence-based compliance checker"
+---
+
+## Mauritius Premium Visa Requirements
+
+All requirements below are derived from official sources. Missing evidence means UNKNOWN.
+
+## Routes
+
+| Authority | Route | Last Verified | Details |
+| --- | --- | --- | --- |
+| Economic Development Board of Mauritius (EDB) | Premium Visa (Economic Development Board) | 2026-06-15 | [View requirements](/visas/mauritius/premium-visa/premium-visa-economic-development-board/) |
+
+## What the authority requires
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+## How we evaluate
+
+We compare these official requirements against insurance product specifications using our automated rule engine. Each requirement is matched to a product fact with evidence.
+
+## Check in the engine
+
+Try the compliance checker: [Open Checker](/ui/?visa=MU_PREMIUM_EDB_2026&snapshot=2026-06-13)
+
+## Disclaimer
+
+This is not legal advice. VisaFact provides evidence-based compliance checking only. Final visa decisions are made by government authorities. A GREEN result does not ensure visa approval.
+
+## Affiliate disclosure
+
+If affiliate links appear, they are shown only after compliance results and do not influence the compliance evaluation in any way.
+
+## Evidence log
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+
+{{< checker_cta visa="MU_PREMIUM_EDB_2026" snapshot="2026-06-13" >}}

--- a/content/visas/mauritius/premium-visa/premium-visa-economic-development-board/index.md
+++ b/content/visas/mauritius/premium-visa/premium-visa-economic-development-board/index.md
@@ -1,0 +1,99 @@
+---
+title: "Mauritius Premium Visa - Premium Visa (Economic Development Board)"
+visa_id: "MU_PREMIUM_EDB_2026"
+last_verified: "2026-06-15"
+source_ids: ["MU_PREMIUM_EDB_2026"]
+description: "Official insurance requirements for Mauritius Premium Visa via Premium Visa (Economic Development Board)"
+faq:
+  - question: "What insurance does the Mauritius Premium Visa require?"
+    answer: "The Economic Development Board states that to qualify for the Premium Visa, the applicant must have proof of long stay plans and travel and health insurance for the initial period of stay."
+  - question: "Is there a minimum amount or territory requirement?"
+    answer: "The published eligibility statement names travel and health insurance but states no coverage amount or territory, so the engine models only that insurance is mandatory."
+  - question: "Which products show GREEN?"
+    answer: "Because the only modeled requirement is that insurance is mandatory, every tracked product that provides travel or health insurance shows GREEN. Confirm the specific terms with the Economic Development Board."
+---
+
+## Mauritius Premium Visa
+
+**Route:** Premium Visa (Economic Development Board)  
+**Authority:** Economic Development Board of Mauritius (EDB)  
+**Last Verified:** 2026-06-15
+
+## Requirements
+
+| Requirement | Operator | Value | Evidence |
+| --- | --- | --- | --- |
+| `insurance.mandatory` | `==` | Yes | *Premium Visa eligibility (Economic Development Board)*: "In order to qualify for the Premium Visa, the applicant must have proof of his/h..." ([source](/sources/MU_PREMIUM_EDB_2026-06-15.html)) |
+
+## Source Documents
+
+- **MU_PREMIUM_EDB_2026**: [Local copy](/sources/MU_PREMIUM_EDB_2026-06-15.html) | [Original](https://news.edbmauritius.org/2021-january-the-new-premium-visa/) | Retrieved: 2026-06-15
+
+## Related reading
+
+- [Mauritius Premium Visa insurance requirements](/posts/mauritius-premium-visa-insurance/)
+- [Digital nomad insurance in Asia and beyond](/posts/digital-nomad-insurance-asia/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## What the authority requires
+
+The points below are taken directly from the official source for the Mauritius Premium Visa (Premium Visa (Economic Development Board)) route. Each one is recorded with a source identifier and a locator so it can be traced back to the original document. Where the source is silent on a point, the engine records UNKNOWN instead of inferring an answer.
+
+- The authority requires that insurance is mandatory.
+
+This route is defined by a small number of explicit insurance points, which keeps the evidence trail short but also unusually clear. A concise official requirement still has to be matched precisely: a product is only GREEN here when its documented terms line up with the wording above, and a route with few stated rules does not imply that any policy will be accepted. Where the authority is silent, the engine deliberately holds the status at UNKNOWN or NOT_REQUIRED rather than reading extra conditions into the source, so the page reflects exactly what the document states and nothing more. Applicants on routes like this one should still keep the underlying policy wording on hand, because a consular officer may ask to see how each stated point is met even when the published checklist is short.
+
+## How we evaluate
+
+Every requirement is compared against the documented specification of each insurance product using an automated rule engine. A product is marked GREEN for a requirement only when product evidence explicitly satisfies it; a conflict produces RED; and absent evidence produces UNKNOWN rather than a guess. The route status is the combination of its per-requirement outcomes.
+
+- Rule `insurance.mandatory == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+
+## How each compliance status is decided for this route
+
+GREEN means every recorded requirement is satisfied by product evidence. RED means at least one requirement is contradicted by the product evidence. YELLOW means the evidence is partial: some requirements are met while others lack full proof. UNKNOWN means a requirement exists but the product evidence does not address it, so no claim is made. NOT_REQUIRED means the authority does not impose an insurance requirement for the route, which is itself an evidence-based finding drawn from the official document. A GREEN result reflects the evidence on the snapshot date and is not an assurance of a visa outcome, which always rests with the issuing authority.
+
+## Reading the evidence and snapshots
+
+Each requirement above links to a primary source through a source identifier and a locator (for example a page number, article, or section). The underlying documents are listed under Source Documents and are stored alongside this dataset so the wording can be checked directly. Results are tied to a dated snapshot (`2026-06-13`): a deep link to a past snapshot returns the same verdict even if the authority later changes its rules, which keeps every decision reproducible and auditable.
+
+## Proof package checklist
+
+Before applying for this route, prepare the following so the policy can be checked against each requirement:
+
+- A policy certificate that states the coverage limits, any deductible or co-payment, and the covered period.
+- Written confirmation of the insurer's status where the route requires authorization in a specific country.
+- Documentation that the coverage spans the full authorized stay rather than a partial term.
+- The official source wording for the route, so each clause can be matched to the requirements above.
+
+## Common questions
+
+**What insurance does the Mauritius Premium Visa require?**  
+The Economic Development Board states that to qualify for the Premium Visa, the applicant must have proof of long stay plans and travel and health insurance for the initial period of stay.
+
+**Is there a minimum amount or territory requirement?**  
+The published eligibility statement names travel and health insurance but states no coverage amount or territory, so the engine models only that insurance is mandatory.
+
+**Which products show GREEN?**  
+Because the only modeled requirement is that insurance is mandatory, every tracked product that provides travel or health insurance shows GREEN. Confirm the specific terms with the Economic Development Board.
+
+## Check in the engine
+
+Run a specific product against this route in the compliance checker: [Open Checker](/ui/?visa=MU_PREMIUM_EDB_2026&snapshot=2026-06-13). The checker shows the per-requirement outcome and the evidence behind each one.
+
+## Disclaimer
+
+This page is not legal advice. VisaFact provides evidence-based compliance checking only, and final visa decisions are made by government authorities. A GREEN result reflects documented evidence on the snapshot date; it does not ensure that a visa application will succeed. Always confirm the current requirements with the issuing authority before submitting an application.
+
+## Affiliate disclosure
+
+If affiliate links appear on related pages, they are shown only after the compliance result and never change the evaluation, which is generated independently from the official evidence.
+
+## Evidence log
+
+Each entry pairs a requirement with the source identifier and locator it was drawn from:
+
+- `insurance.mandatory` <- MU_PREMIUM_EDB_2026 (Premium Visa eligibility (Economic Development Board)): "In order to qualify for the Premium Visa, the applicant must have proof of his/her long stay plans a"
+
+
+{{< checker_cta visa="MU_PREMIUM_EDB_2026" snapshot="2026-06-13" >}}

--- a/data/mappings/MU_PREMIUM_EDB_2026__ASISA_HEALTH_RESIDENTS_2026.json
+++ b/data/mappings/MU_PREMIUM_EDB_2026__ASISA_HEALTH_RESIDENTS_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "MU_PREMIUM_EDB_2026",
+  "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/MU_PREMIUM_EDB_2026__DKV_VISADO_2026.json
+++ b/data/mappings/MU_PREMIUM_EDB_2026__DKV_VISADO_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "MU_PREMIUM_EDB_2026",
+  "product_id": "DKV_VISADO_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/MU_PREMIUM_EDB_2026__GENERIC_EXPAT_COMPLETE_2026.json
+++ b/data/mappings/MU_PREMIUM_EDB_2026__GENERIC_EXPAT_COMPLETE_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "MU_PREMIUM_EDB_2026",
+  "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/MU_PREMIUM_EDB_2026__GENKI_NATIVE_2026.json
+++ b/data/mappings/MU_PREMIUM_EDB_2026__GENKI_NATIVE_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "MU_PREMIUM_EDB_2026",
+  "product_id": "GENKI_NATIVE_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/MU_PREMIUM_EDB_2026__GENKI_TRAVELER_2026.json
+++ b/data/mappings/MU_PREMIUM_EDB_2026__GENKI_TRAVELER_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "MU_PREMIUM_EDB_2026",
+  "product_id": "GENKI_TRAVELER_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/MU_PREMIUM_EDB_2026__SAFETYWING_NOMAD_2026.json
+++ b/data/mappings/MU_PREMIUM_EDB_2026__SAFETYWING_NOMAD_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "MU_PREMIUM_EDB_2026",
+  "product_id": "SAFETYWING_NOMAD_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/MU_PREMIUM_EDB_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
+++ b/data/mappings/MU_PREMIUM_EDB_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "MU_PREMIUM_EDB_2026",
+  "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/MU_PREMIUM_EDB_2026__WORLDNOMADS_EXPLORER_2026.json
+++ b/data/mappings/MU_PREMIUM_EDB_2026__WORLDNOMADS_EXPLORER_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "MU_PREMIUM_EDB_2026",
+  "product_id": "WORLDNOMADS_EXPLORER_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/ui_index.json
+++ b/data/ui_index.json
@@ -1,5 +1,5 @@
 {
-  "built_at": "2026-06-15T05:19:34.822449+00:00",
+  "built_at": "2026-06-15T05:25:07.066232+00:00",
   "snapshot_id": "2026-06-15",
   "visas": [
     {
@@ -1208,6 +1208,37 @@
               "source_id": "MT_RESIDENCY_FAQ_2026",
               "locator": "FAQ - Are health insurance policies with monthly payments considered acceptable?",
               "excerpt": "No, they are not acceptable. Eligible policies are those with premiums covering a full year, paid in advance. A receipt for this payment may be requested."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "MU_PREMIUM_EDB_2026",
+      "country": "Mauritius",
+      "visa_name": "Premium Visa",
+      "route": "Premium Visa (Economic Development Board)",
+      "authority": "Economic Development Board of Mauritius (EDB)",
+      "last_verified": "2026-06-15",
+      "sources": [
+        {
+          "source_id": "MU_PREMIUM_EDB_2026",
+          "url": "https://news.edbmauritius.org/2021-january-the-new-premium-visa/",
+          "retrieved_at": "2026-06-15T00:00:00Z",
+          "sha256": "b5e3e6a4a9731080eba4a8f3e5d4104a6449712bf2ec18763f05b301c885632e",
+          "local_path": "sources/MU_PREMIUM_EDB_2026-06-15.html"
+        }
+      ],
+      "requirements": [
+        {
+          "key": "insurance.mandatory",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "MU_PREMIUM_EDB_2026",
+              "locator": "Premium Visa eligibility (Economic Development Board)",
+              "excerpt": "In order to qualify for the Premium Visa, the applicant must have proof of his/her long stay plans and travel and health insurance for the initial period of stay."
             }
           ]
         }
@@ -2715,7 +2746,7 @@
       "missing": [
         "specs.jurisdiction_facts.EC.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "EC_NOMAD_CANCILLERIA_2026",
@@ -2725,7 +2756,7 @@
       "missing": [
         "specs.jurisdiction_facts.EC.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "EC_NOMAD_CANCILLERIA_2026",
@@ -2735,7 +2766,7 @@
       "missing": [
         "specs.jurisdiction_facts.EC.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "EC_NOMAD_CANCILLERIA_2026",
@@ -2743,7 +2774,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "EC_NOMAD_CANCILLERIA_2026",
@@ -2753,7 +2784,7 @@
       "missing": [
         "specs.jurisdiction_facts.EC.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "EC_NOMAD_CANCILLERIA_2026",
@@ -2774,7 +2805,7 @@
       "missing": [
         "specs.jurisdiction_facts.EC.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "EC_NOMAD_CANCILLERIA_2026",
@@ -2784,7 +2815,7 @@
       "missing": [
         "specs.jurisdiction_facts.EC.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "EC_NOMAD_CANCILLERIA_2026",
@@ -2794,7 +2825,7 @@
       "missing": [
         "specs.jurisdiction_facts.EC.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "EE_DNV_VM_2026",
@@ -4062,6 +4093,70 @@
       "last_verified": "2026-01-15"
     },
     {
+      "visa_id": "MU_PREMIUM_EDB_2026",
+      "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "MU_PREMIUM_EDB_2026",
+      "product_id": "DKV_VISADO_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "MU_PREMIUM_EDB_2026",
+      "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "MU_PREMIUM_EDB_2026",
+      "product_id": "GENKI_NATIVE_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "MU_PREMIUM_EDB_2026",
+      "product_id": "GENKI_TRAVELER_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "MU_PREMIUM_EDB_2026",
+      "product_id": "SAFETYWING_NOMAD_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "MU_PREMIUM_EDB_2026",
+      "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "MU_PREMIUM_EDB_2026",
+      "product_id": "WORLDNOMADS_EXPLORER_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
       "visa_id": "NZ_STUDENT_INZ_2026",
       "product_id": "ASISA_HEALTH_RESIDENTS_2026",
       "status": "GREEN",
@@ -5079,6 +5174,13 @@
       "sha256": "0f18ac432310a6af5e29ff42cfc7d5ebeb4eba69c02f1bc29a63c69545f4336f",
       "local_path": "sources/MT_NOMAD_RESIDENCY_FAQ_2026-01-12.md",
       "note": "Official FAQ explicitly states monthly payment insurance policies are NOT acceptable - annual payment required"
+    },
+    "MU_PREMIUM_EDB_2026": {
+      "source_id": "MU_PREMIUM_EDB_2026",
+      "url": "https://news.edbmauritius.org/2021-january-the-new-premium-visa/",
+      "retrieved_at": "2026-06-15T00:00:00Z",
+      "sha256": "b5e3e6a4a9731080eba4a8f3e5d4104a6449712bf2ec18763f05b301c885632e",
+      "local_path": "sources/MU_PREMIUM_EDB_2026-06-15.html"
     },
     "NZ_STUDENT_INZ_2026": {
       "source_id": "NZ_STUDENT_INZ_2026",

--- a/data/visas/MU/PREMIUM/edb/2026-06-15/visa_facts.json
+++ b/data/visas/MU/PREMIUM/edb/2026-06-15/visa_facts.json
@@ -1,0 +1,31 @@
+{
+  "id": "MU_PREMIUM_EDB_2026",
+  "country": "Mauritius",
+  "visa_name": "Premium Visa",
+  "route": "Premium Visa (Economic Development Board)",
+  "authority": "Economic Development Board of Mauritius (EDB)",
+  "last_verified": "2026-06-15",
+  "sources": [
+    {
+      "source_id": "MU_PREMIUM_EDB_2026",
+      "url": "https://news.edbmauritius.org/2021-january-the-new-premium-visa/",
+      "retrieved_at": "2026-06-15T00:00:00Z",
+      "sha256": "b5e3e6a4a9731080eba4a8f3e5d4104a6449712bf2ec18763f05b301c885632e",
+      "local_path": "sources/MU_PREMIUM_EDB_2026-06-15.html"
+    }
+  ],
+  "requirements": [
+    {
+      "key": "insurance.mandatory",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "MU_PREMIUM_EDB_2026",
+          "locator": "Premium Visa eligibility (Economic Development Board)",
+          "excerpt": "In order to qualify for the Premium Visa, the applicant must have proof of his/her long stay plans and travel and health insurance for the initial period of stay."
+        }
+      ]
+    }
+  ]
+}

--- a/sources/MU_PREMIUM_EDB_2026-06-15.html
+++ b/sources/MU_PREMIUM_EDB_2026-06-15.html
@@ -1,0 +1,1167 @@
+<!doctype html>
+<html lang="en-US">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="profile" href="https://gmpg.org/xfn/11">
+
+	<meta name='robots' content='index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1' />
+
+	<!-- This site is optimized with the Yoast SEO plugin v16.2 - https://yoast.com/wordpress/plugins/seo/ -->
+	<title>THE NEW PREMIUM VISA</title>
+	<meta name="description" content="The Premium Visa is issued to eligible non-citizens seeking to stay in Mauritius (individually or with their families) for an initial period of more than 6 months up to a year, with the option to renew. It is an appealing invitation to travel to Mauritius, to work remotely in safe haven, take a sabbatical or begin the journey to retirement while relishing an exotic luxury lifestyle in a COVID-Safe environment." />
+	<link rel="canonical" href="https://news.edbmauritius.org/2021-january-the-new-premium-visa/" />
+	<meta property="og:locale" content="en_US" />
+	<meta property="og:type" content="article" />
+	<meta property="og:title" content="THE NEW PREMIUM VISA" />
+	<meta property="og:description" content="The Premium Visa is issued to eligible non-citizens seeking to stay in Mauritius (individually or with their families) for an initial period of more than 6 months up to a year, with the option to ..." />
+	<meta property="og:url" content="https://news.edbmauritius.org/2021-january-the-new-premium-visa/" />
+	<meta property="og:site_name" content="Economic Development Board Mauritius" />
+	<meta property="article:modified_time" content="2021-02-11T08:34:44+00:00" />
+	<meta property="og:image" content="https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_1668766774.jpg" />
+	<meta property="og:image:width" content="1440" />
+	<meta property="og:image:height" content="960" />
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content="THE NEW PREMIUM VISA" />
+	<meta name="twitter:description" content="The Premium Visa is issued to eligible non-citizens seeking to stay in Mauritius (individually or with their families) for an initial period of more than 6 months up to a year, with the option to ..." />
+	<meta name="twitter:label1" content="Est. reading time">
+	<meta name="twitter:data1" content="6 minutes">
+	<script type="application/ld+json" class="yoast-schema-graph">{"@context":"https://schema.org","@graph":[{"@type":"WebSite","@id":"https://news.edbmauritius.org/#website","url":"https://news.edbmauritius.org/","name":"Economic Development Board Mauritius","description":"eNEWSLETTER ","potentialAction":[{"@type":"SearchAction","target":"https://news.edbmauritius.org/?s={search_term_string}","query-input":"required name=search_term_string"}],"inLanguage":"en-US"},{"@type":"ImageObject","@id":"https://news.edbmauritius.org/2021-january-the-new-premium-visa/#primaryimage","inLanguage":"en-US","url":"https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_1668766774.jpg","contentUrl":"https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_1668766774.jpg","width":1440,"height":960},{"@type":"WebPage","@id":"https://news.edbmauritius.org/2021-january-the-new-premium-visa/#webpage","url":"https://news.edbmauritius.org/2021-january-the-new-premium-visa/","name":"THE NEW PREMIUM VISA","isPartOf":{"@id":"https://news.edbmauritius.org/#website"},"primaryImageOfPage":{"@id":"https://news.edbmauritius.org/2021-january-the-new-premium-visa/#primaryimage"},"datePublished":"2021-02-03T07:30:26+00:00","dateModified":"2021-02-11T08:34:44+00:00","description":"The Premium Visa is issued to eligible non-citizens seeking to stay in Mauritius (individually or with their families) for an initial period of more than 6 months up to a year, with the option to renew. It is an appealing invitation to travel to Mauritius, to work remotely in safe haven, take a sabbatical or begin the journey to retirement while relishing an exotic luxury lifestyle in a COVID-Safe environment.","breadcrumb":{"@id":"https://news.edbmauritius.org/2021-january-the-new-premium-visa/#breadcrumb"},"inLanguage":"en-US","potentialAction":[{"@type":"ReadAction","target":["https://news.edbmauritius.org/2021-january-the-new-premium-visa/"]}]},{"@type":"BreadcrumbList","@id":"https://news.edbmauritius.org/2021-january-the-new-premium-visa/#breadcrumb","itemListElement":[{"@type":"ListItem","position":1,"item":{"@type":"WebPage","@id":"https://news.edbmauritius.org/","url":"https://news.edbmauritius.org/","name":"Home"}},{"@type":"ListItem","position":2,"item":{"@id":"https://news.edbmauritius.org/2021-january-the-new-premium-visa/#webpage"}}]}]}</script>
+	<!-- / Yoast SEO plugin. -->
+
+
+
+<!-- Novashare v.1.1.5 https://novashare.io/ -->
+<meta property="og:image" content="https://news.edbmauritius.org/wp-content/uploads/2021/02/Banner-1.jpg" />
+<meta property="og:image:secure_url" content="https://news.edbmauritius.org/wp-content/uploads/2021/02/Banner-1.jpg" />
+<meta property="og:image:width" content="800" />
+<meta property="og:image:height" content="401" />
+<meta name="twitter:image" content="https://news.edbmauritius.org/wp-content/uploads/2021/02/Banner-1.jpg" />
+<!-- / Novashare -->
+<link href='https://fonts.gstatic.com' crossorigin rel='preconnect' />
+<link rel="alternate" type="application/rss+xml" title="Economic Development Board Mauritius &raquo; Feed" href="https://news.edbmauritius.org/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Economic Development Board Mauritius &raquo; Comments Feed" href="https://news.edbmauritius.org/comments/feed/" />
+<style type="text/css">
+img.wp-smiley,
+img.emoji {
+	display: inline !important;
+	border: none !important;
+	box-shadow: none !important;
+	height: 1em !important;
+	width: 1em !important;
+	margin: 0 .07em !important;
+	vertical-align: -0.1em !important;
+	background: none !important;
+	padding: 0 !important;
+}
+</style>
+	<link rel='stylesheet' id='wp-block-library-css'  href='https://news.edbmauritius.org/wp-includes/css/dist/block-library/style.min.css?ver=5.8' type='text/css' media='all' />
+<link rel='stylesheet' id='contact-form-7-css'  href='https://news.edbmauritius.org/wp-content/plugins/contact-form-7/includes/css/styles.css?ver=5.4.2' type='text/css' media='all' />
+<link rel='stylesheet' id='graphina-charts-for-elementor-public-css'  href='https://news.edbmauritius.org/wp-content/plugins/graphina-elementor-charts-and-graphs/elementor/css/graphina-charts-for-elementor-public.css?ver=1.5.6' type='text/css' media='all' />
+<link rel='stylesheet' id='graphina-charts-pro-requirement-css'  href='https://news.edbmauritius.org/wp-content/plugins/graphina-elementor-charts-and-graphs/elementor/css/graphina-charts-for-elementor-pro.css?ver=1.5.6' type='text/css' media='all' />
+<link rel='stylesheet' id='novashare-css-css'  href='https://news.edbmauritius.org/wp-content/plugins/novashare/css/style.min.css?ver=1.1.5' type='text/css' media='all' />
+<link rel='stylesheet' id='rs-plugin-settings-css'  href='https://news.edbmauritius.org/wp-content/plugins/revslider/public/assets/css/rs6.css?ver=6.3.6' type='text/css' media='all' />
+<style id='rs-plugin-settings-inline-css' type='text/css'>
+#rs-demo-id {}
+</style>
+<link rel='stylesheet' id='trp-language-switcher-style-css'  href='https://news.edbmauritius.org/wp-content/plugins/translatepress-multilingual/assets/css/trp-language-switcher.css?ver=1.9.9' type='text/css' media='all' />
+<link rel='stylesheet' id='bootstrap-css'  href='https://news.edbmauritius.org/wp-content/themes/maxbizz/css/bootstrap.css?ver=4.0' type='text/css' media='all' />
+<link rel='stylesheet' id='maxbizz-flaticon-css'  href='https://news.edbmauritius.org/wp-content/themes/maxbizz/css/flaticon.css?ver=5.8' type='text/css' media='all' />
+<link rel='stylesheet' id='owl-slider-css'  href='https://news.edbmauritius.org/wp-content/themes/maxbizz/css/owl.carousel.min.css?ver=5.8' type='text/css' media='all' />
+<link rel='stylesheet' id='lightgallery-css'  href='https://news.edbmauritius.org/wp-content/themes/maxbizz/css/lightgallery.css?ver=5.8' type='text/css' media='all' />
+<link rel='stylesheet' id='maxbizz-style-css'  href='https://news.edbmauritius.org/wp-content/themes/maxbizz/style.css?ver=5.8' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-icons-css'  href='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/lib/eicons/css/elementor-icons.min.css?ver=5.11.0' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-animations-css'  href='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/lib/animations/animations.min.css?ver=3.2.2' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-frontend-legacy-css'  href='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/css/frontend-legacy.min.css?ver=3.2.2' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-frontend-css'  href='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/css/frontend.min.css?ver=3.2.2' type='text/css' media='all' />
+<style id='elementor-frontend-inline-css' type='text/css'>
+.ha-css-transform-yes{-webkit-transition-duration:var(--ha-tfx-transition-duration,.2s);transition-duration:var(--ha-tfx-transition-duration,.2s);-webkit-transition-property:-webkit-transform;transition-property:transform;transition-property:transform,-webkit-transform;-webkit-transform:translate(var(--ha-tfx-translate-x,0),var(--ha-tfx-translate-y,0)) scale(var(--ha-tfx-scale-x,1),var(--ha-tfx-scale-y,1)) skew(var(--ha-tfx-skew-x,0),var(--ha-tfx-skew-y,0)) rotateX(var(--ha-tfx-rotate-x,0)) rotateY(var(--ha-tfx-rotate-y,0)) rotateZ(var(--ha-tfx-rotate-z,0));transform:translate(var(--ha-tfx-translate-x,0),var(--ha-tfx-translate-y,0)) scale(var(--ha-tfx-scale-x,1),var(--ha-tfx-scale-y,1)) skew(var(--ha-tfx-skew-x,0),var(--ha-tfx-skew-y,0)) rotateX(var(--ha-tfx-rotate-x,0)) rotateY(var(--ha-tfx-rotate-y,0)) rotateZ(var(--ha-tfx-rotate-z,0))}.ha-css-transform-yes:hover{-webkit-transform:translate(var(--ha-tfx-translate-x-hover,var(--ha-tfx-translate-x,0)),var(--ha-tfx-translate-y-hover,var(--ha-tfx-translate-y,0))) scale(var(--ha-tfx-scale-x-hover,var(--ha-tfx-scale-x,1)),var(--ha-tfx-scale-y-hover,var(--ha-tfx-scale-y,1))) skew(var(--ha-tfx-skew-x-hover,var(--ha-tfx-skew-x,0)),var(--ha-tfx-skew-y-hover,var(--ha-tfx-skew-y,0))) rotateX(var(--ha-tfx-rotate-x-hover,var(--ha-tfx-rotate-x,0))) rotateY(var(--ha-tfx-rotate-y-hover,var(--ha-tfx-rotate-y,0))) rotateZ(var(--ha-tfx-rotate-z-hover,var(--ha-tfx-rotate-z,0)));transform:translate(var(--ha-tfx-translate-x-hover,var(--ha-tfx-translate-x,0)),var(--ha-tfx-translate-y-hover,var(--ha-tfx-translate-y,0))) scale(var(--ha-tfx-scale-x-hover,var(--ha-tfx-scale-x,1)),var(--ha-tfx-scale-y-hover,var(--ha-tfx-scale-y,1))) skew(var(--ha-tfx-skew-x-hover,var(--ha-tfx-skew-x,0)),var(--ha-tfx-skew-y-hover,var(--ha-tfx-skew-y,0))) rotateX(var(--ha-tfx-rotate-x-hover,var(--ha-tfx-rotate-x,0))) rotateY(var(--ha-tfx-rotate-y-hover,var(--ha-tfx-rotate-y,0))) rotateZ(var(--ha-tfx-rotate-z-hover,var(--ha-tfx-rotate-z,0)))}.happy-addon>.elementor-widget-container{word-wrap:break-word;overflow-wrap:break-word;box-sizing:border-box}.happy-addon>.elementor-widget-container *{box-sizing:border-box}.happy-addon p:empty{display:none}.happy-addon .elementor-inline-editing{min-height:auto!important}.happy-addon-pro img{max-width:100%;height:auto;-o-object-fit:cover;object-fit:cover}.ha-screen-reader-text{position:absolute;overflow:hidden;clip:rect(1px,1px,1px,1px);margin:-1px;padding:0;width:1px;height:1px;border:0;word-wrap:normal!important;-webkit-clip-path:inset(50%);clip-path:inset(50%)}.ha-has-bg-overlay>.elementor-widget-container{position:relative;z-index:1}.ha-has-bg-overlay>.elementor-widget-container:before{position:absolute;top:0;left:0;z-index:-1;width:100%;height:100%;content:""}.ha-popup--is-enabled .ha-js-popup,.ha-popup--is-enabled .ha-js-popup img{cursor:-webkit-zoom-in!important;cursor:zoom-in!important}.mfp-wrap .mfp-arrow,.mfp-wrap .mfp-close{background-color:transparent}.mfp-wrap .mfp-arrow:focus,.mfp-wrap .mfp-close:focus{outline-width:thin}
+</style>
+<link rel='stylesheet' id='elementor-post-7-css'  href='https://news.edbmauritius.org/wp-content/uploads/elementor/css/post-7.css?ver=1620028364' type='text/css' media='all' />
+<link rel='stylesheet' id='font-awesome-5-all-css'  href='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/lib/font-awesome/css/all.min.css?ver=3.2.2' type='text/css' media='all' />
+<link rel='stylesheet' id='font-awesome-4-shim-css'  href='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/lib/font-awesome/css/v4-shims.min.css?ver=3.2.2' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-global-css'  href='https://news.edbmauritius.org/wp-content/uploads/elementor/css/global.css?ver=1620028507' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-post-2047-css'  href='https://news.edbmauritius.org/wp-content/uploads/elementor/css/post-2047.css?ver=1620045936' type='text/css' media='all' />
+<link rel='stylesheet' id='happy-icons-css'  href='https://news.edbmauritius.org/wp-content/plugins/happy-elementor-addons/assets/fonts/style.min.css?ver=2.24.0' type='text/css' media='all' />
+<link rel='stylesheet' id='font-awesome-css'  href='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/lib/font-awesome/css/font-awesome.min.css?ver=4.7.0' type='text/css' media='all' />
+<link rel='stylesheet' id='google-fonts-1-css'  href='https://fonts.googleapis.com/css?family=Roboto%3A100%2C100italic%2C200%2C200italic%2C300%2C300italic%2C400%2C400italic%2C500%2C500italic%2C600%2C600italic%2C700%2C700italic%2C800%2C800italic%2C900%2C900italic%7CRoboto+Slab%3A100%2C100italic%2C200%2C200italic%2C300%2C300italic%2C400%2C400italic%2C500%2C500italic%2C600%2C600italic%2C700%2C700italic%2C800%2C800italic%2C900%2C900italic&#038;display=swap&#038;ver=5.8' type='text/css' media='all' />
+		<script>
+			/* <![CDATA[ */
+			var rcewpp = {
+				"ajax_url":"https://news.edbmauritius.org/wp-admin/admin-ajax.php",
+				"nonce": "0a19ae4e27",
+				"home_url": "https://news.edbmauritius.org"
+			};
+			/* ]]\> */
+		</script>
+		<script type='text/javascript' src='https://news.edbmauritius.org/wp-includes/js/jquery/jquery.min.js?ver=3.6.0' id='jquery-core-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.3.2' id='jquery-migrate-js'></script>
+<script type='text/javascript' id='maxbizz_scripts-js-extra'>
+/* <![CDATA[ */
+var maxbizz_loadmore_params = {"ajaxurl":"https:\/\/news.edbmauritius.org\/wp-admin\/admin-ajax.php"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/themes/maxbizz/js/myloadmore.js?ver=1692945327' id='maxbizz_scripts-js'></script>
+<script type='text/javascript' id='graphina-charts-for-elementor-public-js-extra'>
+/* <![CDATA[ */
+var graphina_localize = {"ajaxurl":"https:\/\/news.edbmauritius.org\/wp-admin\/admin-ajax.php","nonce":"5412e506a1","graphinaAllGraphs":[],"graphinaAllGraphsOptions":[],"graphinaBlockCharts":[]};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/plugins/graphina-elementor-charts-and-graphs/elementor/js/graphina-charts-for-elementor-public.js?ver=1.5.6' id='graphina-charts-for-elementor-public-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/plugins/novashare/js/novashare.min.js?ver=1.1.5' id='novashare-js-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/plugins/revslider/public/assets/js/rbtools.min.js?ver=6.3.6' id='tp-tools-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/plugins/revslider/public/assets/js/rs6.min.js?ver=6.3.6' id='revmin-js'></script>
+<script data-rocketlazyloadscript='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/lib/font-awesome/js/v4-shims.min.js?ver=3.2.2' type='text/javascript'  id='font-awesome-4-shim-js'></script>
+<link rel="https://api.w.org/" href="https://news.edbmauritius.org/wp-json/" /><link rel="alternate" type="application/json" href="https://news.edbmauritius.org/wp-json/wp/v2/pages/2047" /><link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://news.edbmauritius.org/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://news.edbmauritius.org/wp-includes/wlwmanifest.xml" /> 
+<meta name="generator" content="WordPress 5.8" />
+<link rel='shortlink' href='https://news.edbmauritius.org/?p=2047' />
+<link rel="alternate" type="application/json+oembed" href="https://news.edbmauritius.org/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fnews.edbmauritius.org%2F2021-january-the-new-premium-visa%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://news.edbmauritius.org/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fnews.edbmauritius.org%2F2021-january-the-new-premium-visa%2F&#038;format=xml" />
+<link rel="alternate" hreflang="en-US" href="https://news.edbmauritius.org/2021-january-the-new-premium-visa/"/>
+<link rel="alternate" hreflang="en" href="https://news.edbmauritius.org/2021-january-the-new-premium-visa/"/>
+<link rel="alternate" hreflang="fr-FR" href="https://news.edbmauritius.org/fr/2021-january-the-new-premium-visa/"/>
+<link rel="alternate" hreflang="fr" href="https://news.edbmauritius.org/fr/2021-january-the-new-premium-visa/"/>
+<style type="text/css">
+		  	/****Main Color****/
+
+			/*Background Color*/
+			.bg-primary,
+			.list-primary li:before,
+			.btn-details:hover,
+			.owl-carousel .owl-dots button.owl-dot.active span,
+			.owl-carousel .owl-dots button.owl-dot:hover span,
+			.owl-carousel .owl-nav button.owl-prev:hover,.owl-carousel .owl-nav button.owl-next:hover,
+			.octf-btn,
+			.octf-btn-dark:hover, .octf-btn-dark:focus,
+			.octf-btn-light:hover, .octf-btn-light:focus,
+			.octf-btn.octf-btn-border:hover, .octf-btn.octf-btn-border:focus,
+			.main-navigation > ul > li:before,
+			.post-box .post-cat a,
+			.post-box .btn-play:hover i,
+			.page-pagination li span, .page-pagination li a:hover,
+			.blog-post .share-post a,
+			.post-nav > div .thumb-post:before,
+			.post-nav .post-prev.not-thumb a:hover .thumb-post:before,
+			.post-nav .post-next.not-thumb a:hover .thumb-post:before,
+			.widget-area .widget .widget-title:before,
+			.widget-area .widget_categories ul li a:before,.widget-area .widget_product_categories ul li a:before,.widget-area .widget_archive ul li a:before,
+			.search-form .search-submit,
+			.author-widget_social a:hover,
+			.bline-yes .icon-box-1:after,
+			.bline-yes .icon-box-2 .content-box:after,
+			.box-s2.icon-right .icon-main,
+			.ot-image-box:hover .link-box,
+			.line-progress .progress-bar,
+			.ot-pricing-table.is-featured .inner-table .title-table span,
+			.ot-pricing-table.is-featured .octf-btn,
+			.circle-social .team-social a:hover,
+			.ot-accordions .acc-item.current .acc-toggle,
+			.ot-testimonials .tphoto:after,
+			.ot-message-box .icon-main,
+			.ot-minicart .count,
+			.ot-heading > span.is_line:before,
+			.mc4wp-form-fields .subscribe-inner-form .subscribe-btn-icon:hover,
+			#back-to-top,
+			.error-404 .page-content form button:hover,
+			.woocommerce ul.products li.product .added_to_cart, .woocommerce ul.products li.product .product_type_grouped, .woocommerce-page ul.products li.product .added_to_cart, .woocommerce-page ul.products li.product .product_type_grouped,
+			.woocommerce #respond input#submit.alt, .woocommerce a.button.alt,.woocommerce button.button.alt, .woocommerce input.button.alt,.woocommerce #respond input#submit, .woocommerce a.button,.woocommerce input.button, .woocommerce button.button.alt.disabled,
+			.woocommerce button.button,
+			.woocommerce-mini-cart__buttons a.button.wc-forward,
+			.woocommerce-mini-cart__buttons a.button.wc-forward:hover{ background: #00548b; }
+			.post-box .entry-meta .btn-details:hover, 
+			.widget .tagcloud a:hover,
+			.ot-heading > span.is_highlight,
+			.icon-box-1 .icon-main{background: rgba(0,84,139,0.1);}
+			.team-3 .team-thumb a:before{background: rgba(0,84,139,0.8);}
+			.projects-grid .projects-box .portfolio-info,
+			.projects-grid.style-3 .projects-thumbnail .overlay{background: rgba(0,84,139,0.9);}
+
+			/*Background Image*/
+			.author-widget_wrapper:before{ background-image: linear-gradient(230deg, #00548b -150%, #fff 80%); }
+
+			/*Border Color*/
+			.octf-btn.octf-btn-border,
+			.post-box .entry-meta .btn-details:hover,
+			.post-box .btn-play:hover i,
+			.page-pagination li span, .page-pagination li a:hover,
+			.blog-post .tagcloud a:hover,
+			.widget .tagcloud a:hover,
+			.ot-heading > span.is_highlight,
+			.ot-image-box:hover .link-box,
+			.ot-accordions .acc-item.current .acc-toggle,
+			.ot-tabs .tab-link.current, .ot-tabs .tab-link:hover,
+			.ot-video-button a:hover span,
+			.woocommerce div.product .woocommerce-tabs ul.tabs li a:hover,
+			.woocommerce div.product .woocommerce-tabs ul.tabs li.active a{ border-color: #00548b; }
+
+			/*Border Top Color*/
+			.woocommerce-message,
+			.woocommerce-info{ border-top-color: #00548b; }
+
+			/*Color*/
+			blockquote:before,
+			blockquote cite,
+			.text-primary,
+			.link-details,
+			.link-details:visited,
+			.octf-btn.octf-btn-border,
+			.octf-btn.octf-btn-border:visited,
+			a:hover, a:focus, a:active,
+			.main-navigation > ul > li:hover > a,
+			.main-navigation ul li li a:hover,.main-navigation ul ul.sub-menu li.current-menu-item > a,.main-navigation ul ul.sub-menu li.current-menu-ancestor > a,
+			.main-navigation ul > li.menu-item-has-children:hover > a,
+			.main-navigation ul > li.menu-item-has-children:hover > a:after,
+			.main-navigation ul > li.menu-item-has-children > a:hover:after,
+			.header_mobile .mobile_nav .mobile_mainmenu li li a:hover,.header_mobile .mobile_nav .mobile_mainmenu ul > li > ul > li.current-menu-ancestor > a,
+			.header_mobile .mobile_nav .mobile_mainmenu > li > a:hover, .header_mobile .mobile_nav .mobile_mainmenu > li.current-menu-item > a,.header_mobile .mobile_nav .mobile_mainmenu > li.current-menu-ancestor > a,
+			.post-box .entry-meta a:hover,
+			.post-box .entry-meta .btn-details:hover,
+			.post-box .entry-title a:hover,
+			.post-box .link-box a:hover,
+			.post-box .link-box i,
+			.post-box .quote-box i,
+			.post-box .quote-box .quote-text span,
+			.blog-post .tagcloud a:hover,
+			.blog-post .author-bio .author-info .author-socials a:hover,
+			.comments-area .comment-item .comment-meta .comment-reply-link,
+			.comment-respond .comment-reply-title small a:hover,
+			.comment-form .logged-in-as a:hover,
+			.widget .tagcloud a:hover,
+			.widget-area .widget ul:not(.recent-news) > li a:hover,
+			.widget-area .widget_categories ul li a:hover + span.posts-count,.widget-area .widget_product_categories ul li a:hover + span.posts-count,.widget-area .widget_archive ul li a:hover + span.posts-count,
+			.ot-heading > span,
+			.icon-box .icon-main,
+			.icon-box-grid .icon-box .icon-main,
+			.icon-box-grid .icon-box .content-box .title-box a:hover,
+			.icon-box-grid .icon-box:hover .icon-main,
+			.ot-image-box .link-box,
+			.ot-counter span,
+			.ot-counter-2 i,
+			.ot-countdown li.seperator,
+			.ot-pricing-table .inner-table h2,
+			.project_filters li a:before,
+			.project_filters li a .filter-count,
+			.project_filters li a.selected, .project_filters li a:hover,
+			.ot-team .team-info span,
+			.ot-testimonials .t-head span,
+			.woocommerce ul.products li.product .price .woocommerce-Price-amount, .woocommerce-page ul.products li.product .price .woocommerce-Price-amount,
+			.woocommerce table.shop_table td.product-price, .woocommerce table.shop_table td.product-subtotal,
+			.woocommerce-message:before,
+			.woocommerce-info:before,
+			.woocommerce .woocommerce-Price-amount,
+			.woocommerce .site ul.product_list_widget li a:not(.remove):hover,
+			.woocommerce .woocommerce-widget-layered-nav-list li a:hover,
+			.woocommerce .widget_price_filter .price_slider_amount button.button,
+			.woocommerce div.product p.price,.woocommerce div.product span.price{ color: #00548b; }
+
+			/*Other*/
+			.icon-box .icon-main svg,
+			.icon-box-grid .icon-box .icon-main svg,
+			.ot-counter-2 svg{ fill: #00548b; }
+				</style><style type="text/css">h1, h2, h3, h4, h5, h6,
+			blockquote,
+			.font-second,
+			.link-details,
+			.slide-rev-subtitle,
+			.octf-btn,
+			select,
+			.main-navigation ul,
+			.page-header,
+			.post-box .post-cat a,
+			.post-box .entry-meta,
+			.post-box .link-box a,
+			.post-box .quote-box .quote-text,
+			.page-pagination li a, .page-pagination li span,
+			.blog-post .tagcloud a,
+			.drop-cap,
+			.post-nav,
+			.comments-area .comment-item .comment-meta .comment-time,
+			.comments-area .comment-item .comment-meta .comment-reply-link,
+			.comment-form .logged-in-as,
+			.widget .tagcloud a,
+			.widget table,
+			.widget .recent-news .post-on,
+			.ot-heading,
+			.ot-flip-box .number-title span,
+			.ot-counter,
+			.ot-counter span,
+			.ot-countdown li span,
+			.line-progress .percent,
+			.project_filters li a,
+			.projects-grid .projects-box .portfolio-info .portfolio-cates,
+			.project-slider .projects-box .portfolio-info .portfolio-cates,
+			.ot-team .team-info span,
+			.member-info li span,
+			.ot-accordions .acc-item .acc-toggle,
+			.ot-tabs .tab-link,
+			.ot-testimonials .t-head,
+			.features-service-wrapper .features-service-item .features-service-content,
+			div.elementor-widget-heading.elementor-widget-heading .elementor-heading-title,
+			.elementor-element .elementor-widget-button .elementor-button,
+			.elementor-default .elementor-widget-text-editor .elementor-drop-cap,
+			.elementor-widget-wp-widget-polylang .lang-item,
+			#lang_choice_wp-widget-polylang,
+			.mmenu-wrapper .mobile_mainmenu,
+			.woocommerce ul.products li.product, .woocommerce-page ul.products li.product,
+			.woocommerce ul.products li.product .added_to_cart, .woocommerce ul.products li.product .product_type_grouped, .woocommerce-page ul.products li.product .added_to_cart, .woocommerce-page ul.products li.product .product_type_grouped,
+			.woocommerce table.shop_table,
+			.woocommerce .quantity .qty,
+			.cart_totals h2,
+			#add_payment_method .cart-collaterals .cart_totals table td, #add_payment_method .cart-collaterals .cart_totals table th,.woocommerce-cart .cart-collaterals .cart_totals table td, .woocommerce-cart .cart-collaterals .cart_totals table th,.woocommerce-checkout .cart-collaterals .cart_totals table td, .woocommerce-checkout .cart-collaterals .cart_totals table th,
+			.woocommerce .site ul.product_list_widget li a:not(.remove),
+			.woocommerce .widget_shopping_cart .cart_list .quantity,
+			.woocommerce .widget_shopping_cart .total strong,.woocommerce.widget_shopping_cart .total strong,
+			.woocommerce .widget_shopping_cart .total .woocommerce-Price-amount,.woocommerce.widget_shopping_cart .total .woocommerce-Price-amount,
+			.woocommerce-mini-cart__buttons a.button.wc-forward,
+			.woocommerce .woocommerce-widget-layered-nav-list,
+			.woocommerce .widget_price_filter .price_slider_amount,
+			.woocommerce .widget_price_filter .price_slider_amount button.button,
+			.product_meta > span,
+			.woocommerce div.product .entry-summary p.price,.woocommerce div.product .entry-summary span.price{ font-family: Roboto;}
+		    </style><style type="text/css">.recentcomments a{display:inline !important;padding:0 !important;margin:0 !important;}</style><meta name="generator" content="Powered by Slider Revolution 6.3.6 - responsive, Mobile-Friendly Slider Plugin for WordPress with comfortable drag and drop interface." />
+<link rel="icon" href="https://news.edbmauritius.org/wp-content/uploads/2021/01/favicon.ico" sizes="32x32" />
+<link rel="icon" href="https://news.edbmauritius.org/wp-content/uploads/2021/01/favicon.ico" sizes="192x192" />
+<link rel="apple-touch-icon" href="https://news.edbmauritius.org/wp-content/uploads/2021/01/favicon.ico" />
+<meta name="msapplication-TileImage" content="https://news.edbmauritius.org/wp-content/uploads/2021/01/favicon.ico" />
+<script type="text/javascript">function setREVStartSize(e){
+			//window.requestAnimationFrame(function() {				 
+				window.RSIW = window.RSIW===undefined ? window.innerWidth : window.RSIW;	
+				window.RSIH = window.RSIH===undefined ? window.innerHeight : window.RSIH;	
+				try {								
+					var pw = document.getElementById(e.c).parentNode.offsetWidth,
+						newh;
+					pw = pw===0 || isNaN(pw) ? window.RSIW : pw;
+					e.tabw = e.tabw===undefined ? 0 : parseInt(e.tabw);
+					e.thumbw = e.thumbw===undefined ? 0 : parseInt(e.thumbw);
+					e.tabh = e.tabh===undefined ? 0 : parseInt(e.tabh);
+					e.thumbh = e.thumbh===undefined ? 0 : parseInt(e.thumbh);
+					e.tabhide = e.tabhide===undefined ? 0 : parseInt(e.tabhide);
+					e.thumbhide = e.thumbhide===undefined ? 0 : parseInt(e.thumbhide);
+					e.mh = e.mh===undefined || e.mh=="" || e.mh==="auto" ? 0 : parseInt(e.mh,0);		
+					if(e.layout==="fullscreen" || e.l==="fullscreen") 						
+						newh = Math.max(e.mh,window.RSIH);					
+					else{					
+						e.gw = Array.isArray(e.gw) ? e.gw : [e.gw];
+						for (var i in e.rl) if (e.gw[i]===undefined || e.gw[i]===0) e.gw[i] = e.gw[i-1];					
+						e.gh = e.el===undefined || e.el==="" || (Array.isArray(e.el) && e.el.length==0)? e.gh : e.el;
+						e.gh = Array.isArray(e.gh) ? e.gh : [e.gh];
+						for (var i in e.rl) if (e.gh[i]===undefined || e.gh[i]===0) e.gh[i] = e.gh[i-1];
+											
+						var nl = new Array(e.rl.length),
+							ix = 0,						
+							sl;					
+						e.tabw = e.tabhide>=pw ? 0 : e.tabw;
+						e.thumbw = e.thumbhide>=pw ? 0 : e.thumbw;
+						e.tabh = e.tabhide>=pw ? 0 : e.tabh;
+						e.thumbh = e.thumbhide>=pw ? 0 : e.thumbh;					
+						for (var i in e.rl) nl[i] = e.rl[i]<window.RSIW ? 0 : e.rl[i];
+						sl = nl[0];									
+						for (var i in nl) if (sl>nl[i] && nl[i]>0) { sl = nl[i]; ix=i;}															
+						var m = pw>(e.gw[ix]+e.tabw+e.thumbw) ? 1 : (pw-(e.tabw+e.thumbw)) / (e.gw[ix]);					
+						newh =  (e.gh[ix] * m) + (e.tabh + e.thumbh);
+					}				
+					if(window.rs_init_css===undefined) window.rs_init_css = document.head.appendChild(document.createElement("style"));					
+					document.getElementById(e.c).height = newh+"px";
+					window.rs_init_css.innerHTML += "#"+e.c+"_wrapper { height: "+newh+"px }";				
+				} catch(e){
+					console.log("Failure at Presize of Slider:" + e)
+				}					   
+			//});
+		  };</script>
+		<style type="text/css" id="wp-custom-css">
+			.widget .recent-news h6{
+	font-size: 17px;
+}
+.post-nav .info-post h6{
+	font-size: 18px;
+}
+
+@media(min-width:1220px){
+	body{
+	width:800px;
+	margin:0 auto;
+	border:1px solid #efefef;
+}
+}
+
+#site-header > div.header-desktop > div > div > div > section.elementor-section.elementor-top-section.elementor-element.elementor-element-cc784fd.elementor-section-full_width.elementor-section-content-middle.elementor-section-height-default.elementor-section-height-default > div > div > div > div > div > div > div{
+	display:flex;
+	justify-content:center;
+}
+.print-btn{
+
+	background-color:transparent;
+	border:none;
+	padding:10px 0;
+	text-transform:uppercase;
+
+	font-size:15px;
+	color:#ffffff;
+	font-family: "Font Awesome 5 Free"; 
+}
+.footer-logo path,.footer-logo rect{
+	fill:#ffffff;
+}
+
+.news-container-details .elementor-element.elementor-widget.elementor-widget-heading{
+	min-height:160px;
+}
+.icon-container-title h3.elementor-image-box-title{
+	padding-top:10px;
+}
+.page-header .page-title{
+	display:none;
+}
+.elementor-testimonial-content{
+	text-align:justify;
+}
+@media(max-width:480px){
+	body{
+		overflow:hidden;
+	}
+}
+.page-id-2908 .novashare-buttons.novashare-floating.novashare-no-print,.page-id-2917 .novashare-buttons.novashare-floating.novashare-no-print,.page-id-2849 .novashare-buttons.novashare-floating.novashare-no-print,.page-id-2951 .novashare-buttons.novashare-floating.novashare-no-print,.page-id-2949 .novashare-buttons.novashare-floating.novashare-no-print,.page-id-2982 .novashare-buttons.novashare-floating.novashare-no-print,.page-id-3076 .novashare-buttons.novashare-floating.novashare-no-print,.page-id-3087 .novashare-buttons.novashare-floating.novashare-no-print,.page-id-3269 .novashare-buttons.novashare-floating.novashare-no-print{
+	display:none;
+}		</style>
+		<style id="kirki-inline-styles">.page-header{background-image:url("https://edb-newsletter.diizz.com/wp-content/uploads/2021/01/pheader-blog.jpg");}#back-to-top{background:#4aa1c8;}#back-to-top > i:before{color:#ffffff;}body, p, button, input, select, optgroup, textarea, .font-main, .elementor-element .elementor-widget-text-editor, .elementor-element .elementor-widget-icon-list .elementor-icon-list-item{font-family:Roboto;font-weight:400;}h1, .elementor-widget.elementor-widget-heading h1.elementor-heading-title{font-family:Roboto;font-size:48px;font-weight:700;line-height:1.2;}h2, .elementor-widget.elementor-widget-heading h2.elementor-heading-title{font-family:Roboto;font-size:42px;font-weight:700;line-height:1.2;}h3, .elementor-widget.elementor-widget-heading h3.elementor-heading-title{font-family:Roboto;font-size:38px;font-weight:700;line-height:1.2;}h4, .elementor-widget.elementor-widget-heading h4.elementor-heading-title{font-family:Roboto;font-size:30px;font-weight:700;line-height:1.2;}h5, .elementor-widget.elementor-widget-heading h5.elementor-heading-title{font-family:Roboto;font-size:24px;font-weight:700;line-height:1.2;}h6, .elementor-widget.elementor-widget-heading h6.elementor-heading-title{font-family:Roboto;font-size:20px;font-weight:700;line-height:1.2;}@media (max-width: 767px){}@media (min-width: 768px) and (max-width: 1024px){}@media (min-width: 1024px){}/* cyrillic-ext */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://news.edbmauritius.org/wp-content/fonts/roboto/KFOmCnqEu92Fr1Mu72xMKTU1Kvnz.woff) format('woff');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://news.edbmauritius.org/wp-content/fonts/roboto/KFOmCnqEu92Fr1Mu5mxMKTU1Kvnz.woff) format('woff');
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://news.edbmauritius.org/wp-content/fonts/roboto/KFOmCnqEu92Fr1Mu7mxMKTU1Kvnz.woff) format('woff');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://news.edbmauritius.org/wp-content/fonts/roboto/KFOmCnqEu92Fr1Mu4WxMKTU1Kvnz.woff) format('woff');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://news.edbmauritius.org/wp-content/fonts/roboto/KFOmCnqEu92Fr1Mu7WxMKTU1Kvnz.woff) format('woff');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://news.edbmauritius.org/wp-content/fonts/roboto/KFOmCnqEu92Fr1Mu7GxMKTU1Kvnz.woff) format('woff');
+  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url(https://news.edbmauritius.org/wp-content/fonts/roboto/KFOmCnqEu92Fr1Mu4mxMKTU1Kg.woff) format('woff');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* cyrillic-ext */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://news.edbmauritius.org/wp-content/fonts/roboto/KFOlCnqEu92Fr1MmWUlfCRc-AMP6lbBP.woff) format('woff');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+/* cyrillic */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://news.edbmauritius.org/wp-content/fonts/roboto/KFOlCnqEu92Fr1MmWUlfABc-AMP6lbBP.woff) format('woff');
+  unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+/* greek-ext */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://news.edbmauritius.org/wp-content/fonts/roboto/KFOlCnqEu92Fr1MmWUlfCBc-AMP6lbBP.woff) format('woff');
+  unicode-range: U+1F00-1FFF;
+}
+/* greek */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://news.edbmauritius.org/wp-content/fonts/roboto/KFOlCnqEu92Fr1MmWUlfBxc-AMP6lbBP.woff) format('woff');
+  unicode-range: U+0370-03FF;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://news.edbmauritius.org/wp-content/fonts/roboto/KFOlCnqEu92Fr1MmWUlfCxc-AMP6lbBP.woff) format('woff');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://news.edbmauritius.org/wp-content/fonts/roboto/KFOlCnqEu92Fr1MmWUlfChc-AMP6lbBP.woff) format('woff');
+  unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url(https://news.edbmauritius.org/wp-content/fonts/roboto/KFOlCnqEu92Fr1MmWUlfBBc-AMP6lQ.woff) format('woff');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}</style>	
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script data-rocketlazyloadscript='https://www.googletagmanager.com/gtag/js?id=G-KK5BYFD5RQ' async ></script>
+	<script data-rocketlazyloadscript='data:text/javascript;base64,CgkgIHdpbmRvdy5kYXRhTGF5ZXIgPSB3aW5kb3cuZGF0YUxheWVyIHx8IFtdOwoJICBmdW5jdGlvbiBndGFnKCl7ZGF0YUxheWVyLnB1c2goYXJndW1lbnRzKTt9CgkgIGd0YWcoJ2pzJywgbmV3IERhdGUoKSk7CgoJICBndGFnKCdjb25maWcnLCAnRy1LSzVCWUZENVJRJyk7Cgk=' ></script>
+	
+	
+	
+</head>
+
+<body data-rsssl=1 class="page-template-default page page-id-2047 translatepress-en_US elementor-default elementor-kit-7 elementor-page elementor-page-2047 maxbizz-theme-ver-1.0 wordpress-version-5.8">
+
+<div id="page" class="site">
+
+<!-- #site-header-open -->
+<header id="site-header" class="site-header header-static">
+
+    <!-- #header-desktop-open -->
+    <div class="header-desktop">		<div data-elementor-type="wp-post" data-elementor-id="106" class="elementor elementor-106" data-elementor-settings="[]">
+						<div class="elementor-inner">
+							<div class="elementor-section-wrap">
+							<section class="elementor-section elementor-top-section elementor-element elementor-element-ae09617 elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="ae09617" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;gradient&quot;,&quot;_ha_eqh_enable&quot;:false}">
+						<div class="elementor-container elementor-column-gap-default">
+							<div class="elementor-row">
+					<div class="elementor-column elementor-col-33 elementor-top-column elementor-element elementor-element-4465690 ot-column-items-center ot-flex-column-vertical" data-id="4465690" data-element_type="column">
+			<div class="elementor-column-wrap elementor-element-populated">
+							<div class="elementor-widget-wrap">
+						<div class="elementor-element elementor-element-bedbb6b elementor-widget elementor-widget-html" data-id="bedbb6b" data-element_type="widget" data-widget_type="html.default">
+				<div class="elementor-widget-container">
+			<a href="/2021-january/" ><svg class="footer-logo" width="150px" height="100px" viewBox="0 0 682 247" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="edb-logo">
+              <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+              <defs></defs>
+              <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                <g id="Group" fill-rule="nonzero">
+                  <g id="logo-EDB-01">
+                    <rect id="Rectangle-path1" fill="#80BA27" x="0.03" y="179.64" width="92.32" height="66.83"></rect>
+                    <path d="M178.89,60.76 C198,60.76 213.5,47.29 213.5,30.67 C213.5,14.05 198,0.57 178.89,0.57 L118.43,0.57 L118.43,60.76 L178.89,60.76 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M273.36,88.81 C273.357305,88.5094872 273.475492,88.2204986 273.687995,88.0079954 C273.900499,87.7954922 274.189487,87.6773047 274.49,87.68 L299.21,87.68 C299.834082,87.68 300.34,88.1859182 300.34,88.81 L300.34,95.32 C300.34,95.9440818 299.834082,96.45 299.21,96.45 L282.67,96.45 L282.67,103.85 L296.28,103.85 C296.899044,103.870981 297.394473,104.370795 297.41,104.99 L297.41,111.5 C297.41,112.124082 296.904082,112.63 296.28,112.63 L282.67,112.63 L282.67,120.69 L299.21,120.69 C299.834082,120.69 300.34,121.195918 300.34,121.82 L300.34,128.33 C300.34,128.954082 299.834082,129.46 299.21,129.46 L274.49,129.46 C274.189487,129.462695 273.900499,129.344508 273.687995,129.132005 C273.475492,128.919501 273.357305,128.630513 273.36,128.33 L273.36,88.81 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M325.66,87.08 C331.022925,86.9182118 336.225964,88.9179949 340.1,92.63 C340.351406,92.8300857 340.502761,93.1300913 340.514298,93.4511929 C340.525834,93.7722945 340.396399,94.0823883 340.16,94.3 L335.51,99.14 C335.312507,99.3415659 335.042192,99.4551531 334.76,99.4551531 C334.477808,99.4551531 334.207493,99.3415659 334.01,99.14 C331.783821,97.1766924 328.91824,96.0923225 325.95,96.09 C319.21,96.09 314.25,101.71 314.25,108.39 C314.172112,111.563622 315.373018,114.63538 317.582722,116.914667 C319.792427,119.193954 322.825489,120.489488 326,120.51 C328.918147,120.506256 331.744964,119.492136 334,117.64 C334.46509,117.277012 335.124165,117.302361 335.56,117.7 L340.21,122.7 C340.61157,123.170665 340.585488,123.87053 340.15,124.31 C336.27083,128.078949 331.058261,130.160381 325.65,130.1 C313.775878,130.1 304.15,120.474122 304.15,108.6 C304.15,96.7258779 313.775878,87.1 325.65,87.1 L325.66,87.08 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M363.15,87.08 C375.018531,87.0469094 384.666711,96.6414134 384.699832,108.509945 C384.732954,120.378476 375.138475,130.02668 363.269944,130.059833 C351.401413,130.092985 341.753183,120.498531 341.72,108.63 C341.693411,102.927264 343.938826,97.4486868 347.960038,93.4049568 C351.981251,89.3612268 357.447205,87.0852553 363.15,87.08 Z M363.15,120.51 C367.990113,120.534262 372.366029,117.634105 374.229485,113.167023 C376.092941,108.699941 375.075225,103.549815 371.652705,100.127295 C368.230185,96.704775 363.080059,95.6870587 358.612977,97.5505149 C354.145895,99.413971 351.245738,103.789887 351.27,108.63 C351.33502,115.164021 356.615979,120.44498 363.15,120.51 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M389.42,88.15 C389.452106,87.5455803 389.95476,87.0737915 390.56,87.08 L392.05,87.08 L415.87,110 L415.93,110 L415.93,88.81 C415.93,88.1859182 416.435918,87.68 417.06,87.68 L424.23,87.68 C424.845304,87.7006998 425.3393,88.1946963 425.36,88.81 L425.36,129 C425.33309,129.602842 424.833412,130.075988 424.23,130.07 L423.23,130.07 C422.952867,130.03367 422.688664,129.930733 422.46,129.77 L398.88,106.07 L398.82,106.07 L398.82,128.34 C398.820012,128.641435 398.699587,128.930381 398.485503,129.142587 C398.271419,129.354793 397.981424,129.472668 397.68,129.47 L390.58,129.47 C389.960795,129.454473 389.460981,128.959044 389.44,128.34 L389.42,88.15 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M452.83,87.08 C464.698531,87.0469094 474.346711,96.6414134 474.379832,108.509945 C474.412954,120.378476 464.818475,130.02668 452.949944,130.059833 C441.081413,130.092985 431.433183,120.498531 431.4,108.63 C431.373411,102.927264 433.618826,97.4486868 437.640038,93.4049568 C441.661251,89.3612268 447.127205,87.0852553 452.83,87.08 Z M452.83,120.51 C457.674489,120.554573 462.065696,117.667408 463.94496,113.202049 C465.824224,108.73669 464.818977,103.578406 461.400492,100.145474 C457.982008,96.7125408 452.82801,95.6855469 448.354765,97.5459611 C443.881519,99.4063754 440.97586,103.785366 441,108.63 C441.064502,115.144817 446.315513,120.418022 452.83,120.51 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M483.28,88 C483.373107,87.4694918 483.821949,87.074677 484.36,87.05 L485.31,87.05 C485.718399,87.0839273 486.087876,87.3056139 486.31,87.65 L500.15,113.44 L500.27,113.44 L514.12,87.65 C514.342124,87.3056139 514.711601,87.0839273 515.12,87.05 L516.12,87.05 C516.658051,87.074677 517.106893,87.4694918 517.2,88 L523.94,128.12 C524.008989,128.451926 523.919606,128.797055 523.698169,129.053764 C523.476733,129.310474 523.148456,129.449535 522.81,129.43 L515.81,129.43 C515.257628,129.410863 514.788431,129.019866 514.67,128.48 L511.98,110.03 L511.87,110.03 L501.87,129.37 C501.652404,129.72873 501.285391,129.970959 500.87,130.03 L499.7,130.03 C499.27911,129.985882 498.906037,129.739653 498.7,129.37 L488.61,110.03 L488.49,110.03 L485.87,128.48 C485.76874,129.0301 485.289342,129.429598 484.73,129.43 L477.73,129.43 C477.391065,129.448687 477.062486,129.309845 476.839649,129.053778 C476.616813,128.797712 476.524681,128.453106 476.59,128.12 L483.28,88 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M530.39,88.81 C530.4107,88.1946963 530.904696,87.7006998 531.52,87.68 L538.69,87.68 C539.305304,87.7006998 539.7993,88.1946963 539.82,88.81 L539.82,128.33 C539.7993,128.945304 539.305304,129.4393 538.69,129.46 L531.52,129.46 C530.904696,129.4393 530.4107,128.945304 530.39,128.33 L530.39,88.81 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M567.4,87.08 C572.765204,86.9222785 577.969828,88.9212866 581.85,92.63 C582.101406,92.8300857 582.252761,93.1300913 582.264298,93.4511929 C582.275834,93.7722945 582.146399,94.0823883 581.91,94.3 L577.25,99.14 C577.060303,99.3518604 576.789376,99.4729355 576.505,99.4729355 C576.220624,99.4729355 575.949697,99.3518604 575.76,99.14 C573.533821,97.1766924 570.66824,96.0923225 567.7,96.09 C560.95,96.09 556,101.71 556,108.39 C555.922086,111.565345 557.124352,114.638633 559.336225,116.918217 C561.548099,119.197801 564.583749,120.492161 567.76,120.51 C570.678147,120.506256 573.504964,119.492136 575.76,117.64 C576.221898,117.278506 576.877429,117.303882 577.31,117.7 L581.97,122.7 C582.37157,123.170665 582.345488,123.87053 581.91,124.31 C578.027759,128.080472 572.811508,130.16194 567.4,130.1 C555.525878,130.1 545.9,120.474122 545.9,108.6 C545.9,96.7258779 555.525878,87.1 567.4,87.1 L567.4,87.08 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M273.36,147.13 C273.348553,146.522731 273.823224,146.017007 274.43,145.99 L289,145.99 C296.574034,145.824296 303.644732,149.770222 307.480393,156.303304 C311.316053,162.836386 311.316053,170.933614 307.480393,177.466696 C303.644732,183.999778 296.574034,187.945704 289,187.78 L274.43,187.78 C273.827158,187.75309 273.354012,187.253412 273.36,186.65 L273.36,147.13 Z M288.36,178.95 C295.11,178.95 300,173.63 300,166.83 C300,160.03 295.11,154.77 288.36,154.77 L282.63,154.77 L282.63,179 L288.36,178.95 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M316.05,147.13 C316.047332,146.828576 316.165207,146.538581 316.377413,146.324497 C316.589619,146.110413 316.878565,145.989988 317.18,145.99 L341.9,145.99 C342.525696,145.995489 343.030024,146.50428 343.03,147.13 L343.03,153.63 C343.030024,154.25572 342.525696,154.764511 341.9,154.77 L325.36,154.77 L325.36,162.17 L339,162.17 C339.619044,162.190981 340.114473,162.690795 340.13,163.31 L340.13,169.81 C340.146481,170.119948 340.034744,170.42303 339.821015,170.648107 C339.607287,170.873184 339.310386,171.000438 339,171 L325.36,171 L325.36,179 L341.9,179 C342.524082,179 343.03,179.505918 343.03,180.13 L343.03,186.64 C343.03,187.264082 342.524082,187.77 341.9,187.77 L317.18,187.77 C316.555918,187.77 316.05,187.264082 316.05,186.64 L316.05,147.13 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M344.47,147.55 C344.287697,147.211036 344.30345,146.799889 344.511155,146.475869 C344.718861,146.151848 345.085879,145.965872 345.47,145.99 L353.41,145.99 C353.838541,146.011816 354.221462,146.264544 354.41,146.65 L364.26,168.44 L364.61,168.44 L374.46,146.65 C374.648538,146.264544 375.031459,146.011816 375.46,145.99 L383.4,145.99 C383.784121,145.965872 384.151139,146.151848 384.358845,146.475869 C384.56655,146.799889 384.582303,147.211036 384.4,147.55 L365.66,187.72 C365.478474,188.111556 365.091393,188.36703 364.66,188.38 L364.07,188.38 C363.638607,188.36703 363.251526,188.111556 363.07,187.72 L344.47,147.55 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M388.17,147.13 C388.175431,146.508182 388.678182,146.005431 389.3,146 L414,146 C414.301435,145.999988 414.590381,146.120413 414.802587,146.334497 C415.014793,146.548581 415.132668,146.838576 415.13,147.14 L415.13,153.64 C415.132668,153.941424 415.014793,154.231419 414.802587,154.445503 C414.590381,154.659587 414.301435,154.780012 414,154.78 L397.48,154.78 L397.48,162.18 L411.09,162.18 C411.710823,162.200711 412.209289,162.699177 412.23,163.32 L412.23,169.82 C412.23,170.449605 411.719605,170.96 411.09,170.96 L397.48,170.96 L397.48,179 L414,179 C414.300513,178.997305 414.589501,179.115492 414.802005,179.327995 C415.014508,179.540499 415.132695,179.829487 415.13,180.13 L415.13,186.64 C415.13,187.264082 414.624082,187.77 414,187.77 L389.3,187.77 C388.675918,187.77 388.17,187.264082 388.17,186.64 L388.17,147.13 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M422,147.13 C422.00498,146.519572 422.489927,146.021399 423.1,146 L430.2,146 C430.820823,146.020711 431.319289,146.519177 431.34,147.14 L431.34,179 L445.54,179 C445.841424,178.997332 446.131419,179.115207 446.345503,179.327413 C446.559587,179.539619 446.680012,179.828565 446.68,180.13 L446.68,186.64 C446.674511,187.265696 446.16572,187.770024 445.54,187.77 L423.1,187.77 C422.47428,187.770024 421.965489,187.265696 421.96,186.64 L422,147.13 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M468.23,145.4 C480.091998,145.367037 489.737352,154.951442 489.779582,166.813411 C489.821812,178.675379 480.244944,188.328218 468.383013,188.379715 C456.521081,188.431211 446.860764,178.861888 446.8,167 C446.760057,161.288626 448.999568,155.797165 453.022231,151.742591 C457.044894,147.688017 462.518489,145.405186 468.23,145.4 Z M468.23,178.83 C473.074634,178.85414 477.453625,175.948481 479.314039,171.475235 C481.174453,167.00199 480.147459,161.847992 476.714526,158.429508 C473.281594,155.011023 468.12331,154.005776 463.657951,155.88504 C459.192592,157.764304 456.305427,162.155511 456.35,167 C456.441978,173.514487 461.715183,178.765498 468.23,178.83 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M494.56,147.13 C494.565489,146.504304 495.07428,145.999976 495.7,146 L510.09,146 C514.933402,145.856782 519.472528,148.355059 521.942782,152.523619 C524.413037,156.692179 524.424711,161.873387 521.973266,166.053036 C519.52182,170.232686 514.993998,172.751391 510.15,172.63 L503.88,172.63 L503.88,186.63 C503.854173,187.246916 503.35712,187.73961 502.74,187.76 L495.74,187.76 C495.11428,187.760024 494.605489,187.255696 494.6,186.63 L494.56,147.13 Z M509.56,163.9 C510.81162,163.908049 512.014309,163.414404 512.899357,162.529357 C513.784404,161.644309 514.278049,160.44162 514.27,159.19 C514.236117,157.97773 513.71968,156.829149 512.835348,155.999267 C511.951017,155.169385 510.771976,154.726881 509.56,154.77 L503.89,154.77 L503.89,163.9 L509.56,163.9 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M530.86,146.35 C530.927756,145.797788 531.384215,145.37514 531.94,145.35 L532.89,145.35 C533.295653,145.384544 533.663602,145.601634 533.89,145.94 L547.74,171.73 L547.86,171.73 L561.73,146 C561.956398,145.661634 562.324347,145.444544 562.73,145.41 L563.73,145.41 C564.283643,145.435818 564.736839,145.859366 564.8,146.41 L571.55,186.53 C571.615319,186.863106 571.523187,187.207712 571.300351,187.463778 C571.077514,187.719845 570.748935,187.858687 570.41,187.84 L563.41,187.84 C562.861411,187.816411 562.397481,187.426381 562.28,186.89 L559.59,168.44 L559.47,168.44 L549.47,187.78 C549.252404,188.13873 548.885391,188.380959 548.47,188.44 L547.39,188.44 C546.968519,188.397536 546.594748,188.150847 546.39,187.78 L536.3,168.44 L536.18,168.44 L533.55,186.89 C533.445866,187.434327 532.974124,187.830924 532.42,187.84 L525.42,187.84 C525.081544,187.859535 524.753267,187.720474 524.531831,187.463764 C524.310394,187.207055 524.221011,186.861926 524.29,186.53 L530.86,146.35 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M578,147.13 C578,146.500395 578.510395,145.99 579.14,145.99 L603.85,145.99 C604.479605,145.99 604.99,146.500395 604.99,147.13 L604.99,153.63 C604.99,154.259605 604.479605,154.77 603.85,154.77 L587.29,154.77 L587.29,162.17 L600.9,162.17 C601.516916,162.195827 602.00961,162.69288 602.03,163.31 L602.03,169.81 C602.043583,170.119185 601.930878,170.420605 601.717771,170.645027 C601.504665,170.869448 601.209473,170.997583 600.9,171 L587.29,171 L587.29,179 L603.82,179 C604.121424,178.997332 604.411419,179.115207 604.625503,179.327413 C604.839587,179.539619 604.960012,179.828565 604.96,180.13 L604.96,186.64 C604.954511,187.265696 604.44572,187.770024 603.82,187.77 L579.11,187.77 C578.48428,187.770024 577.975489,187.265696 577.97,186.64 L578,147.13 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M611.71,146.47 C611.731718,145.864799 612.234515,145.388699 612.84,145.4 L614.33,145.4 L638.15,168.32 L638.21,168.32 L638.21,147.13 C638.21,146.500395 638.720395,145.99 639.35,145.99 L646.51,145.99 C647.129044,146.010981 647.624473,146.510795 647.64,147.13 L647.64,187.3 C647.618343,187.906783 647.117141,188.385808 646.51,188.38 L645.51,188.38 C645.229781,188.343693 644.962327,188.240826 644.73,188.08 L621.15,164.38 L621.09,164.38 L621.09,186.65 C621.084511,187.275696 620.57572,187.780024 619.95,187.78 L612.85,187.78 C612.234696,187.7593 611.7407,187.265304 611.72,186.65 L611.71,146.47 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M662.1,154.77 L653.56,154.77 C653.258565,154.770012 652.969619,154.649587 652.757413,154.435503 C652.545207,154.221419 652.427332,153.931424 652.43,153.63 L652.43,147.13 C652.427332,146.828576 652.545207,146.538581 652.757413,146.324497 C652.969619,146.110413 653.258565,145.989988 653.56,145.99 L680.07,145.99 C680.695696,145.995489 681.200024,146.50428 681.2,147.13 L681.2,153.63 C681.200024,154.25572 680.695696,154.764511 680.07,154.77 L671.53,154.77 L671.53,186.65 C671.504173,187.266916 671.00712,187.75961 670.39,187.78 L663.23,187.78 C662.614696,187.7593 662.1207,187.265304 662.1,186.65 L662.1,154.77 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M273.36,205.45 C273.357332,205.148576 273.475207,204.858581 273.687413,204.644497 C273.899619,204.430413 274.188565,204.309988 274.49,204.31 L288.4,204.31 C295.45,204.31 301.24,209.15 301.24,215.41 C301.24,220.01 297.12,223.35 294.31,224.85 C297.47,226.16 302.31,229.08 302.31,234.58 C302.31,241.26 296.4,246.1 289.31,246.1 L274.49,246.1 C274.188565,246.100012 273.899619,245.979587 273.687413,245.765503 C273.475207,245.551419 273.357332,245.261424 273.36,244.96 L273.36,205.45 Z M287.36,221.27 C289.693155,221.220805 291.552431,219.303566 291.53,216.97 C291.547524,215.868636 291.1101,214.80879 290.32088,214.040389 C289.53166,213.271988 288.460502,212.863047 287.36,212.91 L282.7,212.91 L282.7,221.27 L287.36,221.27 Z M288.13,237.56 C289.278396,237.552071 290.376604,237.088254 291.183016,236.270589 C291.989429,235.452925 292.437984,234.348396 292.43,233.2 C292.43,230.82 289.86,229.03 287.54,229.03 L282.7,229.03 L282.7,237.56 L288.13,237.56 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M327.09,203.71 C335.787697,203.681705 343.645637,208.896623 346.998392,216.922192 C350.351147,224.947761 348.538162,234.202797 342.405124,240.370177 C336.272087,246.537557 327.027319,248.402194 318.983154,245.094306 C310.938988,241.786417 305.680273,233.957719 305.66,225.26 C305.633411,219.557264 307.878826,214.078687 311.900038,210.034957 C315.921251,205.991227 321.387205,203.715255 327.09,203.71 Z M327.09,237.15 C331.929207,237.174276 336.3045,234.275212 338.168555,229.809362 C340.03261,225.343513 339.016741,220.194166 335.596302,216.770848 C332.175863,213.347529 327.027373,212.327328 322.559957,214.187625 C318.09254,216.047922 315.189796,220.420774 315.21,225.26 C315.269609,231.797926 320.552126,237.08489 327.09,237.15 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M348.89,244.55 L367.57,204.37 C367.764904,203.990195 368.144152,203.739891 368.57,203.71 L369.16,203.71 C369.585848,203.739891 369.965096,203.990195 370.16,204.37 L388.84,244.55 C389.024222,244.887629 389.009102,245.298962 388.800591,245.622155 C388.592079,245.945349 388.223548,246.128674 387.84,246.1 L381.21,246.1 C380.14,246.1 379.66,245.74 379.12,244.61 L377,239.89 L360.76,239.89 L358.62,244.67 C358.277804,245.553332 357.416944,246.125905 356.47,246.1 L349.9,246.1 C349.501584,246.175708 349.096895,246.003293 348.875493,245.663517 C348.654091,245.323741 348.659821,244.883893 348.89,244.55 Z M373.42,231.77 L368.88,221.92 L368.82,221.92 L364.35,231.77 L373.42,231.77 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M392.59,205.45 C392.589976,204.82428 393.094304,204.315489 393.72,204.31 L411.57,204.31 C418.71083,204.309789 424.515071,210.069381 424.57,217.21 C424.57,222.7 420.93,227.11 415.73,229.21 L423.91,244.37 C424.132725,244.724777 424.140916,245.173653 423.931282,245.536319 C423.721649,245.898985 423.328592,246.115927 422.91,246.1 L415,246.1 C414.592296,246.119472 414.20733,245.91159 414,245.56 L406.06,229.74 L402,229.74 L402,245 C401.97961,245.61712 401.486916,246.114173 400.87,246.14 L393.76,246.14 C393.134304,246.134511 392.629976,245.62572 392.63,245 L392.59,205.45 Z M410.8,222.16 C413.339536,222.021952 415.32844,219.923285 415.33,217.38 C415.308275,214.887204 413.292796,212.871725 410.8,212.85 L402,212.85 L402,222.16 L410.8,222.16 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M431.4,205.45 C431.393791,204.84476 431.86558,204.342106 432.47,204.31 L447,204.31 C454.574034,204.144296 461.644732,208.090222 465.480393,214.623304 C469.316053,221.156386 469.316053,229.253614 465.480393,235.786696 C461.644732,242.319778 454.574034,246.265704 447,246.1 L432.47,246.1 C431.880874,246.068862 431.41484,245.589762 431.4,245 L431.4,205.45 Z M446.4,237.26 C453.15,237.26 458.04,231.95 458.04,225.15 C458.04,218.35 453.15,213.09 446.4,213.09 L440.67,213.09 L440.67,237.26 L446.4,237.26 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M487.21,221.18 C487.241696,220.85628 487.525562,220.616767 487.85,220.64 L488.42,220.64 C488.6766,220.628945 488.915649,220.770023 489.03,221 L496.91,237.89 L497.01,237.89 L504.89,221 C504.995705,220.762148 505.240686,220.617569 505.5,220.64 L506.07,220.64 C506.394438,220.616767 506.678304,220.85628 506.71,221.18 L510.94,245.23 C511.008231,245.431272 510.970387,245.653378 510.839353,245.820698 C510.70832,245.988018 510.501759,246.077997 510.29,246.06 L507,246.06 C506.683777,246.03716 506.413878,245.822829 506.32,245.52 L504.24,232 L504.14,232 L497.87,246 C497.77414,246.249661 497.52684,246.407771 497.26,246.39 L496.62,246.39 C496.352788,246.399902 496.106775,246.245152 496,246 L489.68,232 L489.57,232 L487.49,245.57 C487.422756,245.873672 487.160657,246.094818 486.85,246.11 L483.63,246.11 C483.417643,246.123748 483.211686,246.034261 483.076824,245.869651 C482.941962,245.70504 482.894743,245.485502 482.95,245.28 L487.21,221.18 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M514,245.12 L525.14,221 C525.233922,220.752109 525.475054,220.591355 525.74,220.6 L526.1,220.6 C526.369439,220.58368 526.617566,220.746386 526.71,221 L537.71,245.08 C537.819828,245.285537 537.809254,245.534527 537.682397,245.730013 C537.555539,245.925499 537.33245,246.036579 537.1,246.02 L534,246.02 C533.540829,246.038276 533.128306,245.741259 533,245.3 L531.24,241.43 L520.54,241.43 L518.79,245.3 C518.637319,245.723466 518.240028,246.009516 517.79,246.02 L514.67,246.02 C514.438645,246.05209 514.208181,245.955596 514.068706,245.768241 C513.929231,245.580887 513.902897,245.332429 514,245.12 Z M529.47,237.5 L525.89,229.63 L525.78,229.63 L522.27,237.5 L529.47,237.5 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M539.56,221.68 C539.570461,221.308866 539.868866,221.010461 540.24,221 L543.64,221 C544.015554,221 544.32,221.304446 544.32,221.68 L544.32,236.32 C544.236086,238.233992 545.209392,240.039623 546.854384,241.021667 C548.499375,242.00371 550.550625,242.00371 552.195616,241.021667 C553.840608,240.039623 554.813914,238.233992 554.73,236.32 L554.73,221.68 C554.73,221.304446 555.034446,221 555.41,221 L558.81,221 C559.181134,221.010461 559.479539,221.308866 559.49,221.68 L559.49,236.57 C559.05542,241.750582 554.723777,245.734072 549.525,245.734072 C544.326223,245.734072 539.99458,241.750582 539.56,236.57 L539.56,221.68 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M564.93,221.68 C564.927275,221.498831 564.998043,221.324283 565.126163,221.196163 C565.254283,221.068043 565.428831,220.997275 565.61,221 L575.84,221 C580.118017,220.972262 583.611499,224.412066 583.65,228.69 C583.552568,231.967842 581.445167,234.846632 578.35,235.93 L583.25,245.02 C583.36328,245.232337 583.355886,245.488735 583.230558,245.69419 C583.10523,245.899646 582.880638,246.023553 582.64,246.02 L578.89,246.02 C578.648304,246.034873 578.420695,245.905371 578.31,245.69 L573.55,236.21 L569.55,236.21 L569.55,245.34 C569.53471,245.709035 569.239035,246.00471 568.87,246.02 L565.58,246.02 C565.204446,246.02 564.9,245.715554 564.9,245.34 L564.93,221.68 Z M575.45,232.42 C577.425049,232.36573 578.996173,230.745785 578.99,228.77 C578.946712,226.842926 577.377532,225.300343 575.45,225.29 L569.61,225.29 L569.61,232.42 L575.45,232.42 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M589.47,221.68 C589.48529,221.310965 589.780965,221.01529 590.15,221 L593.48,221 C593.851134,221.010461 594.149539,221.308866 594.16,221.68 L594.16,245.38 C594.14471,245.749035 593.849035,246.04471 593.48,246.06 L590.15,246.06 C589.782997,246.040119 589.489881,245.747003 589.47,245.38 L589.47,221.68 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M604.75,225.29 L599.28,225.29 C599.098831,225.292725 598.924283,225.221957 598.796163,225.093837 C598.668043,224.965717 598.597275,224.791169 598.6,224.61 L598.6,221.68 C598.597275,221.498831 598.668043,221.324283 598.796163,221.196163 C598.924283,221.068043 599.098831,220.997275 599.28,221 L614.92,221 C615.295554,221 615.6,221.304446 615.6,221.68 L615.6,224.61 C615.6,224.985554 615.295554,225.29 614.92,225.29 L609.44,225.29 L609.44,245.38 C609.42471,245.749035 609.129035,246.04471 608.76,246.06 L605.43,246.06 C605.062997,246.040119 604.769881,245.747003 604.75,245.38 L604.75,225.29 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M620,221.68 C620.010461,221.308866 620.308866,221.010461 620.68,221 L624,221 C624.371134,221.010461 624.669539,221.308866 624.68,221.68 L624.68,245.38 C624.66471,245.749035 624.369035,246.04471 624,246.06 L620.67,246.06 C620.300965,246.04471 620.00529,245.749035 619.99,245.38 L620,221.68 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M631.59,221.68 C631.600461,221.308866 631.898866,221.010461 632.27,221 L635.67,221 C636.045554,221 636.35,221.304446 636.35,221.68 L636.35,236.32 C636.35,239.197404 638.682596,241.53 641.56,241.53 C644.437404,241.53 646.77,239.197404 646.77,236.32 L646.77,221.68 C646.767275,221.498831 646.838043,221.324283 646.966163,221.196163 C647.094283,221.068043 647.268831,220.997275 647.45,221 L650.85,221 C651.221134,221.010461 651.519539,221.308866 651.53,221.68 L651.53,236.57 C651.125759,241.776976 646.782644,245.795984 641.56,245.795984 C636.337356,245.795984 631.994241,241.776976 631.59,236.57 L631.59,221.68 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M656.92,242.55 L658.21,240.33 C658.328469,240.123231 658.530097,239.977357 658.763549,239.929519 C658.997001,239.88168 659.239753,239.936492 659.43,240.08 C659.61,240.18 662.51,242.3 664.83,242.3 C665.629507,242.371891 666.424476,242.120368 667.037129,241.601681 C667.649781,241.082994 668.029007,240.340412 668.09,239.54 C668.09,237.71 666.55,236.46 663.55,235.25 C660.18,233.89 656.82,231.74 656.82,227.51 C656.82,224.33 659.18,220.64 664.82,220.64 C667.398441,220.67342 669.904546,221.497154 672,223 C672.372976,223.274705 672.465301,223.793483 672.21,224.18 L670.85,226.18 C670.742227,226.403682 670.549485,226.574981 670.314697,226.655748 C670.07991,226.736515 669.822574,226.720043 669.6,226.61 C669.32,226.43 666.6,224.61 664.6,224.61 C662.6,224.61 661.45,225.97 661.45,227.12 C661.45,228.8 662.77,229.95 665.67,231.12 C669.14,232.51 673.15,234.59 673.15,239.21 C673.15,242.89 669.97,246.29 664.92,246.29 C662.037116,246.376488 659.226186,245.381248 657.04,243.5 C656.78,243.3 656.6,243.12 656.92,242.55 Z" id="Shape" fill="#00548B"></path>
+                    <rect id="Rectangle-path" fill="#00548B" x="0.03" y="86.83" width="92.32" height="66.83"></rect>
+                    <path d="M118.43,179.52 C118.43,197.32 118.43,228.83 118.43,246.63 L150.93,246.63 C216.82,246.63 230.61,204.68 230.61,167.87 L230.61,166 C219.69,174.66 208.34,179.51 190.61,179.51 L118.43,179.52 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M118.43,86.84 L118.43,153.38 L190.63,153.38 C211.76,153.38 228.89,138.48 228.89,120.11 C228.89,101.74 211.76,86.84 190.63,86.84 L118.43,86.84 Z" id="Shape1" fill="#00A3CC"></path>
+                  </g>
+                </g>
+              </g>
+            </svg>
+            </a>		</div>
+				</div>
+						</div>
+					</div>
+		</div>
+				<div class="elementor-column elementor-col-33 elementor-top-column elementor-element elementor-element-306fc23 ot-column-items-center ot-flex-column-vertical" data-id="306fc23" data-element_type="column">
+			<div class="elementor-column-wrap elementor-element-populated">
+							<div class="elementor-widget-wrap">
+						<div class="elementor-element elementor-element-303faf5 elementor-widget elementor-widget-text-editor" data-id="303faf5" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<p><strong>EDB E-Newsletter</strong></p>					</div>
+						</div>
+				</div>
+						</div>
+					</div>
+		</div>
+				<div class="elementor-column elementor-col-33 elementor-top-column elementor-element elementor-element-724268f ot-column-items-center ot-flex-column-vertical" data-id="724268f" data-element_type="column">
+			<div class="elementor-column-wrap elementor-element-populated">
+							<div class="elementor-widget-wrap">
+						<div class="elementor-element elementor-element-adf53c5 elementor-widget elementor-widget-text-editor" data-id="adf53c5" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<p><strong>Issue : <span lang="EN-US">January 2021</span></strong></p>					</div>
+						</div>
+				</div>
+				<section class="elementor-section elementor-inner-section elementor-element elementor-element-1f5e531 elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="1f5e531" data-element_type="section" data-settings="{&quot;_ha_eqh_enable&quot;:false}">
+						<div class="elementor-container elementor-column-gap-default">
+							<div class="elementor-row">
+					<div class="elementor-column elementor-col-50 elementor-inner-column elementor-element elementor-element-d8fbce6 ot-column-items-center ot-flex-column-vertical" data-id="d8fbce6" data-element_type="column">
+			<div class="elementor-column-wrap elementor-element-populated">
+							<div class="elementor-widget-wrap">
+						<div class="elementor-element elementor-element-c4c6d14 elementor-widget elementor-widget-html" data-id="c4c6d14" data-element_type="widget" data-widget_type="html.default">
+				<div class="elementor-widget-container">
+			<div style="text-align:center">
+<button class="print-btn" onclick="  window.print();
+           return false;">
+    <img src="https://edb-newsletter.diizz.com/wp-content/uploads/2021/02/icon-print-icon-2.png" style="width:30%">
+</button>
+</div>		</div>
+				</div>
+						</div>
+					</div>
+		</div>
+				<div class="elementor-column elementor-col-50 elementor-inner-column elementor-element elementor-element-5a07493 ot-column-items-center ot-flex-column-vertical" data-id="5a07493" data-element_type="column">
+			<div class="elementor-column-wrap elementor-element-populated">
+							<div class="elementor-widget-wrap">
+						<div class="elementor-element elementor-element-b0ef626 elementor-widget elementor-widget-imenu" data-id="b0ef626" data-element_type="widget" data-widget_type="imenu.default">
+				<div class="elementor-widget-container">
+						<nav id="site-navigation" class="main-navigation">			
+				<ul id="primary-menu" class="menu"><li id="menu-item-1813" class="trp-language-switcher-container menu-item menu-item-type-post_type menu-item-object-language_switcher menu-item-1813"><a href="https://news.edbmauritius.org/2021-january-the-new-premium-visa/"><span data-no-translation><span class="trp-ls-language-name">EN</span></span></a></li>
+<li id="menu-item-1812" class="trp-language-switcher-container menu-item menu-item-type-post_type menu-item-object-language_switcher menu-item-1812"><a href="https://news.edbmauritius.org/fr/2021-january-the-new-premium-visa/"><span data-no-translation><span class="trp-ls-language-name">FR</span></span></a></li>
+</ul>			</nav>
+	    		</div>
+				</div>
+						</div>
+					</div>
+		</div>
+								</div>
+					</div>
+		</section>
+						</div>
+					</div>
+		</div>
+								</div>
+					</div>
+		</section>
+						</div>
+						</div>
+					</div>
+		</div>    <!-- #header-desktop-close -->
+
+    <!-- #header-mobile-open -->
+    <div class="header-mobile">		<div data-elementor-type="wp-post" data-elementor-id="77" class="elementor elementor-77" data-elementor-settings="[]">
+						<div class="elementor-inner">
+							<div class="elementor-section-wrap">
+							<section class="elementor-section elementor-top-section elementor-element elementor-element-e7c1045 elementor-section-content-middle elementor-section-stretched elementor-hidden-desktop elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="e7c1045" data-element_type="section" data-settings="{&quot;stretch_section&quot;:&quot;section-stretched&quot;,&quot;background_background&quot;:&quot;gradient&quot;,&quot;_ha_eqh_enable&quot;:false}">
+						<div class="elementor-container elementor-column-gap-default">
+							<div class="elementor-row">
+					<div class="elementor-column elementor-col-50 elementor-top-column elementor-element elementor-element-026b8ab ot-flex-column-vertical" data-id="026b8ab" data-element_type="column">
+			<div class="elementor-column-wrap elementor-element-populated">
+							<div class="elementor-widget-wrap">
+						<div class="elementor-element elementor-element-1f632ff elementor-widget elementor-widget-html" data-id="1f632ff" data-element_type="widget" data-widget_type="html.default">
+				<div class="elementor-widget-container">
+			<a href="https://news.edbmauritius.org/2021-january/" ><svg class="footer-logo" width="100px" height="50px" viewBox="0 0 682 247" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="edb-logo">
+              <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+              <defs></defs>
+              <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                <g id="Group" fill-rule="nonzero">
+                  <g id="logo-EDB-01">
+                    <rect id="Rectangle-path1" fill="#80BA27" x="0.03" y="179.64" width="92.32" height="66.83"></rect>
+                    <path d="M178.89,60.76 C198,60.76 213.5,47.29 213.5,30.67 C213.5,14.05 198,0.57 178.89,0.57 L118.43,0.57 L118.43,60.76 L178.89,60.76 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M273.36,88.81 C273.357305,88.5094872 273.475492,88.2204986 273.687995,88.0079954 C273.900499,87.7954922 274.189487,87.6773047 274.49,87.68 L299.21,87.68 C299.834082,87.68 300.34,88.1859182 300.34,88.81 L300.34,95.32 C300.34,95.9440818 299.834082,96.45 299.21,96.45 L282.67,96.45 L282.67,103.85 L296.28,103.85 C296.899044,103.870981 297.394473,104.370795 297.41,104.99 L297.41,111.5 C297.41,112.124082 296.904082,112.63 296.28,112.63 L282.67,112.63 L282.67,120.69 L299.21,120.69 C299.834082,120.69 300.34,121.195918 300.34,121.82 L300.34,128.33 C300.34,128.954082 299.834082,129.46 299.21,129.46 L274.49,129.46 C274.189487,129.462695 273.900499,129.344508 273.687995,129.132005 C273.475492,128.919501 273.357305,128.630513 273.36,128.33 L273.36,88.81 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M325.66,87.08 C331.022925,86.9182118 336.225964,88.9179949 340.1,92.63 C340.351406,92.8300857 340.502761,93.1300913 340.514298,93.4511929 C340.525834,93.7722945 340.396399,94.0823883 340.16,94.3 L335.51,99.14 C335.312507,99.3415659 335.042192,99.4551531 334.76,99.4551531 C334.477808,99.4551531 334.207493,99.3415659 334.01,99.14 C331.783821,97.1766924 328.91824,96.0923225 325.95,96.09 C319.21,96.09 314.25,101.71 314.25,108.39 C314.172112,111.563622 315.373018,114.63538 317.582722,116.914667 C319.792427,119.193954 322.825489,120.489488 326,120.51 C328.918147,120.506256 331.744964,119.492136 334,117.64 C334.46509,117.277012 335.124165,117.302361 335.56,117.7 L340.21,122.7 C340.61157,123.170665 340.585488,123.87053 340.15,124.31 C336.27083,128.078949 331.058261,130.160381 325.65,130.1 C313.775878,130.1 304.15,120.474122 304.15,108.6 C304.15,96.7258779 313.775878,87.1 325.65,87.1 L325.66,87.08 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M363.15,87.08 C375.018531,87.0469094 384.666711,96.6414134 384.699832,108.509945 C384.732954,120.378476 375.138475,130.02668 363.269944,130.059833 C351.401413,130.092985 341.753183,120.498531 341.72,108.63 C341.693411,102.927264 343.938826,97.4486868 347.960038,93.4049568 C351.981251,89.3612268 357.447205,87.0852553 363.15,87.08 Z M363.15,120.51 C367.990113,120.534262 372.366029,117.634105 374.229485,113.167023 C376.092941,108.699941 375.075225,103.549815 371.652705,100.127295 C368.230185,96.704775 363.080059,95.6870587 358.612977,97.5505149 C354.145895,99.413971 351.245738,103.789887 351.27,108.63 C351.33502,115.164021 356.615979,120.44498 363.15,120.51 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M389.42,88.15 C389.452106,87.5455803 389.95476,87.0737915 390.56,87.08 L392.05,87.08 L415.87,110 L415.93,110 L415.93,88.81 C415.93,88.1859182 416.435918,87.68 417.06,87.68 L424.23,87.68 C424.845304,87.7006998 425.3393,88.1946963 425.36,88.81 L425.36,129 C425.33309,129.602842 424.833412,130.075988 424.23,130.07 L423.23,130.07 C422.952867,130.03367 422.688664,129.930733 422.46,129.77 L398.88,106.07 L398.82,106.07 L398.82,128.34 C398.820012,128.641435 398.699587,128.930381 398.485503,129.142587 C398.271419,129.354793 397.981424,129.472668 397.68,129.47 L390.58,129.47 C389.960795,129.454473 389.460981,128.959044 389.44,128.34 L389.42,88.15 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M452.83,87.08 C464.698531,87.0469094 474.346711,96.6414134 474.379832,108.509945 C474.412954,120.378476 464.818475,130.02668 452.949944,130.059833 C441.081413,130.092985 431.433183,120.498531 431.4,108.63 C431.373411,102.927264 433.618826,97.4486868 437.640038,93.4049568 C441.661251,89.3612268 447.127205,87.0852553 452.83,87.08 Z M452.83,120.51 C457.674489,120.554573 462.065696,117.667408 463.94496,113.202049 C465.824224,108.73669 464.818977,103.578406 461.400492,100.145474 C457.982008,96.7125408 452.82801,95.6855469 448.354765,97.5459611 C443.881519,99.4063754 440.97586,103.785366 441,108.63 C441.064502,115.144817 446.315513,120.418022 452.83,120.51 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M483.28,88 C483.373107,87.4694918 483.821949,87.074677 484.36,87.05 L485.31,87.05 C485.718399,87.0839273 486.087876,87.3056139 486.31,87.65 L500.15,113.44 L500.27,113.44 L514.12,87.65 C514.342124,87.3056139 514.711601,87.0839273 515.12,87.05 L516.12,87.05 C516.658051,87.074677 517.106893,87.4694918 517.2,88 L523.94,128.12 C524.008989,128.451926 523.919606,128.797055 523.698169,129.053764 C523.476733,129.310474 523.148456,129.449535 522.81,129.43 L515.81,129.43 C515.257628,129.410863 514.788431,129.019866 514.67,128.48 L511.98,110.03 L511.87,110.03 L501.87,129.37 C501.652404,129.72873 501.285391,129.970959 500.87,130.03 L499.7,130.03 C499.27911,129.985882 498.906037,129.739653 498.7,129.37 L488.61,110.03 L488.49,110.03 L485.87,128.48 C485.76874,129.0301 485.289342,129.429598 484.73,129.43 L477.73,129.43 C477.391065,129.448687 477.062486,129.309845 476.839649,129.053778 C476.616813,128.797712 476.524681,128.453106 476.59,128.12 L483.28,88 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M530.39,88.81 C530.4107,88.1946963 530.904696,87.7006998 531.52,87.68 L538.69,87.68 C539.305304,87.7006998 539.7993,88.1946963 539.82,88.81 L539.82,128.33 C539.7993,128.945304 539.305304,129.4393 538.69,129.46 L531.52,129.46 C530.904696,129.4393 530.4107,128.945304 530.39,128.33 L530.39,88.81 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M567.4,87.08 C572.765204,86.9222785 577.969828,88.9212866 581.85,92.63 C582.101406,92.8300857 582.252761,93.1300913 582.264298,93.4511929 C582.275834,93.7722945 582.146399,94.0823883 581.91,94.3 L577.25,99.14 C577.060303,99.3518604 576.789376,99.4729355 576.505,99.4729355 C576.220624,99.4729355 575.949697,99.3518604 575.76,99.14 C573.533821,97.1766924 570.66824,96.0923225 567.7,96.09 C560.95,96.09 556,101.71 556,108.39 C555.922086,111.565345 557.124352,114.638633 559.336225,116.918217 C561.548099,119.197801 564.583749,120.492161 567.76,120.51 C570.678147,120.506256 573.504964,119.492136 575.76,117.64 C576.221898,117.278506 576.877429,117.303882 577.31,117.7 L581.97,122.7 C582.37157,123.170665 582.345488,123.87053 581.91,124.31 C578.027759,128.080472 572.811508,130.16194 567.4,130.1 C555.525878,130.1 545.9,120.474122 545.9,108.6 C545.9,96.7258779 555.525878,87.1 567.4,87.1 L567.4,87.08 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M273.36,147.13 C273.348553,146.522731 273.823224,146.017007 274.43,145.99 L289,145.99 C296.574034,145.824296 303.644732,149.770222 307.480393,156.303304 C311.316053,162.836386 311.316053,170.933614 307.480393,177.466696 C303.644732,183.999778 296.574034,187.945704 289,187.78 L274.43,187.78 C273.827158,187.75309 273.354012,187.253412 273.36,186.65 L273.36,147.13 Z M288.36,178.95 C295.11,178.95 300,173.63 300,166.83 C300,160.03 295.11,154.77 288.36,154.77 L282.63,154.77 L282.63,179 L288.36,178.95 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M316.05,147.13 C316.047332,146.828576 316.165207,146.538581 316.377413,146.324497 C316.589619,146.110413 316.878565,145.989988 317.18,145.99 L341.9,145.99 C342.525696,145.995489 343.030024,146.50428 343.03,147.13 L343.03,153.63 C343.030024,154.25572 342.525696,154.764511 341.9,154.77 L325.36,154.77 L325.36,162.17 L339,162.17 C339.619044,162.190981 340.114473,162.690795 340.13,163.31 L340.13,169.81 C340.146481,170.119948 340.034744,170.42303 339.821015,170.648107 C339.607287,170.873184 339.310386,171.000438 339,171 L325.36,171 L325.36,179 L341.9,179 C342.524082,179 343.03,179.505918 343.03,180.13 L343.03,186.64 C343.03,187.264082 342.524082,187.77 341.9,187.77 L317.18,187.77 C316.555918,187.77 316.05,187.264082 316.05,186.64 L316.05,147.13 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M344.47,147.55 C344.287697,147.211036 344.30345,146.799889 344.511155,146.475869 C344.718861,146.151848 345.085879,145.965872 345.47,145.99 L353.41,145.99 C353.838541,146.011816 354.221462,146.264544 354.41,146.65 L364.26,168.44 L364.61,168.44 L374.46,146.65 C374.648538,146.264544 375.031459,146.011816 375.46,145.99 L383.4,145.99 C383.784121,145.965872 384.151139,146.151848 384.358845,146.475869 C384.56655,146.799889 384.582303,147.211036 384.4,147.55 L365.66,187.72 C365.478474,188.111556 365.091393,188.36703 364.66,188.38 L364.07,188.38 C363.638607,188.36703 363.251526,188.111556 363.07,187.72 L344.47,147.55 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M388.17,147.13 C388.175431,146.508182 388.678182,146.005431 389.3,146 L414,146 C414.301435,145.999988 414.590381,146.120413 414.802587,146.334497 C415.014793,146.548581 415.132668,146.838576 415.13,147.14 L415.13,153.64 C415.132668,153.941424 415.014793,154.231419 414.802587,154.445503 C414.590381,154.659587 414.301435,154.780012 414,154.78 L397.48,154.78 L397.48,162.18 L411.09,162.18 C411.710823,162.200711 412.209289,162.699177 412.23,163.32 L412.23,169.82 C412.23,170.449605 411.719605,170.96 411.09,170.96 L397.48,170.96 L397.48,179 L414,179 C414.300513,178.997305 414.589501,179.115492 414.802005,179.327995 C415.014508,179.540499 415.132695,179.829487 415.13,180.13 L415.13,186.64 C415.13,187.264082 414.624082,187.77 414,187.77 L389.3,187.77 C388.675918,187.77 388.17,187.264082 388.17,186.64 L388.17,147.13 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M422,147.13 C422.00498,146.519572 422.489927,146.021399 423.1,146 L430.2,146 C430.820823,146.020711 431.319289,146.519177 431.34,147.14 L431.34,179 L445.54,179 C445.841424,178.997332 446.131419,179.115207 446.345503,179.327413 C446.559587,179.539619 446.680012,179.828565 446.68,180.13 L446.68,186.64 C446.674511,187.265696 446.16572,187.770024 445.54,187.77 L423.1,187.77 C422.47428,187.770024 421.965489,187.265696 421.96,186.64 L422,147.13 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M468.23,145.4 C480.091998,145.367037 489.737352,154.951442 489.779582,166.813411 C489.821812,178.675379 480.244944,188.328218 468.383013,188.379715 C456.521081,188.431211 446.860764,178.861888 446.8,167 C446.760057,161.288626 448.999568,155.797165 453.022231,151.742591 C457.044894,147.688017 462.518489,145.405186 468.23,145.4 Z M468.23,178.83 C473.074634,178.85414 477.453625,175.948481 479.314039,171.475235 C481.174453,167.00199 480.147459,161.847992 476.714526,158.429508 C473.281594,155.011023 468.12331,154.005776 463.657951,155.88504 C459.192592,157.764304 456.305427,162.155511 456.35,167 C456.441978,173.514487 461.715183,178.765498 468.23,178.83 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M494.56,147.13 C494.565489,146.504304 495.07428,145.999976 495.7,146 L510.09,146 C514.933402,145.856782 519.472528,148.355059 521.942782,152.523619 C524.413037,156.692179 524.424711,161.873387 521.973266,166.053036 C519.52182,170.232686 514.993998,172.751391 510.15,172.63 L503.88,172.63 L503.88,186.63 C503.854173,187.246916 503.35712,187.73961 502.74,187.76 L495.74,187.76 C495.11428,187.760024 494.605489,187.255696 494.6,186.63 L494.56,147.13 Z M509.56,163.9 C510.81162,163.908049 512.014309,163.414404 512.899357,162.529357 C513.784404,161.644309 514.278049,160.44162 514.27,159.19 C514.236117,157.97773 513.71968,156.829149 512.835348,155.999267 C511.951017,155.169385 510.771976,154.726881 509.56,154.77 L503.89,154.77 L503.89,163.9 L509.56,163.9 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M530.86,146.35 C530.927756,145.797788 531.384215,145.37514 531.94,145.35 L532.89,145.35 C533.295653,145.384544 533.663602,145.601634 533.89,145.94 L547.74,171.73 L547.86,171.73 L561.73,146 C561.956398,145.661634 562.324347,145.444544 562.73,145.41 L563.73,145.41 C564.283643,145.435818 564.736839,145.859366 564.8,146.41 L571.55,186.53 C571.615319,186.863106 571.523187,187.207712 571.300351,187.463778 C571.077514,187.719845 570.748935,187.858687 570.41,187.84 L563.41,187.84 C562.861411,187.816411 562.397481,187.426381 562.28,186.89 L559.59,168.44 L559.47,168.44 L549.47,187.78 C549.252404,188.13873 548.885391,188.380959 548.47,188.44 L547.39,188.44 C546.968519,188.397536 546.594748,188.150847 546.39,187.78 L536.3,168.44 L536.18,168.44 L533.55,186.89 C533.445866,187.434327 532.974124,187.830924 532.42,187.84 L525.42,187.84 C525.081544,187.859535 524.753267,187.720474 524.531831,187.463764 C524.310394,187.207055 524.221011,186.861926 524.29,186.53 L530.86,146.35 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M578,147.13 C578,146.500395 578.510395,145.99 579.14,145.99 L603.85,145.99 C604.479605,145.99 604.99,146.500395 604.99,147.13 L604.99,153.63 C604.99,154.259605 604.479605,154.77 603.85,154.77 L587.29,154.77 L587.29,162.17 L600.9,162.17 C601.516916,162.195827 602.00961,162.69288 602.03,163.31 L602.03,169.81 C602.043583,170.119185 601.930878,170.420605 601.717771,170.645027 C601.504665,170.869448 601.209473,170.997583 600.9,171 L587.29,171 L587.29,179 L603.82,179 C604.121424,178.997332 604.411419,179.115207 604.625503,179.327413 C604.839587,179.539619 604.960012,179.828565 604.96,180.13 L604.96,186.64 C604.954511,187.265696 604.44572,187.770024 603.82,187.77 L579.11,187.77 C578.48428,187.770024 577.975489,187.265696 577.97,186.64 L578,147.13 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M611.71,146.47 C611.731718,145.864799 612.234515,145.388699 612.84,145.4 L614.33,145.4 L638.15,168.32 L638.21,168.32 L638.21,147.13 C638.21,146.500395 638.720395,145.99 639.35,145.99 L646.51,145.99 C647.129044,146.010981 647.624473,146.510795 647.64,147.13 L647.64,187.3 C647.618343,187.906783 647.117141,188.385808 646.51,188.38 L645.51,188.38 C645.229781,188.343693 644.962327,188.240826 644.73,188.08 L621.15,164.38 L621.09,164.38 L621.09,186.65 C621.084511,187.275696 620.57572,187.780024 619.95,187.78 L612.85,187.78 C612.234696,187.7593 611.7407,187.265304 611.72,186.65 L611.71,146.47 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M662.1,154.77 L653.56,154.77 C653.258565,154.770012 652.969619,154.649587 652.757413,154.435503 C652.545207,154.221419 652.427332,153.931424 652.43,153.63 L652.43,147.13 C652.427332,146.828576 652.545207,146.538581 652.757413,146.324497 C652.969619,146.110413 653.258565,145.989988 653.56,145.99 L680.07,145.99 C680.695696,145.995489 681.200024,146.50428 681.2,147.13 L681.2,153.63 C681.200024,154.25572 680.695696,154.764511 680.07,154.77 L671.53,154.77 L671.53,186.65 C671.504173,187.266916 671.00712,187.75961 670.39,187.78 L663.23,187.78 C662.614696,187.7593 662.1207,187.265304 662.1,186.65 L662.1,154.77 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M273.36,205.45 C273.357332,205.148576 273.475207,204.858581 273.687413,204.644497 C273.899619,204.430413 274.188565,204.309988 274.49,204.31 L288.4,204.31 C295.45,204.31 301.24,209.15 301.24,215.41 C301.24,220.01 297.12,223.35 294.31,224.85 C297.47,226.16 302.31,229.08 302.31,234.58 C302.31,241.26 296.4,246.1 289.31,246.1 L274.49,246.1 C274.188565,246.100012 273.899619,245.979587 273.687413,245.765503 C273.475207,245.551419 273.357332,245.261424 273.36,244.96 L273.36,205.45 Z M287.36,221.27 C289.693155,221.220805 291.552431,219.303566 291.53,216.97 C291.547524,215.868636 291.1101,214.80879 290.32088,214.040389 C289.53166,213.271988 288.460502,212.863047 287.36,212.91 L282.7,212.91 L282.7,221.27 L287.36,221.27 Z M288.13,237.56 C289.278396,237.552071 290.376604,237.088254 291.183016,236.270589 C291.989429,235.452925 292.437984,234.348396 292.43,233.2 C292.43,230.82 289.86,229.03 287.54,229.03 L282.7,229.03 L282.7,237.56 L288.13,237.56 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M327.09,203.71 C335.787697,203.681705 343.645637,208.896623 346.998392,216.922192 C350.351147,224.947761 348.538162,234.202797 342.405124,240.370177 C336.272087,246.537557 327.027319,248.402194 318.983154,245.094306 C310.938988,241.786417 305.680273,233.957719 305.66,225.26 C305.633411,219.557264 307.878826,214.078687 311.900038,210.034957 C315.921251,205.991227 321.387205,203.715255 327.09,203.71 Z M327.09,237.15 C331.929207,237.174276 336.3045,234.275212 338.168555,229.809362 C340.03261,225.343513 339.016741,220.194166 335.596302,216.770848 C332.175863,213.347529 327.027373,212.327328 322.559957,214.187625 C318.09254,216.047922 315.189796,220.420774 315.21,225.26 C315.269609,231.797926 320.552126,237.08489 327.09,237.15 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M348.89,244.55 L367.57,204.37 C367.764904,203.990195 368.144152,203.739891 368.57,203.71 L369.16,203.71 C369.585848,203.739891 369.965096,203.990195 370.16,204.37 L388.84,244.55 C389.024222,244.887629 389.009102,245.298962 388.800591,245.622155 C388.592079,245.945349 388.223548,246.128674 387.84,246.1 L381.21,246.1 C380.14,246.1 379.66,245.74 379.12,244.61 L377,239.89 L360.76,239.89 L358.62,244.67 C358.277804,245.553332 357.416944,246.125905 356.47,246.1 L349.9,246.1 C349.501584,246.175708 349.096895,246.003293 348.875493,245.663517 C348.654091,245.323741 348.659821,244.883893 348.89,244.55 Z M373.42,231.77 L368.88,221.92 L368.82,221.92 L364.35,231.77 L373.42,231.77 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M392.59,205.45 C392.589976,204.82428 393.094304,204.315489 393.72,204.31 L411.57,204.31 C418.71083,204.309789 424.515071,210.069381 424.57,217.21 C424.57,222.7 420.93,227.11 415.73,229.21 L423.91,244.37 C424.132725,244.724777 424.140916,245.173653 423.931282,245.536319 C423.721649,245.898985 423.328592,246.115927 422.91,246.1 L415,246.1 C414.592296,246.119472 414.20733,245.91159 414,245.56 L406.06,229.74 L402,229.74 L402,245 C401.97961,245.61712 401.486916,246.114173 400.87,246.14 L393.76,246.14 C393.134304,246.134511 392.629976,245.62572 392.63,245 L392.59,205.45 Z M410.8,222.16 C413.339536,222.021952 415.32844,219.923285 415.33,217.38 C415.308275,214.887204 413.292796,212.871725 410.8,212.85 L402,212.85 L402,222.16 L410.8,222.16 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M431.4,205.45 C431.393791,204.84476 431.86558,204.342106 432.47,204.31 L447,204.31 C454.574034,204.144296 461.644732,208.090222 465.480393,214.623304 C469.316053,221.156386 469.316053,229.253614 465.480393,235.786696 C461.644732,242.319778 454.574034,246.265704 447,246.1 L432.47,246.1 C431.880874,246.068862 431.41484,245.589762 431.4,245 L431.4,205.45 Z M446.4,237.26 C453.15,237.26 458.04,231.95 458.04,225.15 C458.04,218.35 453.15,213.09 446.4,213.09 L440.67,213.09 L440.67,237.26 L446.4,237.26 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M487.21,221.18 C487.241696,220.85628 487.525562,220.616767 487.85,220.64 L488.42,220.64 C488.6766,220.628945 488.915649,220.770023 489.03,221 L496.91,237.89 L497.01,237.89 L504.89,221 C504.995705,220.762148 505.240686,220.617569 505.5,220.64 L506.07,220.64 C506.394438,220.616767 506.678304,220.85628 506.71,221.18 L510.94,245.23 C511.008231,245.431272 510.970387,245.653378 510.839353,245.820698 C510.70832,245.988018 510.501759,246.077997 510.29,246.06 L507,246.06 C506.683777,246.03716 506.413878,245.822829 506.32,245.52 L504.24,232 L504.14,232 L497.87,246 C497.77414,246.249661 497.52684,246.407771 497.26,246.39 L496.62,246.39 C496.352788,246.399902 496.106775,246.245152 496,246 L489.68,232 L489.57,232 L487.49,245.57 C487.422756,245.873672 487.160657,246.094818 486.85,246.11 L483.63,246.11 C483.417643,246.123748 483.211686,246.034261 483.076824,245.869651 C482.941962,245.70504 482.894743,245.485502 482.95,245.28 L487.21,221.18 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M514,245.12 L525.14,221 C525.233922,220.752109 525.475054,220.591355 525.74,220.6 L526.1,220.6 C526.369439,220.58368 526.617566,220.746386 526.71,221 L537.71,245.08 C537.819828,245.285537 537.809254,245.534527 537.682397,245.730013 C537.555539,245.925499 537.33245,246.036579 537.1,246.02 L534,246.02 C533.540829,246.038276 533.128306,245.741259 533,245.3 L531.24,241.43 L520.54,241.43 L518.79,245.3 C518.637319,245.723466 518.240028,246.009516 517.79,246.02 L514.67,246.02 C514.438645,246.05209 514.208181,245.955596 514.068706,245.768241 C513.929231,245.580887 513.902897,245.332429 514,245.12 Z M529.47,237.5 L525.89,229.63 L525.78,229.63 L522.27,237.5 L529.47,237.5 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M539.56,221.68 C539.570461,221.308866 539.868866,221.010461 540.24,221 L543.64,221 C544.015554,221 544.32,221.304446 544.32,221.68 L544.32,236.32 C544.236086,238.233992 545.209392,240.039623 546.854384,241.021667 C548.499375,242.00371 550.550625,242.00371 552.195616,241.021667 C553.840608,240.039623 554.813914,238.233992 554.73,236.32 L554.73,221.68 C554.73,221.304446 555.034446,221 555.41,221 L558.81,221 C559.181134,221.010461 559.479539,221.308866 559.49,221.68 L559.49,236.57 C559.05542,241.750582 554.723777,245.734072 549.525,245.734072 C544.326223,245.734072 539.99458,241.750582 539.56,236.57 L539.56,221.68 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M564.93,221.68 C564.927275,221.498831 564.998043,221.324283 565.126163,221.196163 C565.254283,221.068043 565.428831,220.997275 565.61,221 L575.84,221 C580.118017,220.972262 583.611499,224.412066 583.65,228.69 C583.552568,231.967842 581.445167,234.846632 578.35,235.93 L583.25,245.02 C583.36328,245.232337 583.355886,245.488735 583.230558,245.69419 C583.10523,245.899646 582.880638,246.023553 582.64,246.02 L578.89,246.02 C578.648304,246.034873 578.420695,245.905371 578.31,245.69 L573.55,236.21 L569.55,236.21 L569.55,245.34 C569.53471,245.709035 569.239035,246.00471 568.87,246.02 L565.58,246.02 C565.204446,246.02 564.9,245.715554 564.9,245.34 L564.93,221.68 Z M575.45,232.42 C577.425049,232.36573 578.996173,230.745785 578.99,228.77 C578.946712,226.842926 577.377532,225.300343 575.45,225.29 L569.61,225.29 L569.61,232.42 L575.45,232.42 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M589.47,221.68 C589.48529,221.310965 589.780965,221.01529 590.15,221 L593.48,221 C593.851134,221.010461 594.149539,221.308866 594.16,221.68 L594.16,245.38 C594.14471,245.749035 593.849035,246.04471 593.48,246.06 L590.15,246.06 C589.782997,246.040119 589.489881,245.747003 589.47,245.38 L589.47,221.68 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M604.75,225.29 L599.28,225.29 C599.098831,225.292725 598.924283,225.221957 598.796163,225.093837 C598.668043,224.965717 598.597275,224.791169 598.6,224.61 L598.6,221.68 C598.597275,221.498831 598.668043,221.324283 598.796163,221.196163 C598.924283,221.068043 599.098831,220.997275 599.28,221 L614.92,221 C615.295554,221 615.6,221.304446 615.6,221.68 L615.6,224.61 C615.6,224.985554 615.295554,225.29 614.92,225.29 L609.44,225.29 L609.44,245.38 C609.42471,245.749035 609.129035,246.04471 608.76,246.06 L605.43,246.06 C605.062997,246.040119 604.769881,245.747003 604.75,245.38 L604.75,225.29 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M620,221.68 C620.010461,221.308866 620.308866,221.010461 620.68,221 L624,221 C624.371134,221.010461 624.669539,221.308866 624.68,221.68 L624.68,245.38 C624.66471,245.749035 624.369035,246.04471 624,246.06 L620.67,246.06 C620.300965,246.04471 620.00529,245.749035 619.99,245.38 L620,221.68 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M631.59,221.68 C631.600461,221.308866 631.898866,221.010461 632.27,221 L635.67,221 C636.045554,221 636.35,221.304446 636.35,221.68 L636.35,236.32 C636.35,239.197404 638.682596,241.53 641.56,241.53 C644.437404,241.53 646.77,239.197404 646.77,236.32 L646.77,221.68 C646.767275,221.498831 646.838043,221.324283 646.966163,221.196163 C647.094283,221.068043 647.268831,220.997275 647.45,221 L650.85,221 C651.221134,221.010461 651.519539,221.308866 651.53,221.68 L651.53,236.57 C651.125759,241.776976 646.782644,245.795984 641.56,245.795984 C636.337356,245.795984 631.994241,241.776976 631.59,236.57 L631.59,221.68 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M656.92,242.55 L658.21,240.33 C658.328469,240.123231 658.530097,239.977357 658.763549,239.929519 C658.997001,239.88168 659.239753,239.936492 659.43,240.08 C659.61,240.18 662.51,242.3 664.83,242.3 C665.629507,242.371891 666.424476,242.120368 667.037129,241.601681 C667.649781,241.082994 668.029007,240.340412 668.09,239.54 C668.09,237.71 666.55,236.46 663.55,235.25 C660.18,233.89 656.82,231.74 656.82,227.51 C656.82,224.33 659.18,220.64 664.82,220.64 C667.398441,220.67342 669.904546,221.497154 672,223 C672.372976,223.274705 672.465301,223.793483 672.21,224.18 L670.85,226.18 C670.742227,226.403682 670.549485,226.574981 670.314697,226.655748 C670.07991,226.736515 669.822574,226.720043 669.6,226.61 C669.32,226.43 666.6,224.61 664.6,224.61 C662.6,224.61 661.45,225.97 661.45,227.12 C661.45,228.8 662.77,229.95 665.67,231.12 C669.14,232.51 673.15,234.59 673.15,239.21 C673.15,242.89 669.97,246.29 664.92,246.29 C662.037116,246.376488 659.226186,245.381248 657.04,243.5 C656.78,243.3 656.6,243.12 656.92,242.55 Z" id="Shape" fill="#00548B"></path>
+                    <rect id="Rectangle-path" fill="#00548B" x="0.03" y="86.83" width="92.32" height="66.83"></rect>
+                    <path d="M118.43,179.52 C118.43,197.32 118.43,228.83 118.43,246.63 L150.93,246.63 C216.82,246.63 230.61,204.68 230.61,167.87 L230.61,166 C219.69,174.66 208.34,179.51 190.61,179.51 L118.43,179.52 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M118.43,86.84 L118.43,153.38 L190.63,153.38 C211.76,153.38 228.89,138.48 228.89,120.11 C228.89,101.74 211.76,86.84 190.63,86.84 L118.43,86.84 Z" id="Shape1" fill="#00A3CC"></path>
+                  </g>
+                </g>
+              </g>
+            </svg>
+            </a>		</div>
+				</div>
+						</div>
+					</div>
+		</div>
+				<div class="elementor-column elementor-col-50 elementor-top-column elementor-element elementor-element-977a8ca ot-flex-column-vertical" data-id="977a8ca" data-element_type="column">
+			<div class="elementor-column-wrap elementor-element-populated">
+							<div class="elementor-widget-wrap">
+						<div class="elementor-element elementor-element-ca9cafb elementor-widget elementor-widget-text-editor" data-id="ca9cafb" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<p><strong>EDB e-newsletter </strong></p>					</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-1cc6788 elementor-widget elementor-widget-text-editor" data-id="1cc6788" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<p><strong>Issue <span lang="EN-US">January 2021</span></strong></p>					</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-f1339c4 elementor-widget elementor-widget-imenu" data-id="f1339c4" data-element_type="widget" data-widget_type="imenu.default">
+				<div class="elementor-widget-container">
+						<nav id="site-navigation" class="main-navigation">			
+				<ul id="primary-menu" class="menu"><li class="trp-language-switcher-container menu-item menu-item-type-post_type menu-item-object-language_switcher menu-item-1813"><a href="https://news.edbmauritius.org/2021-january-the-new-premium-visa/"><span data-no-translation><span class="trp-ls-language-name">EN</span></span></a></li>
+<li class="trp-language-switcher-container menu-item menu-item-type-post_type menu-item-object-language_switcher menu-item-1812"><a href="https://news.edbmauritius.org/fr/2021-january-the-new-premium-visa/"><span data-no-translation><span class="trp-ls-language-name">FR</span></span></a></li>
+</ul>			</nav>
+	    		</div>
+				</div>
+						</div>
+					</div>
+		</div>
+								</div>
+					</div>
+		</section>
+						</div>
+						</div>
+					</div>
+		</div>    <!-- #header-mobile-close -->
+
+</header>
+<!-- #site-header-close -->
+<!-- #side-panel-open -->
+<!-- #side-panel-close --><!-- #site-content-open -->
+<div id="content" class="site-content">
+	
+    		<div data-elementor-type="wp-page" data-elementor-id="2047" class="elementor elementor-2047" data-elementor-settings="[]">
+						<div class="elementor-inner">
+							<div class="elementor-section-wrap">
+							<section class="elementor-section elementor-top-section elementor-element elementor-element-fed2b68 elementor-section-full_width elementor-section-height-default elementor-section-height-default" data-id="fed2b68" data-element_type="section" data-settings="{&quot;_ha_eqh_enable&quot;:false}">
+						<div class="elementor-container elementor-column-gap-default">
+							<div class="elementor-row">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-bcb37a2 ot-flex-column-vertical" data-id="bcb37a2" data-element_type="column">
+			<div class="elementor-column-wrap elementor-element-populated">
+							<div class="elementor-widget-wrap">
+						<div class="elementor-element elementor-element-93c969a elementor-aspect-ratio-169 elementor-widget elementor-widget-video" data-id="93c969a" data-element_type="widget" data-settings="{&quot;youtube_url&quot;:&quot;https:\/\/www.youtube.com\/watch?v=oftRZSHbgnc&amp;ab_channel=EDBMauritius&quot;,&quot;autoplay&quot;:&quot;yes&quot;,&quot;play_on_mobile&quot;:&quot;yes&quot;,&quot;loop&quot;:&quot;yes&quot;,&quot;video_type&quot;:&quot;youtube&quot;,&quot;aspect_ratio&quot;:&quot;169&quot;}" data-widget_type="video.default">
+				<div class="elementor-widget-container">
+					<div class="elementor-wrapper elementor-fit-aspect-ratio elementor-open-inline">
+			<div class="elementor-video"></div>		</div>
+				</div>
+				</div>
+						</div>
+					</div>
+		</div>
+								</div>
+					</div>
+		</section>
+				<section class="elementor-section elementor-top-section elementor-element elementor-element-a9df1df elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="a9df1df" data-element_type="section" data-settings="{&quot;_ha_eqh_enable&quot;:false}">
+						<div class="elementor-container elementor-column-gap-default">
+							<div class="elementor-row">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-7fdb4ee ot-flex-column-vertical" data-id="7fdb4ee" data-element_type="column">
+			<div class="elementor-column-wrap elementor-element-populated">
+							<div class="elementor-widget-wrap">
+						<div class="elementor-element elementor-element-e7d83f4 elementor-invisible elementor-widget elementor-widget-text-editor" data-id="e7d83f4" data-element_type="widget" data-settings="{&quot;_animation&quot;:&quot;fadeInUp&quot;}" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<h1 class="ydp98fe7493yiv7114771159ydpbb45440emsonormal" style="text-align: center;" align="center">THE NEW PREMIUM VISA</h1>					</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-cbf04e7 elementor-invisible elementor-widget elementor-widget-text-editor" data-id="cbf04e7" data-element_type="widget" data-settings="{&quot;_animation&quot;:&quot;fadeInUp&quot;,&quot;_animation_delay&quot;:200}" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<p>Our country’s early success in controlling the COVID-19 spread has been a result of a vigorous, decisive, and highly effective response to the pandemic. Mauritius enjoys today an enviable position on the international scene, that of being a COVID-Safe destination.</p><p>As things stand at present, the economic impact of the protracted shutdown of the global tourism industry is likely to keep playing out over the coming months. With travel initially brought to a screeching halt, this global disruption has proven how important travel and tourism is to our economy, an industry that accounts for, directly and indirectly, more than 20% of our GDP. Nothing can change the reality of the global pandemic, but as a COVID-Safe destination we can leverage possible benefits.</p><p>This could be the perfect time for us to rethink and reinvent our tourism strategy to make the industry more resilient. The launch of the Premium Visa is aimed at triggering tourism demand; re-activating tourism and adapting to evolving consumer needs. With the gradual easing of flight restrictions, this new concept will help rebuild the trust of travellers seeking a safe holiday destination or chart a way for those seeking a retreat while remaining professionally productive or retiring in a secure environment.</p>					</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-afa7ba5 elementor-widget elementor-widget-image" data-id="afa7ba5" data-element_type="widget" data-widget_type="image.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-image">
+												<img width="1024" height="576" src="https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_84690172-1024x576.jpg" class="attachment-large size-large" alt="" loading="lazy" srcset="https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_84690172-1024x576.jpg 1024w, https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_84690172-300x169.jpg 300w, https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_84690172-768x432.jpg 768w, https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_84690172-16x9.jpg 16w, https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_84690172.jpg 1460w" sizes="(max-width: 1024px) 100vw, 1024px" />														</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-ff0c005 elementor-widget elementor-widget-text-editor" data-id="ff0c005" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<p> </p><p><strong>What is the Premium Visa?        </strong></p><p>The Premium Visa is issued to eligible non-citizens seeking to stay in Mauritius (individually or with their families) for an initial period of more than 6 months up to a year, with the option to renew. It is an appealing invitation to travel to Mauritius, to work remotely in safe haven, take a sabbatical or begin the journey to retirement while relishing an exotic luxury lifestyle in a COVID-Safe environment.</p><p>In order to qualify for the Premium Visa, the applicant must have proof of his/her long stay plans and travel and health insurance for the initial period of stay. The following criteria should also be met:</p>					</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-73c1f7a elementor-widget elementor-widget-image" data-id="73c1f7a" data-element_type="widget" data-widget_type="image.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-image">
+												<img width="1024" height="1003" src="https://news.edbmauritius.org/wp-content/uploads/2021/02/Inforgraphic-01-1024x1003.jpg" class="attachment-large size-large" alt="" loading="lazy" srcset="https://news.edbmauritius.org/wp-content/uploads/2021/02/Inforgraphic-01-1024x1003.jpg 1024w, https://news.edbmauritius.org/wp-content/uploads/2021/02/Inforgraphic-01-300x294.jpg 300w, https://news.edbmauritius.org/wp-content/uploads/2021/02/Inforgraphic-01-768x752.jpg 768w, https://news.edbmauritius.org/wp-content/uploads/2021/02/Inforgraphic-01-1536x1504.jpg 1536w, https://news.edbmauritius.org/wp-content/uploads/2021/02/Inforgraphic-01-2048x2005.jpg 2048w, https://news.edbmauritius.org/wp-content/uploads/2021/02/Inforgraphic-01-12x12.jpg 12w" sizes="(max-width: 1024px) 100vw, 1024px" />														</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-391e113 elementor-widget elementor-widget-text-editor" data-id="391e113" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<p><strong>How to get </strong><strong>your Premium Visa</strong><strong>?</strong></p><p>Applying for the Premium Visa is a relatively swift online procedure with no charges applicable. The online portal is accessible from the website of the Economic Development Board. Starting with the basics, the following is required:</p>					</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-dba46ad elementor-widget elementor-widget-image" data-id="dba46ad" data-element_type="widget" data-widget_type="image.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-image">
+												<img width="1024" height="314" src="https://news.edbmauritius.org/wp-content/uploads/2021/02/Inforgraphic-02-1024x314.jpg" class="attachment-large size-large" alt="" loading="lazy" srcset="https://news.edbmauritius.org/wp-content/uploads/2021/02/Inforgraphic-02-1024x314.jpg 1024w, https://news.edbmauritius.org/wp-content/uploads/2021/02/Inforgraphic-02-300x92.jpg 300w, https://news.edbmauritius.org/wp-content/uploads/2021/02/Inforgraphic-02-768x236.jpg 768w, https://news.edbmauritius.org/wp-content/uploads/2021/02/Inforgraphic-02-1536x471.jpg 1536w, https://news.edbmauritius.org/wp-content/uploads/2021/02/Inforgraphic-02-2048x629.jpg 2048w, https://news.edbmauritius.org/wp-content/uploads/2021/02/Inforgraphic-02-16x5.jpg 16w" sizes="(max-width: 1024px) 100vw, 1024px" />														</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-6e06b5a elementor-widget elementor-widget-text-editor" data-id="6e06b5a" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<p>Note: Pre-booking for Quarantine accommodation should be made prior to the date of travel.</p><p><strong>Mandatory safety of travellers &amp; nationals </strong></p><p>In the midst of the spiralling pandemic and its devastating impacts, travellers need to be and feel safe. To ensure the safety of visitors and nationals, the highest sanitary standards and protocols are being maintained in Mauritius. For all incoming travellers, including Premium Visa holders, a 14-day quarantine requirement has to be compulsorily observed. Health protocols are regularly reviewed in line with the country’s requirements and the status of the global pandemic.</p><p><strong>Working remotely</strong></p><p>The combined effect of flight restrictions, lingering risk to contamination and greater familiarity with online conferencing, have encouraged the business world to eschew the personal appeal of face-to-face meetings and opt for socially responsible online options. The Premium Visa stands as the perfectly adapted option for those looking to maximise their business productivity and leisure time in a country that prominently delivers the work, live, and play balance.</p><p> </p>					</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-b43163e elementor-widget elementor-widget-image" data-id="b43163e" data-element_type="widget" data-widget_type="image.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-image">
+												<img width="1024" height="683" src="https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_1668766774-1024x683.jpg" class="attachment-large size-large" alt="" loading="lazy" srcset="https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_1668766774-1024x683.jpg 1024w, https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_1668766774-300x200.jpg 300w, https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_1668766774-768x512.jpg 768w, https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_1668766774-16x12.jpg 16w, https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_1668766774-600x400.jpg 600w, https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_1668766774.jpg 1440w" sizes="(max-width: 1024px) 100vw, 1024px" />														</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-5968a52 elementor-widget elementor-widget-text-editor" data-id="5968a52" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<p><strong>Schooling</strong></p><p>For the children, Mauritius offers a comprehensive education system that offers English, French, and international educational systems in primary, secondary, and tertiary institutions. Premium Visa holders are allowed to enrol their children in private schools in Mauritius.</p><p><strong>Retirement</strong></p><p>Choosing the ideal retirement destination has never been easy, and these days, it is particularly challenging. Non-citizens seeking to spend their golden days in a country offering unparalleled luxury retirement with a robust and reliable healthcare system may apply for the Premium Visa to get an intense feel of the secure and peaceful lifestyle Mauritius offers.</p><p>Communication is key to creating awareness and bolstering demand. With a thoughtful marketing campaign across available media platforms and channels, including dedicated webinar sessions, the scheme has garnered impressive global interest. With the online platform operational since 16 November 2020, EDB has registered more than 300 applications from 50 different countries over a period of 2 months only.</p><p>In the midst of global travel disruptions, the offer of living in a unique tropical setting with white immaculate sandy beaches overlooking gloriously the gorgeous turquoise seas; or working while exalting over a magnificent sunset and lush greenery in our near idyllic climate seems enticing, doesn’t it?</p>					</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-2feed86 elementor-widget elementor-widget-image" data-id="2feed86" data-element_type="widget" data-widget_type="image.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-image">
+												<img width="1024" height="596" src="https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_599466431-1024x596.jpg" class="attachment-large size-large" alt="" loading="lazy" srcset="https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_599466431-1024x596.jpg 1024w, https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_599466431-300x175.jpg 300w, https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_599466431-768x447.jpg 768w, https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_599466431-16x9.jpg 16w, https://news.edbmauritius.org/wp-content/uploads/2021/02/shutterstock_599466431.jpg 1382w" sizes="(max-width: 1024px) 100vw, 1024px" />														</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-fba7033 elementor-widget elementor-widget-text-editor" data-id="fba7033" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<p>It definitely is mesmerising, which is why we also allow Premium Visa holders to apply for an <strong>Occupation Permit</strong> or <strong>Residence Permit (as retiree)</strong> for a period of 10 years during their stay in Mauritius for a prolonged feeling of serenity and wellness blended with exclusive luxury lifestyle.</p><p>We have also opened up <strong>acquisition of freehold property</strong> developed under the Integrated Resort Scheme (IRS), Real Estate Scheme (RES), Property Development Scheme (PDS), Smart City Scheme (SCS), and Apartment (G+2) to those holding a Premium Visa. Property holders are eligible to apply for a Residence Permit upon the acquisition of a residential property of not less than USD 375,000.  Mauritius offers property investors a golden opportunity to tap into a well-established luxury end property market.</p><p>While this new year brings with it a lot of uncertainty on the international front, opportunities remain for those who can seize the reset moment accordingly. As a long-stay visitor, whatever your interest may be – from remote working professionals to travel enthusiasts to retirees – the Premium Visa is what you need.</p><p>For any questions/assistance pertaining to the Premium Visa, you may contact EDB office on 2033800 or at <a style="color: #6ec1e4;" href="mailto:hpd@edbmauritius.org" target="_blank" rel="noopener">hpd@edbmauritius.org</a>.</p><p>You may submit your application for a Premium Visa through the online portal via the following hyperlink: <a style="color: #6ec1e4;" href="https://eur02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fbusiness.edbmauritius.org%2Fwps%2Fportal%2Fbusiness%2Fhome%2Flicensing%2FLegislation%2F!ut%2Fp%2Fz1%2FhY_bToQwEIafhkvo0HL0DjysuCYr2Y2LvTEUulADlLRl9fGF1WQT4-rczcw3359BFBWIDuVRNKURcii7uX-hwWuIE5wlEWw21083kEcuyW-39y6sXPSM9v8hdF7DhUpgvqcn5GxItynk611A3K2HIfJ_AtFuAVZpmPnrDDyffAN_hDwg2nSSfX3UGjNeWWCBYL1TyR7RynzY0yRqVNQsjoERYvskDGyvxJ7NAh_bAcEVCw8MqgAvjmRgJGoQVfzAFVfOpGb1ItYnM5u0GLjWDq9ZX05KGDFpR6rGgvdRWzBKZcruzFnQyp5b0ImKD_Oo-S2jldqg4qIajf1dnL353fGR7z8BA8DF9A!!%2Fdz%2Fd5%2FL2dBISEvZ0FBIS9nQSEh%2F&amp;data=04%7C01%7CShabina%40edbmauritius.org%7C2663920da6ff481abbb408d8b7afdb02%7Cf57fad5bdf2e483caf0e80c0e984e516%7C0%7C0%7C637461313223943406%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&amp;sdata=xi9qh%2BC6cJOLnyhrso%2FUXhz%2FDhAm9ntGRJ2pJCLzurw%3D&amp;reserved=0" target="_blank" rel="noopener">Apply Now for Premium Visa</a></p><p> </p>					</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-93f31b7 elementor-widget elementor-widget-text-editor" data-id="93f31b7" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<p><span lang="FR" style="font-size:11.0pt;font-family: &quot;Calibri&quot;,sans-serif;mso-fareast-font-family:Calibri;mso-fareast-theme-font: minor-latin;mso-ansi-language:FR;mso-fareast-language:EN-US;mso-bidi-language: AR-SA">Written by&nbsp; <b>Shabina Fatadin</b></span><br></p>					</div>
+						</div>
+				</div>
+						</div>
+					</div>
+		</div>
+								</div>
+					</div>
+		</section>
+						</div>
+						</div>
+					</div>
+		
+
+	</div><!-- #content -->
+	<footer id="site-footer" class="site-footer" itemscope="itemscope" itemtype="http://schema.org/WPFooter">		<div data-elementor-type="wp-post" data-elementor-id="300" class="elementor elementor-300" data-elementor-settings="[]">
+						<div class="elementor-inner">
+							<div class="elementor-section-wrap">
+							<section class="elementor-section elementor-top-section elementor-element elementor-element-fae9e04 elementor-section-stretched elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="fae9e04" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;gradient&quot;,&quot;stretch_section&quot;:&quot;section-stretched&quot;,&quot;_ha_eqh_enable&quot;:false}">
+						<div class="elementor-container elementor-column-gap-default">
+							<div class="elementor-row">
+					<div class="elementor-column elementor-col-50 elementor-top-column elementor-element elementor-element-bb981be ot-flex-column-vertical" data-id="bb981be" data-element_type="column">
+			<div class="elementor-column-wrap elementor-element-populated">
+							<div class="elementor-widget-wrap">
+						<div class="elementor-element elementor-element-1003490 elementor-widget elementor-widget-html" data-id="1003490" data-element_type="widget" data-widget_type="html.default">
+				<div class="elementor-widget-container">
+			<svg class="footer-logo" width="180px" height="100px" viewBox="0 0 682 247" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+              <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+              <defs></defs>
+              <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+                <g id="Group" fill-rule="nonzero">
+                  <g id="logo-EDB-01">
+                    <rect id="Rectangle-path1" fill="#80BA27" x="0.03" y="179.64" width="92.32" height="66.83"></rect>
+                    <path d="M178.89,60.76 C198,60.76 213.5,47.29 213.5,30.67 C213.5,14.05 198,0.57 178.89,0.57 L118.43,0.57 L118.43,60.76 L178.89,60.76 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M273.36,88.81 C273.357305,88.5094872 273.475492,88.2204986 273.687995,88.0079954 C273.900499,87.7954922 274.189487,87.6773047 274.49,87.68 L299.21,87.68 C299.834082,87.68 300.34,88.1859182 300.34,88.81 L300.34,95.32 C300.34,95.9440818 299.834082,96.45 299.21,96.45 L282.67,96.45 L282.67,103.85 L296.28,103.85 C296.899044,103.870981 297.394473,104.370795 297.41,104.99 L297.41,111.5 C297.41,112.124082 296.904082,112.63 296.28,112.63 L282.67,112.63 L282.67,120.69 L299.21,120.69 C299.834082,120.69 300.34,121.195918 300.34,121.82 L300.34,128.33 C300.34,128.954082 299.834082,129.46 299.21,129.46 L274.49,129.46 C274.189487,129.462695 273.900499,129.344508 273.687995,129.132005 C273.475492,128.919501 273.357305,128.630513 273.36,128.33 L273.36,88.81 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M325.66,87.08 C331.022925,86.9182118 336.225964,88.9179949 340.1,92.63 C340.351406,92.8300857 340.502761,93.1300913 340.514298,93.4511929 C340.525834,93.7722945 340.396399,94.0823883 340.16,94.3 L335.51,99.14 C335.312507,99.3415659 335.042192,99.4551531 334.76,99.4551531 C334.477808,99.4551531 334.207493,99.3415659 334.01,99.14 C331.783821,97.1766924 328.91824,96.0923225 325.95,96.09 C319.21,96.09 314.25,101.71 314.25,108.39 C314.172112,111.563622 315.373018,114.63538 317.582722,116.914667 C319.792427,119.193954 322.825489,120.489488 326,120.51 C328.918147,120.506256 331.744964,119.492136 334,117.64 C334.46509,117.277012 335.124165,117.302361 335.56,117.7 L340.21,122.7 C340.61157,123.170665 340.585488,123.87053 340.15,124.31 C336.27083,128.078949 331.058261,130.160381 325.65,130.1 C313.775878,130.1 304.15,120.474122 304.15,108.6 C304.15,96.7258779 313.775878,87.1 325.65,87.1 L325.66,87.08 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M363.15,87.08 C375.018531,87.0469094 384.666711,96.6414134 384.699832,108.509945 C384.732954,120.378476 375.138475,130.02668 363.269944,130.059833 C351.401413,130.092985 341.753183,120.498531 341.72,108.63 C341.693411,102.927264 343.938826,97.4486868 347.960038,93.4049568 C351.981251,89.3612268 357.447205,87.0852553 363.15,87.08 Z M363.15,120.51 C367.990113,120.534262 372.366029,117.634105 374.229485,113.167023 C376.092941,108.699941 375.075225,103.549815 371.652705,100.127295 C368.230185,96.704775 363.080059,95.6870587 358.612977,97.5505149 C354.145895,99.413971 351.245738,103.789887 351.27,108.63 C351.33502,115.164021 356.615979,120.44498 363.15,120.51 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M389.42,88.15 C389.452106,87.5455803 389.95476,87.0737915 390.56,87.08 L392.05,87.08 L415.87,110 L415.93,110 L415.93,88.81 C415.93,88.1859182 416.435918,87.68 417.06,87.68 L424.23,87.68 C424.845304,87.7006998 425.3393,88.1946963 425.36,88.81 L425.36,129 C425.33309,129.602842 424.833412,130.075988 424.23,130.07 L423.23,130.07 C422.952867,130.03367 422.688664,129.930733 422.46,129.77 L398.88,106.07 L398.82,106.07 L398.82,128.34 C398.820012,128.641435 398.699587,128.930381 398.485503,129.142587 C398.271419,129.354793 397.981424,129.472668 397.68,129.47 L390.58,129.47 C389.960795,129.454473 389.460981,128.959044 389.44,128.34 L389.42,88.15 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M452.83,87.08 C464.698531,87.0469094 474.346711,96.6414134 474.379832,108.509945 C474.412954,120.378476 464.818475,130.02668 452.949944,130.059833 C441.081413,130.092985 431.433183,120.498531 431.4,108.63 C431.373411,102.927264 433.618826,97.4486868 437.640038,93.4049568 C441.661251,89.3612268 447.127205,87.0852553 452.83,87.08 Z M452.83,120.51 C457.674489,120.554573 462.065696,117.667408 463.94496,113.202049 C465.824224,108.73669 464.818977,103.578406 461.400492,100.145474 C457.982008,96.7125408 452.82801,95.6855469 448.354765,97.5459611 C443.881519,99.4063754 440.97586,103.785366 441,108.63 C441.064502,115.144817 446.315513,120.418022 452.83,120.51 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M483.28,88 C483.373107,87.4694918 483.821949,87.074677 484.36,87.05 L485.31,87.05 C485.718399,87.0839273 486.087876,87.3056139 486.31,87.65 L500.15,113.44 L500.27,113.44 L514.12,87.65 C514.342124,87.3056139 514.711601,87.0839273 515.12,87.05 L516.12,87.05 C516.658051,87.074677 517.106893,87.4694918 517.2,88 L523.94,128.12 C524.008989,128.451926 523.919606,128.797055 523.698169,129.053764 C523.476733,129.310474 523.148456,129.449535 522.81,129.43 L515.81,129.43 C515.257628,129.410863 514.788431,129.019866 514.67,128.48 L511.98,110.03 L511.87,110.03 L501.87,129.37 C501.652404,129.72873 501.285391,129.970959 500.87,130.03 L499.7,130.03 C499.27911,129.985882 498.906037,129.739653 498.7,129.37 L488.61,110.03 L488.49,110.03 L485.87,128.48 C485.76874,129.0301 485.289342,129.429598 484.73,129.43 L477.73,129.43 C477.391065,129.448687 477.062486,129.309845 476.839649,129.053778 C476.616813,128.797712 476.524681,128.453106 476.59,128.12 L483.28,88 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M530.39,88.81 C530.4107,88.1946963 530.904696,87.7006998 531.52,87.68 L538.69,87.68 C539.305304,87.7006998 539.7993,88.1946963 539.82,88.81 L539.82,128.33 C539.7993,128.945304 539.305304,129.4393 538.69,129.46 L531.52,129.46 C530.904696,129.4393 530.4107,128.945304 530.39,128.33 L530.39,88.81 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M567.4,87.08 C572.765204,86.9222785 577.969828,88.9212866 581.85,92.63 C582.101406,92.8300857 582.252761,93.1300913 582.264298,93.4511929 C582.275834,93.7722945 582.146399,94.0823883 581.91,94.3 L577.25,99.14 C577.060303,99.3518604 576.789376,99.4729355 576.505,99.4729355 C576.220624,99.4729355 575.949697,99.3518604 575.76,99.14 C573.533821,97.1766924 570.66824,96.0923225 567.7,96.09 C560.95,96.09 556,101.71 556,108.39 C555.922086,111.565345 557.124352,114.638633 559.336225,116.918217 C561.548099,119.197801 564.583749,120.492161 567.76,120.51 C570.678147,120.506256 573.504964,119.492136 575.76,117.64 C576.221898,117.278506 576.877429,117.303882 577.31,117.7 L581.97,122.7 C582.37157,123.170665 582.345488,123.87053 581.91,124.31 C578.027759,128.080472 572.811508,130.16194 567.4,130.1 C555.525878,130.1 545.9,120.474122 545.9,108.6 C545.9,96.7258779 555.525878,87.1 567.4,87.1 L567.4,87.08 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M273.36,147.13 C273.348553,146.522731 273.823224,146.017007 274.43,145.99 L289,145.99 C296.574034,145.824296 303.644732,149.770222 307.480393,156.303304 C311.316053,162.836386 311.316053,170.933614 307.480393,177.466696 C303.644732,183.999778 296.574034,187.945704 289,187.78 L274.43,187.78 C273.827158,187.75309 273.354012,187.253412 273.36,186.65 L273.36,147.13 Z M288.36,178.95 C295.11,178.95 300,173.63 300,166.83 C300,160.03 295.11,154.77 288.36,154.77 L282.63,154.77 L282.63,179 L288.36,178.95 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M316.05,147.13 C316.047332,146.828576 316.165207,146.538581 316.377413,146.324497 C316.589619,146.110413 316.878565,145.989988 317.18,145.99 L341.9,145.99 C342.525696,145.995489 343.030024,146.50428 343.03,147.13 L343.03,153.63 C343.030024,154.25572 342.525696,154.764511 341.9,154.77 L325.36,154.77 L325.36,162.17 L339,162.17 C339.619044,162.190981 340.114473,162.690795 340.13,163.31 L340.13,169.81 C340.146481,170.119948 340.034744,170.42303 339.821015,170.648107 C339.607287,170.873184 339.310386,171.000438 339,171 L325.36,171 L325.36,179 L341.9,179 C342.524082,179 343.03,179.505918 343.03,180.13 L343.03,186.64 C343.03,187.264082 342.524082,187.77 341.9,187.77 L317.18,187.77 C316.555918,187.77 316.05,187.264082 316.05,186.64 L316.05,147.13 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M344.47,147.55 C344.287697,147.211036 344.30345,146.799889 344.511155,146.475869 C344.718861,146.151848 345.085879,145.965872 345.47,145.99 L353.41,145.99 C353.838541,146.011816 354.221462,146.264544 354.41,146.65 L364.26,168.44 L364.61,168.44 L374.46,146.65 C374.648538,146.264544 375.031459,146.011816 375.46,145.99 L383.4,145.99 C383.784121,145.965872 384.151139,146.151848 384.358845,146.475869 C384.56655,146.799889 384.582303,147.211036 384.4,147.55 L365.66,187.72 C365.478474,188.111556 365.091393,188.36703 364.66,188.38 L364.07,188.38 C363.638607,188.36703 363.251526,188.111556 363.07,187.72 L344.47,147.55 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M388.17,147.13 C388.175431,146.508182 388.678182,146.005431 389.3,146 L414,146 C414.301435,145.999988 414.590381,146.120413 414.802587,146.334497 C415.014793,146.548581 415.132668,146.838576 415.13,147.14 L415.13,153.64 C415.132668,153.941424 415.014793,154.231419 414.802587,154.445503 C414.590381,154.659587 414.301435,154.780012 414,154.78 L397.48,154.78 L397.48,162.18 L411.09,162.18 C411.710823,162.200711 412.209289,162.699177 412.23,163.32 L412.23,169.82 C412.23,170.449605 411.719605,170.96 411.09,170.96 L397.48,170.96 L397.48,179 L414,179 C414.300513,178.997305 414.589501,179.115492 414.802005,179.327995 C415.014508,179.540499 415.132695,179.829487 415.13,180.13 L415.13,186.64 C415.13,187.264082 414.624082,187.77 414,187.77 L389.3,187.77 C388.675918,187.77 388.17,187.264082 388.17,186.64 L388.17,147.13 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M422,147.13 C422.00498,146.519572 422.489927,146.021399 423.1,146 L430.2,146 C430.820823,146.020711 431.319289,146.519177 431.34,147.14 L431.34,179 L445.54,179 C445.841424,178.997332 446.131419,179.115207 446.345503,179.327413 C446.559587,179.539619 446.680012,179.828565 446.68,180.13 L446.68,186.64 C446.674511,187.265696 446.16572,187.770024 445.54,187.77 L423.1,187.77 C422.47428,187.770024 421.965489,187.265696 421.96,186.64 L422,147.13 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M468.23,145.4 C480.091998,145.367037 489.737352,154.951442 489.779582,166.813411 C489.821812,178.675379 480.244944,188.328218 468.383013,188.379715 C456.521081,188.431211 446.860764,178.861888 446.8,167 C446.760057,161.288626 448.999568,155.797165 453.022231,151.742591 C457.044894,147.688017 462.518489,145.405186 468.23,145.4 Z M468.23,178.83 C473.074634,178.85414 477.453625,175.948481 479.314039,171.475235 C481.174453,167.00199 480.147459,161.847992 476.714526,158.429508 C473.281594,155.011023 468.12331,154.005776 463.657951,155.88504 C459.192592,157.764304 456.305427,162.155511 456.35,167 C456.441978,173.514487 461.715183,178.765498 468.23,178.83 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M494.56,147.13 C494.565489,146.504304 495.07428,145.999976 495.7,146 L510.09,146 C514.933402,145.856782 519.472528,148.355059 521.942782,152.523619 C524.413037,156.692179 524.424711,161.873387 521.973266,166.053036 C519.52182,170.232686 514.993998,172.751391 510.15,172.63 L503.88,172.63 L503.88,186.63 C503.854173,187.246916 503.35712,187.73961 502.74,187.76 L495.74,187.76 C495.11428,187.760024 494.605489,187.255696 494.6,186.63 L494.56,147.13 Z M509.56,163.9 C510.81162,163.908049 512.014309,163.414404 512.899357,162.529357 C513.784404,161.644309 514.278049,160.44162 514.27,159.19 C514.236117,157.97773 513.71968,156.829149 512.835348,155.999267 C511.951017,155.169385 510.771976,154.726881 509.56,154.77 L503.89,154.77 L503.89,163.9 L509.56,163.9 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M530.86,146.35 C530.927756,145.797788 531.384215,145.37514 531.94,145.35 L532.89,145.35 C533.295653,145.384544 533.663602,145.601634 533.89,145.94 L547.74,171.73 L547.86,171.73 L561.73,146 C561.956398,145.661634 562.324347,145.444544 562.73,145.41 L563.73,145.41 C564.283643,145.435818 564.736839,145.859366 564.8,146.41 L571.55,186.53 C571.615319,186.863106 571.523187,187.207712 571.300351,187.463778 C571.077514,187.719845 570.748935,187.858687 570.41,187.84 L563.41,187.84 C562.861411,187.816411 562.397481,187.426381 562.28,186.89 L559.59,168.44 L559.47,168.44 L549.47,187.78 C549.252404,188.13873 548.885391,188.380959 548.47,188.44 L547.39,188.44 C546.968519,188.397536 546.594748,188.150847 546.39,187.78 L536.3,168.44 L536.18,168.44 L533.55,186.89 C533.445866,187.434327 532.974124,187.830924 532.42,187.84 L525.42,187.84 C525.081544,187.859535 524.753267,187.720474 524.531831,187.463764 C524.310394,187.207055 524.221011,186.861926 524.29,186.53 L530.86,146.35 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M578,147.13 C578,146.500395 578.510395,145.99 579.14,145.99 L603.85,145.99 C604.479605,145.99 604.99,146.500395 604.99,147.13 L604.99,153.63 C604.99,154.259605 604.479605,154.77 603.85,154.77 L587.29,154.77 L587.29,162.17 L600.9,162.17 C601.516916,162.195827 602.00961,162.69288 602.03,163.31 L602.03,169.81 C602.043583,170.119185 601.930878,170.420605 601.717771,170.645027 C601.504665,170.869448 601.209473,170.997583 600.9,171 L587.29,171 L587.29,179 L603.82,179 C604.121424,178.997332 604.411419,179.115207 604.625503,179.327413 C604.839587,179.539619 604.960012,179.828565 604.96,180.13 L604.96,186.64 C604.954511,187.265696 604.44572,187.770024 603.82,187.77 L579.11,187.77 C578.48428,187.770024 577.975489,187.265696 577.97,186.64 L578,147.13 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M611.71,146.47 C611.731718,145.864799 612.234515,145.388699 612.84,145.4 L614.33,145.4 L638.15,168.32 L638.21,168.32 L638.21,147.13 C638.21,146.500395 638.720395,145.99 639.35,145.99 L646.51,145.99 C647.129044,146.010981 647.624473,146.510795 647.64,147.13 L647.64,187.3 C647.618343,187.906783 647.117141,188.385808 646.51,188.38 L645.51,188.38 C645.229781,188.343693 644.962327,188.240826 644.73,188.08 L621.15,164.38 L621.09,164.38 L621.09,186.65 C621.084511,187.275696 620.57572,187.780024 619.95,187.78 L612.85,187.78 C612.234696,187.7593 611.7407,187.265304 611.72,186.65 L611.71,146.47 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M662.1,154.77 L653.56,154.77 C653.258565,154.770012 652.969619,154.649587 652.757413,154.435503 C652.545207,154.221419 652.427332,153.931424 652.43,153.63 L652.43,147.13 C652.427332,146.828576 652.545207,146.538581 652.757413,146.324497 C652.969619,146.110413 653.258565,145.989988 653.56,145.99 L680.07,145.99 C680.695696,145.995489 681.200024,146.50428 681.2,147.13 L681.2,153.63 C681.200024,154.25572 680.695696,154.764511 680.07,154.77 L671.53,154.77 L671.53,186.65 C671.504173,187.266916 671.00712,187.75961 670.39,187.78 L663.23,187.78 C662.614696,187.7593 662.1207,187.265304 662.1,186.65 L662.1,154.77 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M273.36,205.45 C273.357332,205.148576 273.475207,204.858581 273.687413,204.644497 C273.899619,204.430413 274.188565,204.309988 274.49,204.31 L288.4,204.31 C295.45,204.31 301.24,209.15 301.24,215.41 C301.24,220.01 297.12,223.35 294.31,224.85 C297.47,226.16 302.31,229.08 302.31,234.58 C302.31,241.26 296.4,246.1 289.31,246.1 L274.49,246.1 C274.188565,246.100012 273.899619,245.979587 273.687413,245.765503 C273.475207,245.551419 273.357332,245.261424 273.36,244.96 L273.36,205.45 Z M287.36,221.27 C289.693155,221.220805 291.552431,219.303566 291.53,216.97 C291.547524,215.868636 291.1101,214.80879 290.32088,214.040389 C289.53166,213.271988 288.460502,212.863047 287.36,212.91 L282.7,212.91 L282.7,221.27 L287.36,221.27 Z M288.13,237.56 C289.278396,237.552071 290.376604,237.088254 291.183016,236.270589 C291.989429,235.452925 292.437984,234.348396 292.43,233.2 C292.43,230.82 289.86,229.03 287.54,229.03 L282.7,229.03 L282.7,237.56 L288.13,237.56 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M327.09,203.71 C335.787697,203.681705 343.645637,208.896623 346.998392,216.922192 C350.351147,224.947761 348.538162,234.202797 342.405124,240.370177 C336.272087,246.537557 327.027319,248.402194 318.983154,245.094306 C310.938988,241.786417 305.680273,233.957719 305.66,225.26 C305.633411,219.557264 307.878826,214.078687 311.900038,210.034957 C315.921251,205.991227 321.387205,203.715255 327.09,203.71 Z M327.09,237.15 C331.929207,237.174276 336.3045,234.275212 338.168555,229.809362 C340.03261,225.343513 339.016741,220.194166 335.596302,216.770848 C332.175863,213.347529 327.027373,212.327328 322.559957,214.187625 C318.09254,216.047922 315.189796,220.420774 315.21,225.26 C315.269609,231.797926 320.552126,237.08489 327.09,237.15 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M348.89,244.55 L367.57,204.37 C367.764904,203.990195 368.144152,203.739891 368.57,203.71 L369.16,203.71 C369.585848,203.739891 369.965096,203.990195 370.16,204.37 L388.84,244.55 C389.024222,244.887629 389.009102,245.298962 388.800591,245.622155 C388.592079,245.945349 388.223548,246.128674 387.84,246.1 L381.21,246.1 C380.14,246.1 379.66,245.74 379.12,244.61 L377,239.89 L360.76,239.89 L358.62,244.67 C358.277804,245.553332 357.416944,246.125905 356.47,246.1 L349.9,246.1 C349.501584,246.175708 349.096895,246.003293 348.875493,245.663517 C348.654091,245.323741 348.659821,244.883893 348.89,244.55 Z M373.42,231.77 L368.88,221.92 L368.82,221.92 L364.35,231.77 L373.42,231.77 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M392.59,205.45 C392.589976,204.82428 393.094304,204.315489 393.72,204.31 L411.57,204.31 C418.71083,204.309789 424.515071,210.069381 424.57,217.21 C424.57,222.7 420.93,227.11 415.73,229.21 L423.91,244.37 C424.132725,244.724777 424.140916,245.173653 423.931282,245.536319 C423.721649,245.898985 423.328592,246.115927 422.91,246.1 L415,246.1 C414.592296,246.119472 414.20733,245.91159 414,245.56 L406.06,229.74 L402,229.74 L402,245 C401.97961,245.61712 401.486916,246.114173 400.87,246.14 L393.76,246.14 C393.134304,246.134511 392.629976,245.62572 392.63,245 L392.59,205.45 Z M410.8,222.16 C413.339536,222.021952 415.32844,219.923285 415.33,217.38 C415.308275,214.887204 413.292796,212.871725 410.8,212.85 L402,212.85 L402,222.16 L410.8,222.16 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M431.4,205.45 C431.393791,204.84476 431.86558,204.342106 432.47,204.31 L447,204.31 C454.574034,204.144296 461.644732,208.090222 465.480393,214.623304 C469.316053,221.156386 469.316053,229.253614 465.480393,235.786696 C461.644732,242.319778 454.574034,246.265704 447,246.1 L432.47,246.1 C431.880874,246.068862 431.41484,245.589762 431.4,245 L431.4,205.45 Z M446.4,237.26 C453.15,237.26 458.04,231.95 458.04,225.15 C458.04,218.35 453.15,213.09 446.4,213.09 L440.67,213.09 L440.67,237.26 L446.4,237.26 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M487.21,221.18 C487.241696,220.85628 487.525562,220.616767 487.85,220.64 L488.42,220.64 C488.6766,220.628945 488.915649,220.770023 489.03,221 L496.91,237.89 L497.01,237.89 L504.89,221 C504.995705,220.762148 505.240686,220.617569 505.5,220.64 L506.07,220.64 C506.394438,220.616767 506.678304,220.85628 506.71,221.18 L510.94,245.23 C511.008231,245.431272 510.970387,245.653378 510.839353,245.820698 C510.70832,245.988018 510.501759,246.077997 510.29,246.06 L507,246.06 C506.683777,246.03716 506.413878,245.822829 506.32,245.52 L504.24,232 L504.14,232 L497.87,246 C497.77414,246.249661 497.52684,246.407771 497.26,246.39 L496.62,246.39 C496.352788,246.399902 496.106775,246.245152 496,246 L489.68,232 L489.57,232 L487.49,245.57 C487.422756,245.873672 487.160657,246.094818 486.85,246.11 L483.63,246.11 C483.417643,246.123748 483.211686,246.034261 483.076824,245.869651 C482.941962,245.70504 482.894743,245.485502 482.95,245.28 L487.21,221.18 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M514,245.12 L525.14,221 C525.233922,220.752109 525.475054,220.591355 525.74,220.6 L526.1,220.6 C526.369439,220.58368 526.617566,220.746386 526.71,221 L537.71,245.08 C537.819828,245.285537 537.809254,245.534527 537.682397,245.730013 C537.555539,245.925499 537.33245,246.036579 537.1,246.02 L534,246.02 C533.540829,246.038276 533.128306,245.741259 533,245.3 L531.24,241.43 L520.54,241.43 L518.79,245.3 C518.637319,245.723466 518.240028,246.009516 517.79,246.02 L514.67,246.02 C514.438645,246.05209 514.208181,245.955596 514.068706,245.768241 C513.929231,245.580887 513.902897,245.332429 514,245.12 Z M529.47,237.5 L525.89,229.63 L525.78,229.63 L522.27,237.5 L529.47,237.5 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M539.56,221.68 C539.570461,221.308866 539.868866,221.010461 540.24,221 L543.64,221 C544.015554,221 544.32,221.304446 544.32,221.68 L544.32,236.32 C544.236086,238.233992 545.209392,240.039623 546.854384,241.021667 C548.499375,242.00371 550.550625,242.00371 552.195616,241.021667 C553.840608,240.039623 554.813914,238.233992 554.73,236.32 L554.73,221.68 C554.73,221.304446 555.034446,221 555.41,221 L558.81,221 C559.181134,221.010461 559.479539,221.308866 559.49,221.68 L559.49,236.57 C559.05542,241.750582 554.723777,245.734072 549.525,245.734072 C544.326223,245.734072 539.99458,241.750582 539.56,236.57 L539.56,221.68 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M564.93,221.68 C564.927275,221.498831 564.998043,221.324283 565.126163,221.196163 C565.254283,221.068043 565.428831,220.997275 565.61,221 L575.84,221 C580.118017,220.972262 583.611499,224.412066 583.65,228.69 C583.552568,231.967842 581.445167,234.846632 578.35,235.93 L583.25,245.02 C583.36328,245.232337 583.355886,245.488735 583.230558,245.69419 C583.10523,245.899646 582.880638,246.023553 582.64,246.02 L578.89,246.02 C578.648304,246.034873 578.420695,245.905371 578.31,245.69 L573.55,236.21 L569.55,236.21 L569.55,245.34 C569.53471,245.709035 569.239035,246.00471 568.87,246.02 L565.58,246.02 C565.204446,246.02 564.9,245.715554 564.9,245.34 L564.93,221.68 Z M575.45,232.42 C577.425049,232.36573 578.996173,230.745785 578.99,228.77 C578.946712,226.842926 577.377532,225.300343 575.45,225.29 L569.61,225.29 L569.61,232.42 L575.45,232.42 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M589.47,221.68 C589.48529,221.310965 589.780965,221.01529 590.15,221 L593.48,221 C593.851134,221.010461 594.149539,221.308866 594.16,221.68 L594.16,245.38 C594.14471,245.749035 593.849035,246.04471 593.48,246.06 L590.15,246.06 C589.782997,246.040119 589.489881,245.747003 589.47,245.38 L589.47,221.68 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M604.75,225.29 L599.28,225.29 C599.098831,225.292725 598.924283,225.221957 598.796163,225.093837 C598.668043,224.965717 598.597275,224.791169 598.6,224.61 L598.6,221.68 C598.597275,221.498831 598.668043,221.324283 598.796163,221.196163 C598.924283,221.068043 599.098831,220.997275 599.28,221 L614.92,221 C615.295554,221 615.6,221.304446 615.6,221.68 L615.6,224.61 C615.6,224.985554 615.295554,225.29 614.92,225.29 L609.44,225.29 L609.44,245.38 C609.42471,245.749035 609.129035,246.04471 608.76,246.06 L605.43,246.06 C605.062997,246.040119 604.769881,245.747003 604.75,245.38 L604.75,225.29 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M620,221.68 C620.010461,221.308866 620.308866,221.010461 620.68,221 L624,221 C624.371134,221.010461 624.669539,221.308866 624.68,221.68 L624.68,245.38 C624.66471,245.749035 624.369035,246.04471 624,246.06 L620.67,246.06 C620.300965,246.04471 620.00529,245.749035 619.99,245.38 L620,221.68 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M631.59,221.68 C631.600461,221.308866 631.898866,221.010461 632.27,221 L635.67,221 C636.045554,221 636.35,221.304446 636.35,221.68 L636.35,236.32 C636.35,239.197404 638.682596,241.53 641.56,241.53 C644.437404,241.53 646.77,239.197404 646.77,236.32 L646.77,221.68 C646.767275,221.498831 646.838043,221.324283 646.966163,221.196163 C647.094283,221.068043 647.268831,220.997275 647.45,221 L650.85,221 C651.221134,221.010461 651.519539,221.308866 651.53,221.68 L651.53,236.57 C651.125759,241.776976 646.782644,245.795984 641.56,245.795984 C636.337356,245.795984 631.994241,241.776976 631.59,236.57 L631.59,221.68 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M656.92,242.55 L658.21,240.33 C658.328469,240.123231 658.530097,239.977357 658.763549,239.929519 C658.997001,239.88168 659.239753,239.936492 659.43,240.08 C659.61,240.18 662.51,242.3 664.83,242.3 C665.629507,242.371891 666.424476,242.120368 667.037129,241.601681 C667.649781,241.082994 668.029007,240.340412 668.09,239.54 C668.09,237.71 666.55,236.46 663.55,235.25 C660.18,233.89 656.82,231.74 656.82,227.51 C656.82,224.33 659.18,220.64 664.82,220.64 C667.398441,220.67342 669.904546,221.497154 672,223 C672.372976,223.274705 672.465301,223.793483 672.21,224.18 L670.85,226.18 C670.742227,226.403682 670.549485,226.574981 670.314697,226.655748 C670.07991,226.736515 669.822574,226.720043 669.6,226.61 C669.32,226.43 666.6,224.61 664.6,224.61 C662.6,224.61 661.45,225.97 661.45,227.12 C661.45,228.8 662.77,229.95 665.67,231.12 C669.14,232.51 673.15,234.59 673.15,239.21 C673.15,242.89 669.97,246.29 664.92,246.29 C662.037116,246.376488 659.226186,245.381248 657.04,243.5 C656.78,243.3 656.6,243.12 656.92,242.55 Z" id="Shape" fill="#00548B"></path>
+                    <rect id="Rectangle-path" fill="#00548B" x="0.03" y="86.83" width="92.32" height="66.83"></rect>
+                    <path d="M118.43,179.52 C118.43,197.32 118.43,228.83 118.43,246.63 L150.93,246.63 C216.82,246.63 230.61,204.68 230.61,167.87 L230.61,166 C219.69,174.66 208.34,179.51 190.61,179.51 L118.43,179.52 Z" id="Shape" fill="#00548B"></path>
+                    <path d="M118.43,86.84 L118.43,153.38 L190.63,153.38 C211.76,153.38 228.89,138.48 228.89,120.11 C228.89,101.74 211.76,86.84 190.63,86.84 L118.43,86.84 Z" id="Shape1" fill="#00A3CC"></path>
+                  </g>
+                </g>
+              </g>
+            </svg>		</div>
+				</div>
+						</div>
+					</div>
+		</div>
+				<div class="elementor-column elementor-col-50 elementor-top-column elementor-element elementor-element-ab00ba1 ot-column-items-center ot-flex-column-vertical" data-id="ab00ba1" data-element_type="column">
+			<div class="elementor-column-wrap elementor-element-populated">
+							<div class="elementor-widget-wrap">
+						<div class="elementor-element elementor-element-1eb16be elementor-widget elementor-widget-text-editor" data-id="1eb16be" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<p>10th Floor, One Cathedral Square Building,<br />16, Jules Koenig Street Port Louis 11328, Republic of Mauritius<br />T: +230 203 3800</p>					</div>
+						</div>
+				</div>
+						</div>
+					</div>
+		</div>
+								</div>
+					</div>
+		</section>
+				<section class="elementor-section elementor-top-section elementor-element elementor-element-ae593bf elementor-section-stretched elementor-section-boxed elementor-section-height-default elementor-section-height-default" data-id="ae593bf" data-element_type="section" data-settings="{&quot;background_background&quot;:&quot;gradient&quot;,&quot;stretch_section&quot;:&quot;section-stretched&quot;,&quot;_ha_eqh_enable&quot;:false}">
+						<div class="elementor-container elementor-column-gap-default">
+							<div class="elementor-row">
+					<div class="elementor-column elementor-col-100 elementor-top-column elementor-element elementor-element-d1ab8fa ot-flex-column-vertical" data-id="d1ab8fa" data-element_type="column">
+			<div class="elementor-column-wrap elementor-element-populated">
+							<div class="elementor-widget-wrap">
+						<div class="elementor-element elementor-element-d995cb0 elementor-widget elementor-widget-text-editor" data-id="d995cb0" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<p><span lang="EN-US"> connect with us</span></p>					</div>
+						</div>
+				</div>
+				<div class="elementor-element elementor-element-fa79ab8 elementor-shape-square elementor-grid-0 e-grid-align-center elementor-widget elementor-widget-social-icons" data-id="fa79ab8" data-element_type="widget" data-widget_type="social-icons.default">
+				<div class="elementor-widget-container">
+					<div class="elementor-social-icons-wrapper elementor-grid">
+							<div class="elementor-grid-item">
+					<a class="elementor-icon elementor-social-icon elementor-social-icon-youtube elementor-animation-buzz elementor-repeater-item-2f2d88c" href="https://www.youtube.com/channel/UCt-k8QDx5oewa58oGDc9VZA?view_as=subscriber" target="_blank">
+						<span class="elementor-screen-only">Youtube</span>
+						<i class="fab fa-youtube"></i>					</a>
+				</div>
+							<div class="elementor-grid-item">
+					<a class="elementor-icon elementor-social-icon elementor-social-icon-twitter elementor-animation-buzz elementor-repeater-item-0d77827" href="https://twitter.com/" target="_blank">
+						<span class="elementor-screen-only">Twitter</span>
+						<i class="fab fa-twitter"></i>					</a>
+				</div>
+							<div class="elementor-grid-item">
+					<a class="elementor-icon elementor-social-icon elementor-social-icon-facebook-f elementor-animation-buzz elementor-repeater-item-04b0949" href="https://www.facebook.com/mauritiusedb.org/" target="_blank">
+						<span class="elementor-screen-only">Facebook-f</span>
+						<i class="fab fa-facebook-f"></i>					</a>
+				</div>
+							<div class="elementor-grid-item">
+					<a class="elementor-icon elementor-social-icon elementor-social-icon-linkedin-in elementor-animation-buzz elementor-repeater-item-d468e5b" href="https://www.linkedin.com/in/edbmauritius/" target="_blank">
+						<span class="elementor-screen-only">Linkedin-in</span>
+						<i class="fab fa-linkedin-in"></i>					</a>
+				</div>
+							<div class="elementor-grid-item">
+					<a class="elementor-icon elementor-social-icon elementor-social-icon-instagram elementor-animation-buzz elementor-repeater-item-0062e68" href="https://www.instagram.com/edbmauritius/" target="_blank">
+						<span class="elementor-screen-only">Instagram</span>
+						<i class="fab fa-instagram"></i>					</a>
+				</div>
+							<div class="elementor-grid-item">
+					<a class="elementor-icon elementor-social-icon elementor-social-icon-envelope elementor-animation-buzz elementor-repeater-item-e15a93a" href="mailto:contact@edbmauritius.org" target="_blank">
+						<span class="elementor-screen-only">Envelope</span>
+						<i class="fas fa-envelope"></i>					</a>
+				</div>
+							<div class="elementor-grid-item">
+					<a class="elementor-icon elementor-social-icon elementor-social-icon-link elementor-animation-buzz elementor-repeater-item-74dc0d2" href="https://www.edbmauritius.org/" target="_blank">
+						<span class="elementor-screen-only">Link</span>
+						<i class="fas fa-link"></i>					</a>
+				</div>
+					</div>
+				</div>
+				</div>
+				<section class="elementor-section elementor-inner-section elementor-element elementor-element-7f338a0 elementor-section-full_width elementor-section-height-default elementor-section-height-default" data-id="7f338a0" data-element_type="section" data-settings="{&quot;_ha_eqh_enable&quot;:false}">
+						<div class="elementor-container elementor-column-gap-default">
+							<div class="elementor-row">
+					<div class="elementor-column elementor-col-100 elementor-inner-column elementor-element elementor-element-53d769f ot-flex-column-vertical" data-id="53d769f" data-element_type="column">
+			<div class="elementor-column-wrap elementor-element-populated">
+							<div class="elementor-widget-wrap">
+						<div class="elementor-element elementor-element-806cc55 elementor-widget elementor-widget-text-editor" data-id="806cc55" data-element_type="widget" data-widget_type="text-editor.default">
+				<div class="elementor-widget-container">
+								<div class="elementor-text-editor elementor-clearfix">
+					<p>Copyright © 2021 Economic Development Board. All Rights Reserved.</p>					</div>
+						</div>
+				</div>
+						</div>
+					</div>
+		</div>
+								</div>
+					</div>
+		</section>
+						</div>
+					</div>
+		</div>
+								</div>
+					</div>
+		</section>
+						</div>
+						</div>
+					</div>
+		</footer></div><!-- #page -->
+<a id="back-to-top" href="#" class="show"><i class="ot-flaticon-left-arrow-2"></i></a><link rel='stylesheet' id='elementor-post-106-css'  href='https://news.edbmauritius.org/wp-content/uploads/elementor/css/post-106.css?ver=1620028364' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-post-77-css'  href='https://news.edbmauritius.org/wp-content/uploads/elementor/css/post-77.css?ver=1620028364' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-post-300-css'  href='https://news.edbmauritius.org/wp-content/uploads/elementor/css/post-300.css?ver=1620045723' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-icons-shared-0-css'  href='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/lib/font-awesome/css/fontawesome.min.css?ver=5.15.1' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-icons-fa-brands-css'  href='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/lib/font-awesome/css/brands.min.css?ver=5.15.1' type='text/css' media='all' />
+<link rel='stylesheet' id='elementor-icons-fa-solid-css'  href='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/lib/font-awesome/css/solid.min.css?ver=5.15.1' type='text/css' media='all' />
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-includes/js/dist/vendor/regenerator-runtime.min.js?ver=0.13.7' id='regenerator-runtime-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-includes/js/dist/vendor/wp-polyfill.min.js?ver=3.15.0' id='wp-polyfill-js'></script>
+<script type='text/javascript' id='contact-form-7-js-extra'>
+/* <![CDATA[ */
+var wpcf7 = {"api":{"root":"https:\/\/news.edbmauritius.org\/wp-json\/","namespace":"contact-form-7\/v1"},"cached":"1"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/plugins/contact-form-7/includes/js/index.js?ver=5.4.2' id='contact-form-7-js'></script>
+<script type='text/javascript' id='rocket-browser-checker-js-after'>
+"use strict";var _createClass=function(){function defineProperties(target,props){for(var i=0;i<props.length;i++){var descriptor=props[i];descriptor.enumerable=descriptor.enumerable||!1,descriptor.configurable=!0,"value"in descriptor&&(descriptor.writable=!0),Object.defineProperty(target,descriptor.key,descriptor)}}return function(Constructor,protoProps,staticProps){return protoProps&&defineProperties(Constructor.prototype,protoProps),staticProps&&defineProperties(Constructor,staticProps),Constructor}}();function _classCallCheck(instance,Constructor){if(!(instance instanceof Constructor))throw new TypeError("Cannot call a class as a function")}var RocketBrowserCompatibilityChecker=function(){function RocketBrowserCompatibilityChecker(options){_classCallCheck(this,RocketBrowserCompatibilityChecker),this.passiveSupported=!1,this._checkPassiveOption(this),this.options=!!this.passiveSupported&&options}return _createClass(RocketBrowserCompatibilityChecker,[{key:"_checkPassiveOption",value:function(self){try{var options={get passive(){return!(self.passiveSupported=!0)}};window.addEventListener("test",null,options),window.removeEventListener("test",null,options)}catch(err){self.passiveSupported=!1}}},{key:"initRequestIdleCallback",value:function(){!1 in window&&(window.requestIdleCallback=function(cb){var start=Date.now();return setTimeout(function(){cb({didTimeout:!1,timeRemaining:function(){return Math.max(0,50-(Date.now()-start))}})},1)}),!1 in window&&(window.cancelIdleCallback=function(id){return clearTimeout(id)})}},{key:"isDataSaverModeOn",value:function(){return"connection"in navigator&&!0===navigator.connection.saveData}},{key:"supportsLinkPrefetch",value:function(){var elem=document.createElement("link");return elem.relList&&elem.relList.supports&&elem.relList.supports("prefetch")&&window.IntersectionObserver&&"isIntersecting"in IntersectionObserverEntry.prototype}},{key:"isSlowConnection",value:function(){return"connection"in navigator&&"effectiveType"in navigator.connection&&("2g"===navigator.connection.effectiveType||"slow-2g"===navigator.connection.effectiveType)}}]),RocketBrowserCompatibilityChecker}();
+</script>
+<script type='text/javascript' id='rocket-delay-js-js-after'>
+(function() {
+"use strict";var e=function(){function n(e,t){for(var r=0;r<t.length;r++){var n=t[r];n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(e,t,r){return t&&n(e.prototype,t),r&&n(e,r),e}}();function n(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}var t=function(){function r(e,t){n(this,r),this.attrName="data-rocketlazyloadscript",this.browser=t,this.options=this.browser.options,this.triggerEvents=e,this.userEventListener=this.triggerListener.bind(this)}return e(r,[{key:"init",value:function(){this._addEventListener(this)}},{key:"reset",value:function(){this._removeEventListener(this)}},{key:"_addEventListener",value:function(t){this.triggerEvents.forEach(function(e){return window.addEventListener(e,t.userEventListener,t.options)})}},{key:"_removeEventListener",value:function(t){this.triggerEvents.forEach(function(e){return window.removeEventListener(e,t.userEventListener,t.options)})}},{key:"_loadScriptSrc",value:function(){var r=this,e=document.querySelectorAll("script["+this.attrName+"]");0!==e.length&&Array.prototype.slice.call(e).forEach(function(e){var t=e.getAttribute(r.attrName);e.setAttribute("src",t),e.removeAttribute(r.attrName)}),this.reset()}},{key:"triggerListener",value:function(){this._loadScriptSrc(),this._removeEventListener(this)}}],[{key:"run",value:function(){RocketBrowserCompatibilityChecker&&new r(["keydown","mouseover","touchmove","touchstart"],new RocketBrowserCompatibilityChecker({passive:!0})).init()}}]),r}();t.run();
+}());
+</script>
+<script type='text/javascript' id='rocket-preload-links-js-extra'>
+/* <![CDATA[ */
+var RocketPreloadLinksConfig = {"excludeUris":"\/(.+\/)?feed\/?.+\/?|\/(?:.+\/)?embed\/|\/(index\\.php\/)?wp\\-json(\/.*|$)|\/wp-admin\/|\/logout\/|\/wp-login.php","usesTrailingSlash":"1","imageExt":"jpg|jpeg|gif|png|tiff|bmp|webp|avif","fileExt":"jpg|jpeg|gif|png|tiff|bmp|webp|avif|php|pdf|html|htm","siteUrl":"https:\/\/news.edbmauritius.org","onHoverDelay":"100","rateThrottle":"3"};
+/* ]]> */
+</script>
+<script type='text/javascript' id='rocket-preload-links-js-after'>
+(function() {
+"use strict";var r="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e},e=function(){function i(e,t){for(var n=0;n<t.length;n++){var i=t[n];i.enumerable=i.enumerable||!1,i.configurable=!0,"value"in i&&(i.writable=!0),Object.defineProperty(e,i.key,i)}}return function(e,t,n){return t&&i(e.prototype,t),n&&i(e,n),e}}();function i(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}var t=function(){function n(e,t){i(this,n),this.browser=e,this.config=t,this.options=this.browser.options,this.prefetched=new Set,this.eventTime=null,this.threshold=1111,this.numOnHover=0}return e(n,[{key:"init",value:function(){!this.browser.supportsLinkPrefetch()||this.browser.isDataSaverModeOn()||this.browser.isSlowConnection()||(this.regex={excludeUris:RegExp(this.config.excludeUris,"i"),images:RegExp(".("+this.config.imageExt+")$","i"),fileExt:RegExp(".("+this.config.fileExt+")$","i")},this._initListeners(this))}},{key:"_initListeners",value:function(e){-1<this.config.onHoverDelay&&document.addEventListener("mouseover",e.listener.bind(e),e.listenerOptions),document.addEventListener("mousedown",e.listener.bind(e),e.listenerOptions),document.addEventListener("touchstart",e.listener.bind(e),e.listenerOptions)}},{key:"listener",value:function(e){var t=e.target.closest("a"),n=this._prepareUrl(t);if(null!==n)switch(e.type){case"mousedown":case"touchstart":this._addPrefetchLink(n);break;case"mouseover":this._earlyPrefetch(t,n,"mouseout")}}},{key:"_earlyPrefetch",value:function(t,e,n){var i=this,r=setTimeout(function(){if(r=null,0===i.numOnHover)setTimeout(function(){return i.numOnHover=0},1e3);else if(i.numOnHover>i.config.rateThrottle)return;i.numOnHover++,i._addPrefetchLink(e)},this.config.onHoverDelay);t.addEventListener(n,function e(){t.removeEventListener(n,e,{passive:!0}),null!==r&&(clearTimeout(r),r=null)},{passive:!0})}},{key:"_addPrefetchLink",value:function(i){return this.prefetched.add(i.href),new Promise(function(e,t){var n=document.createElement("link");n.rel="prefetch",n.href=i.href,n.onload=e,n.onerror=t,document.head.appendChild(n)}).catch(function(){})}},{key:"_prepareUrl",value:function(e){if(null===e||"object"!==(void 0===e?"undefined":r(e))||!1 in e||-1===["http:","https:"].indexOf(e.protocol))return null;var t=e.href.substring(0,this.config.siteUrl.length),n=this._getPathname(e.href,t),i={original:e.href,protocol:e.protocol,origin:t,pathname:n,href:t+n};return this._isLinkOk(i)?i:null}},{key:"_getPathname",value:function(e,t){var n=t?e.substring(this.config.siteUrl.length):e;return n.startsWith("/")||(n="/"+n),this._shouldAddTrailingSlash(n)?n+"/":n}},{key:"_shouldAddTrailingSlash",value:function(e){return this.config.usesTrailingSlash&&!e.endsWith("/")&&!this.regex.fileExt.test(e)}},{key:"_isLinkOk",value:function(e){return null!==e&&"object"===(void 0===e?"undefined":r(e))&&(!this.prefetched.has(e.href)&&e.origin===this.config.siteUrl&&-1===e.href.indexOf("?")&&-1===e.href.indexOf("#")&&!this.regex.excludeUris.test(e.href)&&!this.regex.images.test(e.href))}}],[{key:"run",value:function(){"undefined"!=typeof RocketPreloadLinksConfig&&new n(new RocketBrowserCompatibilityChecker({capture:!0,passive:!0}),RocketPreloadLinksConfig).init()}}]),n}();t.run();
+}());
+</script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-includes/js/imagesloaded.min.js?ver=4.1.4' id='imagesloaded-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/themes/maxbizz/js/jquery.isotope.min.js?ver=20200716' id='isotope-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/themes/maxbizz/js/lightgallery-all.min.js?ver=20200716' id='lightgallery-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/themes/maxbizz/js/owl.carousel.min.js?ver=20200716' id='owl-slider-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/themes/maxbizz/js/easypiechart.min.js?ver=20200716' id='easypiechart-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/themes/maxbizz/js/jquery.countdown.min.js?ver=20180910' id='countdown-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/themes/maxbizz/js/elementor.js?ver=20200716' id='maxbizz-elementor-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/themes/maxbizz/js/elementor-header.js?ver=20200716' id='maxbizz-elementor-header-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/themes/maxbizz/js/scripts.js?ver=20200716' id='maxbizz-scripts-js'></script>
+<script type='text/javascript' id='happy-elementor-addons-js-extra'>
+/* <![CDATA[ */
+var HappyLocalize = {"ajax_url":"https:\/\/news.edbmauritius.org\/wp-admin\/admin-ajax.php","nonce":"0645b0e76d"};
+/* ]]> */
+</script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/plugins/happy-elementor-addons/assets/js/happy-addons.min.js?ver=2.24.0' id='happy-elementor-addons-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-includes/js/wp-embed.min.js?ver=5.8' id='wp-embed-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/js/webpack.runtime.min.js?ver=3.2.2' id='elementor-webpack-runtime-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/js/frontend-modules.min.js?ver=3.2.2' id='elementor-frontend-modules-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/lib/waypoints/waypoints.min.js?ver=4.0.2' id='elementor-waypoints-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-includes/js/jquery/ui/core.min.js?ver=1.12.1' id='jquery-ui-core-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/lib/swiper/swiper.min.js?ver=5.3.6' id='swiper-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/lib/share-link/share-link.min.js?ver=3.2.2' id='share-link-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/lib/dialog/dialog.min.js?ver=4.8.1' id='elementor-dialog-js'></script>
+<script type='text/javascript' id='elementor-frontend-js-before'>
+var elementorFrontendConfig = {"environmentMode":{"edit":false,"wpPreview":false,"isScriptDebug":false},"i18n":{"shareOnFacebook":"Share on Facebook","shareOnTwitter":"Share on Twitter","pinIt":"Pin it","download":"Download","downloadImage":"Download image","fullscreen":"Fullscreen","zoom":"Zoom","share":"Share","playVideo":"Play Video","previous":"Previous","next":"Next","close":"Close"},"is_rtl":false,"breakpoints":{"xs":0,"sm":480,"md":768,"lg":1025,"xl":1440,"xxl":1600},"responsive":{"breakpoints":{"mobile":{"label":"Mobile","value":767,"direction":"max","is_enabled":true},"mobile_extra":{"label":"Mobile Extra","value":880,"direction":"max","is_enabled":false},"tablet":{"label":"Tablet","value":1024,"direction":"max","is_enabled":true},"tablet_extra":{"label":"Tablet Extra","value":1365,"direction":"max","is_enabled":false},"laptop":{"label":"Laptop","value":1620,"direction":"max","is_enabled":false},"widescreen":{"label":"Widescreen","value":2400,"direction":"min","is_enabled":false}}},"version":"3.2.2","is_static":false,"experimentalFeatures":[],"urls":{"assets":"https:\/\/news.edbmauritius.org\/wp-content\/plugins\/elementor\/assets\/"},"settings":{"page":[],"editorPreferences":[]},"kit":{"active_breakpoints":["viewport_mobile","viewport_tablet"],"global_image_lightbox":"yes","lightbox_enable_counter":"yes","lightbox_enable_fullscreen":"yes","lightbox_enable_zoom":"yes","lightbox_enable_share":"yes","lightbox_title_src":"title","lightbox_description_src":"description"},"post":{"id":2047,"title":"THE%20NEW%20PREMIUM%20VISA%20%E2%80%93%20Economic%20Development%20Board%20Mauritius","excerpt":"","featuredImage":"https:\/\/news.edbmauritius.org\/wp-content\/uploads\/2021\/02\/Banner-1.jpg"}};
+</script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/js/frontend.min.js?ver=3.2.2' id='elementor-frontend-js'></script>
+<script type='text/javascript' src='https://news.edbmauritius.org/wp-content/plugins/elementor/assets/js/preloaded-modules.min.js?ver=3.2.2' id='preloaded-modules-js'></script>
+<style>@media (max-width: 1200px) {
+				.novashare-floating {
+					
+					
+					top: auto;
+	  				bottom: 0;
+	  				left: 0;
+	  				right: 0;
+	  				padding: 10px 5px 0px 5px;
+	  				height: auto;
+	  				
+				}
+				.novashare-floating .novashare-buttons-wrapper {
+					flex-direction: row;
+					justify-content: center;
+				}
+				.novashare-floating a.novashare-button {
+					margin: 0px 5px 10px 5px;
+				}
+				.novashare-floating .novashare-total-share-count {
+					margin: 0px 5px 10px 5px;
+				}
+
+			}</style><style>body .novashare-buttons.novashare-floating .novashare-button-icon { width: 100%; }</style><div class='novashare-buttons novashare-floating novashare-no-print'><div class='novashare-buttons-wrapper'><a href='https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnews.edbmauritius.org%2F2021-january-the-new-premium-visa%2F' aria-label='Facebook' target='_blank' class='novashare-button facebook' rel='nofollow noopener noreferrer'><span class='novashare-button-wrapper novashare-button-block novashare-rounded'><span class='novashare-button-icon novashare-button-block'><svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M279.14 288l14.22-92.66h-88.91v-60.13c0-25.35 12.42-50.06 52.24-50.06h40.42V6.26S260.43 0 225.36 0c-73.22 0-121.08 44.38-121.08 124.72v70.62H22.89V288h81.39v224h100.17V288z"></path></svg></span></span></a><a href='https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fnews.edbmauritius.org%2F2021-january-the-new-premium-visa%2F' aria-label='LinkedIn' target='_blank' class='novashare-button linkedin' rel='nofollow noopener noreferrer'><span class='novashare-button-wrapper novashare-button-block novashare-rounded'><span class='novashare-button-icon novashare-button-block'><svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M100.28 448H7.4V148.9h92.88zM53.79 108.1C24.09 108.1 0 83.5 0 53.8a53.79 53.79 0 0 1 107.58 0c0 29.7-24.1 54.3-53.79 54.3zM447.9 448h-92.68V302.4c0-34.7-.7-79.2-48.29-79.2-48.29 0-55.69 37.7-55.69 76.7V448h-92.78V148.9h89.08v40.8h1.3c12.4-23.5 42.69-48.3 87.88-48.3 94 0 111.28 61.9 111.28 142.3V448z"></path></svg></span></span></a><a href='https://twitter.com/intent/tweet?text=THE%20NEW%20PREMIUM%20VISA&url=https%3A%2F%2Fnews.edbmauritius.org%2F2021-january-the-new-premium-visa%2F' aria-label='Twitter' target='_blank' class='novashare-button twitter' rel='nofollow noopener noreferrer'><span class='novashare-button-wrapper novashare-button-block novashare-rounded'><span class='novashare-button-icon novashare-button-block'><svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"></path></svg></span></span></a><a href='https://api.whatsapp.com/send?text=THE%20NEW%20PREMIUM%20VISA+https%3A%2F%2Fnews.edbmauritius.org%2F2021-january-the-new-premium-visa%2F' aria-label='WhatsApp' target='_blank' class='novashare-button whatsapp' rel='nofollow noopener noreferrer'><span class='novashare-button-wrapper novashare-button-block novashare-rounded'><span class='novashare-button-icon novashare-button-block'><svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path fill="currentColor" d="M380.9 97.1C339 55.1 283.2 32 223.9 32c-122.4 0-222 99.6-222 222 0 39.1 10.2 77.3 29.6 111L0 480l117.7-30.9c32.4 17.7 68.9 27 106.1 27h.1c122.3 0 224.1-99.6 224.1-222 0-59.3-25.2-115-67.1-157zm-157 341.6c-33.2 0-65.7-8.9-94-25.7l-6.7-4-69.8 18.3L72 359.2l-4.4-7c-18.5-29.4-28.2-63.3-28.2-98.2 0-101.7 82.8-184.5 184.6-184.5 49.3 0 95.6 19.2 130.4 54.1 34.8 34.9 56.2 81.2 56.1 130.5 0 101.8-84.9 184.6-186.6 184.6zm101.2-138.2c-5.5-2.8-32.8-16.2-37.9-18-5.1-1.9-8.8-2.8-12.5 2.8-3.7 5.6-14.3 18-17.6 21.8-3.2 3.7-6.5 4.2-12 1.4-32.6-16.3-54-29.1-75.5-66-5.7-9.8 5.7-9.1 16.3-30.3 1.8-3.7.9-6.9-.5-9.7-1.4-2.8-12.5-30.1-17.1-41.2-4.5-10.8-9.1-9.3-12.5-9.5-3.2-.2-6.9-.2-10.6-.2-3.7 0-9.7 1.4-14.8 6.9-5.1 5.6-19.4 19-19.4 46.3 0 27.3 19.9 53.7 22.6 57.4 2.8 3.7 39.1 59.7 94.8 83.8 35.2 15.2 49 16.5 66.6 13.9 10.7-1.6 32.8-13.4 37.4-26.4 4.6-13 4.6-24.1 3.2-26.4-1.3-2.5-5-3.9-10.5-6.6z"></path></svg></span></span></a><a href='mailto:?subject=THE%20NEW%20PREMIUM%20VISA&amp;body=https%3A%2F%2Fnews.edbmauritius.org%2F2021-january-the-new-premium-visa%2F' aria-label='Email' target='_self' class='novashare-button email' rel='nofollow noopener noreferrer'><span class='novashare-button-wrapper novashare-button-block novashare-rounded'><span class='novashare-button-icon novashare-button-block'><svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M502.3 190.8c3.9-3.1 9.7-.2 9.7 4.7V400c0 26.5-21.5 48-48 48H48c-26.5 0-48-21.5-48-48V195.6c0-5 5.7-7.8 9.7-4.7 22.4 17.4 52.1 39.5 154.1 113.6 21.1 15.4 56.7 47.8 92.2 47.6 35.7.3 72-32.8 92.3-47.6 102-74.1 131.6-96.3 154-113.7zM256 320c23.2.4 56.6-29.2 73.4-41.4 132.7-96.3 142.8-104.7 173.4-128.7 5.8-4.5 9.2-11.5 9.2-18.9v-19c0-26.5-21.5-48-48-48H48C21.5 64 0 85.5 0 112v19c0 7.4 3.4 14.3 9.2 18.9 30.6 23.9 40.7 32.4 173.4 128.7 16.8 12.2 50.2 41.8 73.4 41.4z"></path></svg></span></span></a><a href='https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fnews.edbmauritius.org%2F2021-january-the-new-premium-visa%2F' aria-label='Messenger' target='_blank' class='novashare-button messenger' rel='nofollow noopener noreferrer'><span class='novashare-button-wrapper novashare-button-block novashare-rounded'><span class='novashare-button-icon novashare-button-block'><svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M256.55 8C116.52 8 8 110.34 8 248.57c0 72.3 29.71 134.78 78.07 177.94 8.35 7.51 6.63 11.86 8.05 58.23A19.92 19.92 0 0 0 122 502.31c52.91-23.3 53.59-25.14 62.56-22.7C337.85 521.8 504 423.7 504 248.57 504 110.34 396.59 8 256.55 8zm149.24 185.13l-73 115.57a37.37 37.37 0 0 1-53.91 9.93l-58.08-43.47a15 15 0 0 0-18 0l-78.37 59.44c-10.46 7.93-24.16-4.6-17.11-15.67l73-115.57a37.36 37.36 0 0 1 53.91-9.93l58.06 43.46a15 15 0 0 0 18 0l78.41-59.38c10.44-7.98 24.14 4.54 17.09 15.62z"></path></svg></span></span></a><a href='sms:?&body=THE%20NEW%20PREMIUM%20VISA%20https%3A%2F%2Fnews.edbmauritius.org%2F2021-january-the-new-premium-visa%2F' aria-label='SMS' target='_self' class='novashare-button sms' rel='nofollow noopener noreferrer'><span class='novashare-button-wrapper novashare-button-block novashare-rounded'><span class='novashare-button-icon novashare-button-block'><svg role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M256 32C114.6 32 0 125.1 0 240c0 49.6 21.4 95 57 130.7C44.5 421.1 2.7 466 2.2 466.5c-2.2 2.3-2.8 5.7-1.5 8.7S4.8 480 8 480c66.3 0 116-31.8 140.6-51.4 32.7 12.3 69 19.4 107.4 19.4 141.4 0 256-93.1 256-208S397.4 32 256 32z"></path></svg></span></span></a></div></div>
+</body>
+</html>
+<!-- This website is like a Rocket, isn't it? Performance optimized by WP Rocket. Learn more: https://wp-rocket.me - Debug: cached@1692945328 -->

--- a/sources/MU_PREMIUM_EDB_2026-06-15.html.meta.json
+++ b/sources/MU_PREMIUM_EDB_2026-06-15.html.meta.json
@@ -1,0 +1,7 @@
+{
+  "source_id": "MU_PREMIUM_EDB_2026",
+  "url": "https://news.edbmauritius.org/2021-january-the-new-premium-visa/",
+  "retrieved_at": "2026-06-15T00:00:00Z",
+  "sha256": "b5e3e6a4a9731080eba4a8f3e5d4104a6449712bf2ec18763f05b301c885632e",
+  "local_path": "sources/MU_PREMIUM_EDB_2026-06-15.html"
+}

--- a/tools/build_content_hubs.py
+++ b/tools/build_content_hubs.py
@@ -433,6 +433,20 @@ VISA_FAQS = {
             "answer": "Yes. The policy must be valid for the same period as the visa, so a full-period policy is required; a month-to-month subscription that can lapse does not assure this.",
         },
     ],
+    "MU_PREMIUM_EDB_2026": [
+        {
+            "question": "What insurance does the Mauritius Premium Visa require?",
+            "answer": "The Economic Development Board states that to qualify for the Premium Visa, the applicant must have proof of long stay plans and travel and health insurance for the initial period of stay.",
+        },
+        {
+            "question": "Is there a minimum amount or territory requirement?",
+            "answer": "The published eligibility statement names travel and health insurance but states no coverage amount or territory, so the engine models only that insurance is mandatory.",
+        },
+        {
+            "question": "Which products show GREEN?",
+            "answer": "Because the only modeled requirement is that insurance is mandatory, every tracked product that provides travel or health insurance shows GREEN. Confirm the specific terms with the Economic Development Board.",
+        },
+    ],
 }
 
 RELATED_POSTS = {
@@ -578,6 +592,11 @@ RELATED_POSTS = {
     "EC_NOMAD_CANCILLERIA_2026": [
         ("/posts/ecuador-nomad-insurance/", "Ecuador digital nomad visa insurance requirements"),
         ("/posts/digital-nomad-insurance-americas/", "Digital nomad insurance in the Americas"),
+        ("/guides/how-to-read-results/", "How to read compliance results"),
+    ],
+    "MU_PREMIUM_EDB_2026": [
+        ("/posts/mauritius-premium-visa-insurance/", "Mauritius Premium Visa insurance requirements"),
+        ("/posts/digital-nomad-insurance-asia/", "Digital nomad insurance in Asia and beyond"),
         ("/guides/how-to-read-results/", "How to read compliance results"),
     ],
 }

--- a/tools/editorial_targets.json
+++ b/tools/editorial_targets.json
@@ -290,5 +290,13 @@
   "content/posts/ecuador-nomad-insurance.md": [
     450,
     1200
+  ],
+  "content/visas/mauritius/premium-visa/premium-visa-economic-development-board/index.md": [
+    900,
+    1400
+  ],
+  "content/posts/mauritius-premium-visa-insurance.md": [
+    450,
+    1200
   ]
 }


### PR DESCRIPTION
## Summary
- New route **MU_PREMIUM_EDB_2026** — Mauritius Premium Visa
- Primary source (byte-exact, sha256-validated): Economic Development Board of Mauritius eligibility statement (edbmauritius.org)
- Rule encoded verbatim only: `insurance.mandatory` ("must have proof of his/her long stay plans and travel and health insurance for the initial period of stay")
- No amount, period or territory stated, so none encoded (UNKNOWN > Wrong)

## Mapping outcomes
All tracked products **GREEN** (only the mandatory rule is modeled). No existing mapping changed.

## Content
- Hub: /visas/mauritius/premium-visa/premium-visa-economic-development-board/
- Post: /posts/mauritius-premium-visa-insurance/ (dated 2026-06-13, past in UTC)
- Affiliate: Genki Traveler paid link, after results only

## Gates
All gates + ui_compliance_tests.ps1 + mapping_engine_tests.ps1 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)