### PR TITLE
🎨 Palette: Form and Menu Accessibility Improvements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Form Accessibility in Flex-col Layouts
+**Learning:** Input labels in ui/index.html without explicit for attributes fail to trigger corresponding input elements, which is especially problematic in flex-col layouts where labels and inputs are visually separated. Screen readers also miss hint texts if aria-describedby isn't used.
+**Action:** Always include explicit for attributes on <label> elements matching input IDs, and use aria-describedby on inputs referencing their helper text elements.

--- a/ui/index.html
+++ b/ui/index.html
@@ -109,7 +109,7 @@
         <span class="material-symbols-outlined text-primary text-3xl icon-filled">verified_user</span>
         <span class="text-text-primary dark:text-white text-xl font-bold tracking-tight">VisaFact</span>
       </div>
-      <button id="mobileMenuBtn"
+      <button id="mobileMenuBtn" aria-expanded="false" aria-controls="mobileMenu"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
         aria-label="Toggle menu">
         <span class="material-symbols-outlined text-2xl">menu</span>
@@ -183,12 +183,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -200,12 +200,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select an insurance product</option>
             </select>
@@ -1178,6 +1178,7 @@
       const btn = $("mobileMenuBtn");
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
+      btn.setAttribute("aria-expanded", String(!isOpen));
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
     });
 


### PR DESCRIPTION
💡 **What:**
- Added explicit `for` attributes to labels for the "I am applying for" and "I want to use" select inputs.
- Added `aria-describedby` attributes to both select inputs pointing to their respective hint texts.
- Added `aria-expanded="false"` and `aria-controls="mobileMenu"` to the mobile menu button (`#mobileMenuBtn`).
- Updated the JavaScript click handler for the mobile menu button to dynamically toggle the `aria-expanded` attribute based on the menu's visibility state.
- Logged a critical UX learning about flex-col layout accessibility in `.jules/palette.md`.

🎯 **Why:**
- In visually separated layouts like `flex-col`, implicit labels (wrapping the input) are often insufficient, and screen readers may fail to associate the label text with the input. Explicit `for` attributes ensure rock-solid association.
- Hint text below inputs is ignored by screen readers unless explicitly linked via `aria-describedby`.
- The icon-only mobile menu toggle lacked screen reader state management, leaving users unaware of the menu's visibility or the button's purpose beyond its basic ARIA label.
- These micro-interactions adhere strictly to the established design, using no new custom CSS or libraries, and drastically improve the experience for users relying on assistive technologies.

♿ **Accessibility:**
- Ensures form fields have correctly bound labels and hint text.
- Provides dynamic state tracking for the responsive mobile menu.

---
*PR created automatically by Jules for task [18177966359235602130](https://jules.google.com/task/18177966359235602130) started by @W73QB*