### PR TITLE
feat(route): add Belgium national-entry (visa D) route (evidence-based)

### DIFF
--- a/content/posts/belgium-national-d-insurance.md
+++ b/content/posts/belgium-national-d-insurance.md
@@ -1,0 +1,104 @@
+---
+title: "Belgium national entry (visa D) insurance requirements (evidence-based)"
+date: 2026-06-13
+description: "Evidence-based summary of the health insurance requirement for Belgium's national entry (visa D) categories: health insurance covering all risks in Belgium, per the Immigration Office."
+tags: ["belgium", "national-visa", "visa-d", "insurance", "compliance"]
+faq:
+  - question: "What insurance does a Belgium national entry (visa D) require?"
+    answer: "The Immigration Office requires proof of health insurance covering all risks in Belgium; the example proof named is a certificate of registration with a healthcare fund."
+  - question: "Why is only Genki Native GREEN for this route?"
+    answer: "The policy must cover all risks in Belgium. Genki Native documents global comprehensive coverage that includes Belgium; the other products do not document Belgium all-risk coverage, so the engine records UNKNOWN rather than assuming a foreign policy qualifies."
+  - question: "Is registration with a Belgian healthcare fund required?"
+    answer: "The source names a certificate of registration with a healthcare fund as the example proof. Confirm with the Immigration Office which proof is accepted in your category."
+---
+
+## Short answer
+
+Belgium's national entry (visa D) categories require proof of health insurance covering all risks in Belgium, with the example proof named being a certificate of registration with a healthcare fund (Source: `BE_NATIONALD_DOFI_2026`, Immigration Office of Belgium; verified 2026-06-13). The engine models three rules: insurance is mandatory, it must cover risks in Belgium, and it must be comprehensive (all risks).
+
+## Key findings at a glance
+
+| Item | Value |
+|---|---|
+| Route | Belgium National Entry (Visa D) |
+| Authority | Immigration Office of Belgium (Office des Etrangers / DVZ) |
+| Evidence verified | 2026-06-13 |
+| Snapshot | 2026-06-13 |
+| Modeled rules | Insurance mandatory; covers all risks in Belgium; comprehensive |
+
+## What the authority requires
+
+- Proof of health insurance is a required document for the national entry categories. (Source: `BE_NATIONALD_DOFI_2026`; verified 2026-06-13)
+- The insurance must cover all risks in Belgium. (Source: `BE_NATIONALD_DOFI_2026`; verified 2026-06-13)
+- The example proof named is a certificate of registration with a healthcare fund. (Source: `BE_NATIONALD_DOFI_2026`)
+
+Normalized requirements table:
+
+| Requirement | Source URL | Locator | Verified date |
+|---|---|---|---|
+| Insurance is mandatory | https://dofi.ibz.be/en/themes/faq/long-stay/national-entries-visa-d | National entries (visa D), supporting documents | 2026-06-13 |
+| Covers all risks in Belgium | https://dofi.ibz.be/en/themes/faq/long-stay/national-entries-visa-d | National entries (visa D), supporting documents | 2026-06-13 |
+| Comprehensive (all risks) | https://dofi.ibz.be/en/themes/faq/long-stay/national-entries-visa-d | National entries (visa D), supporting documents | 2026-06-13 |
+
+## Verified requirements (PASS/FAIL/UNKNOWN)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Insurance is mandatory | PASS | Immigration Office national-entries documents |
+| Covers all risks in Belgium | PASS only for products documenting Belgium coverage; UNKNOWN otherwise | "health insurance covering all risks in Belgium" |
+| Comprehensive (all risks) | PASS for products documenting comprehensive cover; UNKNOWN otherwise | "covering all risks in Belgium" |
+
+## How we evaluate
+
+The checker compares each modeled requirement against product evidence. Three rules are encoded from the Immigration Office page: insurance is mandatory, it must cover all risks in Belgium, and it must be comprehensive. A product is only credited with Belgium coverage and comprehensiveness when its own documentation states them; the engine does not assume a worldwide or home-country policy is valid there. Products silent about Belgium all-risk coverage stay UNKNOWN rather than GREEN, following the UNKNOWN > Wrong principle.
+
+An important nuance, disclosed rather than over-modeled: the source names a certificate of registration with a Belgian healthcare fund as the example proof. Confirm with the Immigration Office which proof is accepted for your specific category; the engine does not assume any tracked product is registered with a Belgian fund. See /methodology/ for the full logic.
+
+## Proof package checklist
+
+- Health insurance documented to cover all risks in Belgium.
+- Where required, a certificate of registration with a Belgian healthcare fund.
+- Confirmation of the accepted proof for your specific national-entry category.
+
+## FAQ
+
+**Q: What is required?**
+**A:** Health insurance covering all risks in Belgium (Source: `BE_NATIONALD_DOFI_2026`; verified 2026-06-13).
+
+**Q: Why is only Genki Native GREEN?**
+**A:** It documents global comprehensive coverage including Belgium; the others do not state Belgium all-risk coverage, so they are UNKNOWN.
+
+**Q: Is a Belgian healthcare-fund registration required?**
+**A:** It is the example proof named; confirm the accepted proof with the Immigration Office for your category.
+
+## Check in the engine
+
+Use [the compliance checker](/ui/) with the current snapshot for this route:
+
+{{< checker_cta visa="BE_NATIONALD_DOFI_2026" product="GENKI_NATIVE_2026" snapshot="2026-06-13" >}}
+
+## Related reading
+
+- [Belgium national entry (visa D) requirements (route page)](/visas/belgium/national-entry-visa-d/national-entries-visa-d-health-insurance-immigration-office/)
+- [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## Where to find compliant insurance for a Belgium national entry (visa D)
+
+The official requirement is health insurance covering all risks in Belgium. In the current snapshot, Genki Native shows GREEN: it documents global comprehensive coverage that includes Belgium. The travel-medical and Spanish products show UNKNOWN because their documents do not state all-risk coverage in Belgium. Confirm with the Immigration Office whether a certificate of registration with a healthcare fund is required for your category.
+
+- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+
+> Use the compliance checker to confirm the current GREEN products for this route before you buy.
+
+## Disclaimer + Affiliate disclosure
+
+Not legal advice. Compliance results are evidence-based snapshots.
+
+If an affiliate link is present, it appears only after results and does not change the compliance outcome. The Genki link above is a paid affiliate link.
+
+Last updated: 2026-06-13
+
+## Evidence log
+
+- Source: BE_NATIONALD_DOFI_2026

--- a/content/visas/belgium/national-entry-visa-d/_index.md
+++ b/content/visas/belgium/national-entry-visa-d/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Belgium National Entry (Visa D)"
+visa_group: "belgium-national-entry-visa-d"
+description: "Insurance requirements for Belgium National Entry (Visa D) - evidence-based compliance checker"
+---
+
+## Belgium National Entry (Visa D) Requirements
+
+All requirements below are derived from official sources. Missing evidence means UNKNOWN.
+
+## Routes
+
+| Authority | Route | Last Verified | Details |
+| --- | --- | --- | --- |
+| Immigration Office of Belgium (Office des Etrangers / DVZ) | National entries visa D, health insurance (Immigration Office) | 2026-06-15 | [View requirements](/visas/belgium/national-entry-visa-d/national-entries-visa-d-health-insurance-immigration-office/) |
+
+## What the authority requires
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+## How we evaluate
+
+We compare these official requirements against insurance product specifications using our automated rule engine. Each requirement is matched to a product fact with evidence.
+
+## Check in the engine
+
+Try the compliance checker: [Open Checker](/ui/?visa=BE_NATIONALD_DOFI_2026&snapshot=2026-06-13)
+
+## Disclaimer
+
+This is not legal advice. VisaFact provides evidence-based compliance checking only. Final visa decisions are made by government authorities. A GREEN result does not ensure visa approval.
+
+## Affiliate disclosure
+
+If affiliate links appear, they are shown only after compliance results and do not influence the compliance evaluation in any way.
+
+## Evidence log
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+
+{{< checker_cta visa="BE_NATIONALD_DOFI_2026" snapshot="2026-06-13" >}}

--- a/content/visas/belgium/national-entry-visa-d/national-entries-visa-d-health-insurance-immigration-office/index.md
+++ b/content/visas/belgium/national-entry-visa-d/national-entries-visa-d-health-insurance-immigration-office/index.md
@@ -1,0 +1,105 @@
+---
+title: "Belgium National Entry (Visa D) - National entries visa D, health insurance (Immigration Office)"
+visa_id: "BE_NATIONALD_DOFI_2026"
+last_verified: "2026-06-15"
+source_ids: ["BE_NATIONALD_DOFI_2026"]
+description: "Official insurance requirements for Belgium National Entry (Visa D) via National entries visa D, health insurance (Immigration Office)"
+faq:
+  - question: "What insurance does a Belgium national entry (visa D) require?"
+    answer: "The Immigration Office requires proof of health insurance covering all risks in Belgium; the example proof named is a certificate of registration with a healthcare fund."
+  - question: "Why is only Genki Native GREEN for this route?"
+    answer: "The policy must cover all risks in Belgium. Genki Native documents global comprehensive coverage that includes Belgium; the other products do not document Belgium all-risk coverage, so the engine records UNKNOWN rather than assuming a foreign policy qualifies."
+  - question: "Is registration with a Belgian healthcare fund required?"
+    answer: "The source names a certificate of registration with a healthcare fund as the example proof. Confirm with the Immigration Office which proof is accepted in your category; the engine models the all-risks-in-Belgium requirement and does not assume any tracked product is registered with a Belgian fund."
+---
+
+## Belgium National Entry (Visa D)
+
+**Route:** National entries visa D, health insurance (Immigration Office)  
+**Authority:** Immigration Office of Belgium (Office des Etrangers / DVZ)  
+**Last Verified:** 2026-06-15
+
+## Requirements
+
+| Requirement | Operator | Value | Evidence |
+| --- | --- | --- | --- |
+| `insurance.mandatory` | `==` | Yes | *National entries (visa D), category B40/B41, supporting documents*: "proof that he has health insurance covering all risks in Belgium (certificate of..." ([source](/sources/BE_NATIONALD_DOFI_2026-06-15.html)) |
+| `insurance.authorized_in_country` | `==` | Yes | *National entries (visa D), category B40/B41, supporting documents*: "health insurance covering all risks in Belgium..." ([source](/sources/BE_NATIONALD_DOFI_2026-06-15.html)) |
+| `insurance.comprehensive` | `==` | Yes | *National entries (visa D), category B40/B41, supporting documents*: "health insurance covering all risks in Belgium..." ([source](/sources/BE_NATIONALD_DOFI_2026-06-15.html)) |
+
+## Source Documents
+
+- **BE_NATIONALD_DOFI_2026**: [Local copy](/sources/BE_NATIONALD_DOFI_2026-06-15.html) | [Original](https://dofi.ibz.be/en/themes/faq/long-stay/national-entries-visa-d) | Retrieved: 2026-06-15
+
+## Related reading
+
+- [Belgium national entry (visa D) insurance requirements](/posts/belgium-national-d-insurance/)
+- [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## What the authority requires
+
+The points below are taken directly from the official source for the Belgium National Entry (Visa D) (National entries visa D, health insurance (Immigration Office)) route. Each one is recorded with a source identifier and a locator so it can be traced back to the original document. Where the source is silent on a point, the engine records UNKNOWN instead of inferring an answer.
+
+- The authority requires that insurance is mandatory.
+- The authority requires that authorized in country.
+- The authority requires that the coverage is comprehensive.
+
+## How we evaluate
+
+Every requirement is compared against the documented specification of each insurance product using an automated rule engine. A product is marked GREEN for a requirement only when product evidence explicitly satisfies it; a conflict produces RED; and absent evidence produces UNKNOWN rather than a guess. The route status is the combination of its per-requirement outcomes.
+
+- Rule `insurance.mandatory == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+- Rule `insurance.authorized_in_country == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+- Rule `insurance.comprehensive == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+
+## How each compliance status is decided for this route
+
+GREEN means every recorded requirement is satisfied by product evidence. RED means at least one requirement is contradicted by the product evidence. YELLOW means the evidence is partial: some requirements are met while others lack full proof. UNKNOWN means a requirement exists but the product evidence does not address it, so no claim is made. NOT_REQUIRED means the authority does not impose an insurance requirement for the route, which is itself an evidence-based finding drawn from the official document. A GREEN result reflects the evidence on the snapshot date and is not an assurance of a visa outcome, which always rests with the issuing authority.
+
+## Reading the evidence and snapshots
+
+Each requirement above links to a primary source through a source identifier and a locator (for example a page number, article, or section). The underlying documents are listed under Source Documents and are stored alongside this dataset so the wording can be checked directly. Results are tied to a dated snapshot (`2026-06-13`): a deep link to a past snapshot returns the same verdict even if the authority later changes its rules, which keeps every decision reproducible and auditable.
+
+## Proof package checklist
+
+Before applying for this route, prepare the following so the policy can be checked against each requirement:
+
+- A policy certificate that states the coverage limits, any deductible or co-payment, and the covered period.
+- Written confirmation of the insurer's status where the route requires authorization in a specific country.
+- Documentation that the coverage spans the full authorized stay rather than a partial term.
+- The official source wording for the route, so each clause can be matched to the requirements above.
+
+## Common questions
+
+**What insurance does a Belgium national entry (visa D) require?**  
+The Immigration Office requires proof of health insurance covering all risks in Belgium; the example proof named is a certificate of registration with a healthcare fund.
+
+**Why is only Genki Native GREEN for this route?**  
+The policy must cover all risks in Belgium. Genki Native documents global comprehensive coverage that includes Belgium; the other products do not document Belgium all-risk coverage, so the engine records UNKNOWN rather than assuming a foreign policy qualifies.
+
+**Is registration with a Belgian healthcare fund required?**  
+The source names a certificate of registration with a healthcare fund as the example proof. Confirm with the Immigration Office which proof is accepted in your category; the engine models the all-risks-in-Belgium requirement and does not assume any tracked product is registered with a Belgian fund.
+
+## Check in the engine
+
+Run a specific product against this route in the compliance checker: [Open Checker](/ui/?visa=BE_NATIONALD_DOFI_2026&snapshot=2026-06-13). The checker shows the per-requirement outcome and the evidence behind each one.
+
+## Disclaimer
+
+This page is not legal advice. VisaFact provides evidence-based compliance checking only, and final visa decisions are made by government authorities. A GREEN result reflects documented evidence on the snapshot date; it does not ensure that a visa application will succeed. Always confirm the current requirements with the issuing authority before submitting an application.
+
+## Affiliate disclosure
+
+If affiliate links appear on related pages, they are shown only after the compliance result and never change the evaluation, which is generated independently from the official evidence.
+
+## Evidence log
+
+Each entry pairs a requirement with the source identifier and locator it was drawn from:
+
+- `insurance.mandatory` <- BE_NATIONALD_DOFI_2026 (National entries (visa D), category B40/B41, supporting documents): "proof that he has health insurance covering all risks in Belgium (certificate of registration with a"
+- `insurance.authorized_in_country` <- BE_NATIONALD_DOFI_2026 (National entries (visa D), category B40/B41, supporting documents): "health insurance covering all risks in Belgium"
+- `insurance.comprehensive` <- BE_NATIONALD_DOFI_2026 (National entries (visa D), category B40/B41, supporting documents): "health insurance covering all risks in Belgium"
+
+
+{{< checker_cta visa="BE_NATIONALD_DOFI_2026" snapshot="2026-06-13" >}}

--- a/data/mappings/BE_NATIONALD_DOFI_2026__ASISA_HEALTH_RESIDENTS_2026.json
+++ b/data/mappings/BE_NATIONALD_DOFI_2026__ASISA_HEALTH_RESIDENTS_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "BE_NATIONALD_DOFI_2026",
+  "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.BE.authorized"
+  ]
+}

--- a/data/mappings/BE_NATIONALD_DOFI_2026__DKV_VISADO_2026.json
+++ b/data/mappings/BE_NATIONALD_DOFI_2026__DKV_VISADO_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "BE_NATIONALD_DOFI_2026",
+  "product_id": "DKV_VISADO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.BE.authorized"
+  ]
+}

--- a/data/mappings/BE_NATIONALD_DOFI_2026__GENERIC_EXPAT_COMPLETE_2026.json
+++ b/data/mappings/BE_NATIONALD_DOFI_2026__GENERIC_EXPAT_COMPLETE_2026.json
@@ -1,0 +1,10 @@
+{
+  "visa_id": "BE_NATIONALD_DOFI_2026",
+  "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.BE.authorized",
+    "specs.comprehensive"
+  ]
+}

--- a/data/mappings/BE_NATIONALD_DOFI_2026__GENKI_NATIVE_2026.json
+++ b/data/mappings/BE_NATIONALD_DOFI_2026__GENKI_NATIVE_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "BE_NATIONALD_DOFI_2026",
+  "product_id": "GENKI_NATIVE_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/BE_NATIONALD_DOFI_2026__GENKI_TRAVELER_2026.json
+++ b/data/mappings/BE_NATIONALD_DOFI_2026__GENKI_TRAVELER_2026.json
@@ -1,0 +1,10 @@
+{
+  "visa_id": "BE_NATIONALD_DOFI_2026",
+  "product_id": "GENKI_TRAVELER_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.BE.authorized",
+    "specs.comprehensive"
+  ]
+}

--- a/data/mappings/BE_NATIONALD_DOFI_2026__SAFETYWING_NOMAD_2026.json
+++ b/data/mappings/BE_NATIONALD_DOFI_2026__SAFETYWING_NOMAD_2026.json
@@ -1,0 +1,10 @@
+{
+  "visa_id": "BE_NATIONALD_DOFI_2026",
+  "product_id": "SAFETYWING_NOMAD_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.BE.authorized",
+    "specs.comprehensive"
+  ]
+}

--- a/data/mappings/BE_NATIONALD_DOFI_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
+++ b/data/mappings/BE_NATIONALD_DOFI_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "BE_NATIONALD_DOFI_2026",
+  "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.BE.authorized"
+  ]
+}

--- a/data/mappings/BE_NATIONALD_DOFI_2026__WORLDNOMADS_EXPLORER_2026.json
+++ b/data/mappings/BE_NATIONALD_DOFI_2026__WORLDNOMADS_EXPLORER_2026.json
@@ -1,0 +1,10 @@
+{
+  "visa_id": "BE_NATIONALD_DOFI_2026",
+  "product_id": "WORLDNOMADS_EXPLORER_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.BE.authorized",
+    "specs.comprehensive"
+  ]
+}

--- a/data/products/Genki/Native/2026-06-08/product_facts.json
+++ b/data/products/Genki/Native/2026-06-08/product_facts.json
@@ -96,6 +96,16 @@
             "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
           }
         ]
+      },
+      "BE": {
+        "authorized": true,
+        "evidence": [
+          {
+            "source_id": "GENKI_NATIVE_COVERAGE_2026",
+            "locator": "Global Coverage",
+            "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
+          }
+        ]
       }
     }
   },

--- a/data/ui_index.json
+++ b/data/ui_index.json
@@ -1,5 +1,5 @@
 {
-  "built_at": "2026-06-15T13:41:46.536450+00:00",
+  "built_at": "2026-06-15T13:46:21.117588+00:00",
   "snapshot_id": "2026-06-15",
   "visas": [
     {
@@ -40,6 +40,61 @@
               "source_id": "AL_LEJE_UNIKE_MB_2026",
               "locator": "Official checklist, insurance requirement (valid for the permit period)",
               "excerpt": "Health-insurance policy valid for at least 1 year."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "BE_NATIONALD_DOFI_2026",
+      "country": "Belgium",
+      "visa_name": "National Entry (Visa D)",
+      "route": "National entries visa D, health insurance (Immigration Office)",
+      "authority": "Immigration Office of Belgium (Office des Etrangers / DVZ)",
+      "last_verified": "2026-06-15",
+      "sources": [
+        {
+          "source_id": "BE_NATIONALD_DOFI_2026",
+          "url": "https://dofi.ibz.be/en/themes/faq/long-stay/national-entries-visa-d",
+          "retrieved_at": "2026-06-15T00:00:00Z",
+          "sha256": "c88285889ac5816b87cda1d1273538e9d69fa09d33274f4e56a614f84a88c4a8",
+          "local_path": "sources/BE_NATIONALD_DOFI_2026-06-15.html"
+        }
+      ],
+      "requirements": [
+        {
+          "key": "insurance.mandatory",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "BE_NATIONALD_DOFI_2026",
+              "locator": "National entries (visa D), category B40/B41, supporting documents",
+              "excerpt": "proof that he has health insurance covering all risks in Belgium (certificate of registration with a healthcare fund)."
+            }
+          ]
+        },
+        {
+          "key": "insurance.authorized_in_country",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "BE_NATIONALD_DOFI_2026",
+              "locator": "National entries (visa D), category B40/B41, supporting documents",
+              "excerpt": "health insurance covering all risks in Belgium"
+            }
+          ]
+        },
+        {
+          "key": "insurance.comprehensive",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "BE_NATIONALD_DOFI_2026",
+              "locator": "National entries (visa D), category B40/B41, supporting documents",
+              "excerpt": "health insurance covering all risks in Belgium"
             }
           ]
         }
@@ -2030,6 +2085,16 @@
                 "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
               }
             ]
+          },
+          "BE": {
+            "authorized": true,
+            "evidence": [
+              {
+                "source_id": "GENKI_NATIVE_COVERAGE_2026",
+                "locator": "Global Coverage",
+                "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
+              }
+            ]
           }
         }
       },
@@ -2275,6 +2340,88 @@
       "reasons": [],
       "missing": [],
       "last_verified": "2026-06-10"
+    },
+    {
+      "visa_id": "BE_NATIONALD_DOFI_2026",
+      "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.BE.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "BE_NATIONALD_DOFI_2026",
+      "product_id": "DKV_VISADO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.BE.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "BE_NATIONALD_DOFI_2026",
+      "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.BE.authorized",
+        "specs.comprehensive"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "BE_NATIONALD_DOFI_2026",
+      "product_id": "GENKI_NATIVE_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "BE_NATIONALD_DOFI_2026",
+      "product_id": "GENKI_TRAVELER_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.BE.authorized",
+        "specs.comprehensive"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "BE_NATIONALD_DOFI_2026",
+      "product_id": "SAFETYWING_NOMAD_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.BE.authorized",
+        "specs.comprehensive"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "BE_NATIONALD_DOFI_2026",
+      "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.BE.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "BE_NATIONALD_DOFI_2026",
+      "product_id": "WORLDNOMADS_EXPLORER_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.BE.authorized",
+        "specs.comprehensive"
+      ],
+      "last_verified": ""
     },
     {
       "visa_id": "BH_GOLDEN_NPRA_2026",
@@ -4019,7 +4166,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "KZ_NEONOMAD_EGOV_2026",
@@ -4027,7 +4174,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "KZ_NEONOMAD_EGOV_2026",
@@ -4035,7 +4182,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "KZ_NEONOMAD_EGOV_2026",
@@ -4043,7 +4190,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "KZ_NEONOMAD_EGOV_2026",
@@ -4051,7 +4198,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "KZ_NEONOMAD_EGOV_2026",
@@ -4070,7 +4217,7 @@
         }
       ],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "KZ_NEONOMAD_EGOV_2026",
@@ -4078,7 +4225,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "KZ_NEONOMAD_EGOV_2026",
@@ -4086,7 +4233,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "LK_DNV_IMMIGRATION_2026",
@@ -5355,6 +5502,13 @@
       "retrieved_at": "2026-01-16T00:00:00Z",
       "sha256": "4a1c4e1c4f74fc8ded05482ea171df962320632d846c70bf287ceebc235f36f1",
       "local_path": "sources/ASISA_HEALTH_RESIDENTS_2026-01-16.html"
+    },
+    "BE_NATIONALD_DOFI_2026": {
+      "source_id": "BE_NATIONALD_DOFI_2026",
+      "url": "https://dofi.ibz.be/en/themes/faq/long-stay/national-entries-visa-d",
+      "retrieved_at": "2026-06-15T00:00:00Z",
+      "sha256": "c88285889ac5816b87cda1d1273538e9d69fa09d33274f4e56a614f84a88c4a8",
+      "local_path": "sources/BE_NATIONALD_DOFI_2026-06-15.html"
     },
     "BH_GOLDEN_NPRA_2026": {
       "source_id": "BH_GOLDEN_NPRA_2026",

--- a/data/visas/BE/NATIONALD/dofi/2026-06-15/visa_facts.json
+++ b/data/visas/BE/NATIONALD/dofi/2026-06-15/visa_facts.json
@@ -1,0 +1,55 @@
+{
+  "id": "BE_NATIONALD_DOFI_2026",
+  "country": "Belgium",
+  "visa_name": "National Entry (Visa D)",
+  "route": "National entries visa D, health insurance (Immigration Office)",
+  "authority": "Immigration Office of Belgium (Office des Etrangers / DVZ)",
+  "last_verified": "2026-06-15",
+  "sources": [
+    {
+      "source_id": "BE_NATIONALD_DOFI_2026",
+      "url": "https://dofi.ibz.be/en/themes/faq/long-stay/national-entries-visa-d",
+      "retrieved_at": "2026-06-15T00:00:00Z",
+      "sha256": "c88285889ac5816b87cda1d1273538e9d69fa09d33274f4e56a614f84a88c4a8",
+      "local_path": "sources/BE_NATIONALD_DOFI_2026-06-15.html"
+    }
+  ],
+  "requirements": [
+    {
+      "key": "insurance.mandatory",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "BE_NATIONALD_DOFI_2026",
+          "locator": "National entries (visa D), category B40/B41, supporting documents",
+          "excerpt": "proof that he has health insurance covering all risks in Belgium (certificate of registration with a healthcare fund)."
+        }
+      ]
+    },
+    {
+      "key": "insurance.authorized_in_country",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "BE_NATIONALD_DOFI_2026",
+          "locator": "National entries (visa D), category B40/B41, supporting documents",
+          "excerpt": "health insurance covering all risks in Belgium"
+        }
+      ]
+    },
+    {
+      "key": "insurance.comprehensive",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "BE_NATIONALD_DOFI_2026",
+          "locator": "National entries (visa D), category B40/B41, supporting documents",
+          "excerpt": "health insurance covering all risks in Belgium"
+        }
+      ]
+    }
+  ]
+}

--- a/sources/BE_NATIONALD_DOFI_2026-06-15.html
+++ b/sources/BE_NATIONALD_DOFI_2026-06-15.html
@@ -1,0 +1,797 @@
+<!DOCTYPE html>
+<html  lang="en" dir="ltr" xml:lang="en">
+<head>
+  <meta charset="utf-8" />
+<noscript><style>form.antibot * :not(.antibot-message) { display: none !important; }</style>
+</noscript><meta name="description" content="National entries on a national long-stay visa (more than 90 days). (&quot;Remarks&quot; line) and conditions of stay:" />
+<link rel="canonical" href="https://dofi.ibz.be/en/themes/faq/long-stay/national-entries-visa-d" />
+<meta name="Generator" content="Drupal 10 (https://www.drupal.org)" />
+<meta name="MobileOptimized" content="width" />
+<meta name="HandheldFriendly" content="true" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<link rel="icon" href="/themes/custom/dofi/favicon.ico" type="image/vnd.microsoft.icon" />
+<link rel="alternate" hreflang="nl" href="https://dofi.ibz.be/nl/themes/faq/long-stay/nationale-vermeldingen-visum-d" />
+<link rel="alternate" hreflang="fr" href="https://dofi.ibz.be/fr/themes/faq/long-stay/mentions-nationales-visa-d" />
+<link rel="alternate" hreflang="en" href="https://dofi.ibz.be/en/themes/faq/long-stay/national-entries-visa-d" />
+
+    <title>National entries (visa D) | IBZ</title>
+    <link rel="apple-touch-icon" sizes="120x120" href="/themes/custom/dofi/images/favicons/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/themes/custom/dofi/images/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/themes/custom/dofi/images/favicons/favicon-16x16.png">
+    <link rel="manifest" href="/themes/custom/dofi/images/favicons/manifest.json">
+    <link rel="mask-icon" href="/themes/custom/dofi/images/favicons/safari-pinned-tab.svg" color="#5bbad5">
+    <meta name="msapplication-config" content="/themes/custom/dofi/images/favicons/browserconfig.xml">
+    <meta name="theme-color" content="#ffffff">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <link rel="stylesheet" media="all" href="/sites/default/files/css/css_uOKqntGAWuq7lmnJuwq7vYi9Hditd9KJUGs4cYFseQI.css?delta=0&amp;language=en&amp;theme=dofi&amp;include=eJxFjEEOwzAIwD6EyptIQlZUEiIg2vr77bBpR1uWi1lGOi3sToOf5hc064JUK0dIEZW8gV-pMi9svhfp8UWwaYMipdrExp22JixyenyGZ_zqvzn2XLuoxMkN4o7kgYWC3wX-NQk" />
+<link rel="stylesheet" media="all" href="https://cdn.jsdelivr.net/npm/entreprise7pro-bootstrap@3.4.8/dist/css/bootstrap.min.css" integrity="sha256-zL9fLm9PT7/fK/vb1O9aIIAdm/+bGtxmUm/M1NPTU7Y=" crossorigin="anonymous" />
+<link rel="stylesheet" media="all" href="https://cdn.jsdelivr.net/npm/@unicorn-fail/drupal-bootstrap-styles@0.0.2/dist/3.1.1/7.x-3.x/drupal-bootstrap.min.css" integrity="sha512-nrwoY8z0/iCnnY9J1g189dfuRMCdI5JBwgvzKvwXC4dZ+145UNBUs+VdeG/TUuYRqlQbMlL4l8U3yT7pVss9Rg==" crossorigin="anonymous" />
+<link rel="stylesheet" media="all" href="https://cdn.jsdelivr.net/npm/@unicorn-fail/drupal-bootstrap-styles@0.0.2/dist/3.1.1/8.x-3.x/drupal-bootstrap.min.css" integrity="sha512-jM5OBHt8tKkl65deNLp2dhFMAwoqHBIbzSW0WiRRwJfHzGoxAFuCowGd9hYi1vU8ce5xpa5IGmZBJujm/7rVtw==" crossorigin="anonymous" />
+<link rel="stylesheet" media="all" href="https://cdn.jsdelivr.net/npm/@unicorn-fail/drupal-bootstrap-styles@0.0.2/dist/3.2.0/7.x-3.x/drupal-bootstrap.min.css" integrity="sha512-U2uRfTiJxR2skZ8hIFUv5y6dOBd9s8xW+YtYScDkVzHEen0kU0G9mH8F2W27r6kWdHc0EKYGY3JTT3C4pEN+/g==" crossorigin="anonymous" />
+<link rel="stylesheet" media="all" href="https://cdn.jsdelivr.net/npm/@unicorn-fail/drupal-bootstrap-styles@0.0.2/dist/3.2.0/8.x-3.x/drupal-bootstrap.min.css" integrity="sha512-JXQ3Lp7Oc2/VyHbK4DKvRSwk2MVBTb6tV5Zv/3d7UIJKlNEGT1yws9vwOVUkpsTY0o8zcbCLPpCBG2NrZMBJyQ==" crossorigin="anonymous" />
+<link rel="stylesheet" media="all" href="https://cdn.jsdelivr.net/npm/@unicorn-fail/drupal-bootstrap-styles@0.0.2/dist/3.3.1/7.x-3.x/drupal-bootstrap.min.css" integrity="sha512-ZbcpXUXjMO/AFuX8V7yWatyCWP4A4HMfXirwInFWwcxibyAu7jHhwgEA1jO4Xt/UACKU29cG5MxhF/i8SpfiWA==" crossorigin="anonymous" />
+<link rel="stylesheet" media="all" href="https://cdn.jsdelivr.net/npm/@unicorn-fail/drupal-bootstrap-styles@0.0.2/dist/3.3.1/8.x-3.x/drupal-bootstrap.min.css" integrity="sha512-kTMXGtKrWAdF2+qSCfCTa16wLEVDAAopNlklx4qPXPMamBQOFGHXz0HDwz1bGhstsi17f2SYVNaYVRHWYeg3RQ==" crossorigin="anonymous" />
+<link rel="stylesheet" media="all" href="https://cdn.jsdelivr.net/npm/@unicorn-fail/drupal-bootstrap-styles@0.0.2/dist/3.4.0/8.x-3.x/drupal-bootstrap.min.css" integrity="sha512-tGFFYdzcicBwsd5EPO92iUIytu9UkQR3tLMbORL9sfi/WswiHkA1O3ri9yHW+5dXk18Rd+pluMeDBrPKSwNCvw==" crossorigin="anonymous" />
+<link rel="stylesheet" media="all" href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" />
+<link rel="stylesheet" media="all" href="/sites/default/files/css/css_ynf9UgDCEgIkJlDl64FWCKFxl6VSmlwCq0KXeADNNXA.css?delta=10&amp;language=en&amp;theme=dofi&amp;include=eJxFjEEOwzAIwD6EyptIQlZUEiIg2vr77bBpR1uWi1lGOi3sToOf5hc064JUK0dIEZW8gV-pMi9svhfp8UWwaYMipdrExp22JixyenyGZ_zqvzn2XLuoxMkN4o7kgYWC3wX-NQk" />
+
+    
+    <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+    <![endif]-->
+    <!--[if lt IE 10]>
+    <link rel="stylesheet" type="text/css" href="/themes/custom/dofi/js/outdated-browser/outdated-browser.css" />
+    <script src="/themes/custom/dofi/js/outdated-browser/outdated-browser.min.js"></script>
+    <![endif]-->
+</head>
+<body class="path-node page-node-type-themes has-glyphicons">
+<a href="#main-content" class="visually-hidden focusable skip-link">
+  Skip to main content
+</a>
+<noscript>
+  <div class="noscript">This website requires JavaScript to work properly.</div>
+</noscript>
+
+  <div class="dialog-off-canvas-main-canvas" data-off-canvas-main-canvas>
+    
+          <header class="navbar navbar-default clearfix" id="navbar" role="banner">
+                                <div class="region region-above-header clearfix">
+    <div class="container">
+      <div class="row">
+        <div class="col-sm-12">
+          <div class="clearfix">
+            <div class="language-switcher-language-url languages block block-language block-language-blocklanguage-interface pull-left" id="block-languageswitcher" role="navigation">
+  
+    
+
+      <ul class="links hidden-print"><li class="nl"><a href="/nl/themes/faq/long-stay/nationale-vermeldingen-visum-d" class="language-link" lang="nl" hreflang="nl" data-drupal-link-system-path="node/543"><span class="visually-hidden">Ga verder in het</span><abbr title="Nederlands">NL</abbr></a></li><li class="fr"><a href="/fr/themes/faq/long-stay/mentions-nationales-visa-d" class="language-link" lang="fr" hreflang="fr" data-drupal-link-system-path="node/543"><span class="visually-hidden">Continuer en</span><abbr title="Français">FR</abbr></a></li><li class="en"><a href="/en/themes/faq/long-stay/national-entries-visa-d" class="language-link is-active" lang="en" hreflang="en" data-drupal-link-system-path="node/543" aria-current="page"><span class="visually-hidden">Keep going in</span><abbr title="Anglais">EN</abbr></a></li></ul>
+  </div>
+            <div class="belgium-logo-container pull-right">
+              <div class="text-container">
+                <span class="text">Other official information and services: <a href="https://www.belgium.be">www.belgium.be</a></span>
+              </div>
+              <div class="image-container">
+                <img src="/themes/custom/dofi/images/logo-belgium.svg" width="33" height="24" alt="Logo of the Belgian Federal Authorities">
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+                          <div class="container">
+                <div class="row">
+          <div class="col-sm-12">
+            <div class="navbar-header">
+                <div class="region region-navigation">
+          <a class="logo navbar-btn pull-left" href="/en" title="Return to the IBZ home page" rel="home">
+      <img src="/themes/custom/dofi/logo_en_2024.svg" alt="Return to the IBZ home page" width="365" height="94" />
+                        <span class="name navbar-brand visually-hidden">
+            <strong>Immigration Office</strong>
+          </span>
+                  </a>
+  
+  </div>
+
+                                                          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#navbar-collapse">
+                  <span class="sr-only">Toggle navigation</span>
+                  <span class="icon-bar"></span>
+                  <span class="icon-bar"></span>
+                  <span class="icon-bar"></span>
+                </button>
+                          </div>
+            <div class="navbar-menu-container">
+                                <div class="region region-search">
+    <div class="views-exposed-form block block-views block-views-exposed-filter-blockglobal-site-content-search-page-1 exposed-filters clearfix" data-drupal-selector="views-exposed-form-global-site-content-search-page-1" id="block-exposedformglobal-site-content-searchpage-1">
+  
+  
+      <form action="/en/search" method="get" id="views-exposed-form-global-site-content-search-page-1" accept-charset="UTF-8">
+  <div class="form--inline form-inline clearfix">
+  <div class="form-item js-form-item form-type-textfield js-form-type-textfield form-item-search-api-fulltext js-form-item-search-api-fulltext form-no-label form-group">
+  
+  
+  <input data-drupal-selector="edit-search-api-fulltext" class="form-text search-input form-control" type="text" id="edit-search-api-fulltext" name="search_api_fulltext" value="" size="30" maxlength="128" placeholder="Search this site" aria-label="Search this site" />
+
+  
+  
+  </div>
+<div data-drupal-selector="edit-actions" class="form-actions form-group js-form-wrapper form-wrapper" id="edit-actions"><button data-drupal-selector="edit-submit-global-site-content-search" class="button js-form-submit form-submit btn icon-only" type="submit" id="edit-submit-global-site-content-search" value="Apply" name="Apply"><span class="sr-only">Apply</span><span class="icon fa fa-search" aria-hidden="true"></span></button></div>
+
+</div>
+
+</form>
+
+  </div>
+
+  </div>
+
+                                            <div id="navbar-collapse" class="navbar-collapse collapse">
+                    <div class="region region-navigation-collapsible">
+    <nav aria-label="Main navigation" id="block-mainmenuen">
+  
+  
+
+        
+      <ul class="nav navbar-nav navbar-right">
+                                <li>
+          <a href="/en/my-file" title="My file" hreflang="en" data-drupal-link-system-path="node/641">My file</a>
+                        </li>
+                                <li>
+          <a href="/en/contact" title="Contact" hreflang="en" data-drupal-link-system-path="node/601">Contact</a>
+                        </li>
+                                <li>
+          <a href="/en/about-io" title="About IO " hreflang="en" data-drupal-link-system-path="node/108">About IO </a>
+                        </li>
+                                <li>
+          <a href="/en/documentation-0" title="Documentation" hreflang="en" data-drupal-link-system-path="node/607">Documentation</a>
+                        </li>
+                                <li>
+          <a href="/en/figures" title="Figures" hreflang="en" data-drupal-link-system-path="node/135">Figures</a>
+                        </li>
+                                <li>
+          <a href="/en/jobs" title="Jobs" hreflang="en" data-drupal-link-system-path="node/117">Jobs</a>
+                        </li>
+          </ul>
+  
+  </nav>
+  </div>
+
+                </div>
+                        </div>
+        </div>
+                  </div>
+              </div>
+    </header>
+  
+      <div role="heading">
+        <div class="has-background-image region region-header">
+          <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+                  <nav aria-label=Breadcrumb>
+    <ol class="breadcrumb">
+              <li >
+                      <a href="/en">Home</a>
+                  </li>
+              <li >
+                      <a href="/en/themes">Themes</a>
+                  </li>
+              <li >
+                      <a href="/en/themes/faq">FAQ</a>
+                  </li>
+              <li >
+                      <a href="/en/themes/faq/long-stay">Long stay</a>
+                  </li>
+              <li  class="active visually-hidden focusable" aria-current="page">
+                      National entries (visa D)
+                  </li>
+          </ol>
+  </nav>
+
+        <h1 class="page-header"><span class="node-title">National entries (visa D)</span></h1>
+      
+<div data-drupal-messages-fallback class="hidden"></div>
+
+              </div>
+        </div>
+      </div>
+      </div>
+
+    </div>
+  
+  <div class="main-container container js-quickedit-main-content">
+    <div class="row">
+
+                    <main class="col-md-8 col-md-push-4 col-sm-12">
+
+                    
+                                              
+                      
+                                <span id="main-content"></span>
+              <div class="region region-content">
+      <article class="themes full node clearfix">
+
+  
+    
+
+  
+  <div class="content">
+    
+            <div class="text-container"><p>&nbsp;</p>
+
+<h5><span class="is-blue"><strong><span lang="EN-GB">National entries </span>on a <dfn class="onomasticon onomasticon-extra-element onomasticon-orientation-below onomasticon-cursor-help" tabindex="0" title="visa D">
+    <button disabled="disabled" class="onomasticon-term-description"><p>national long-stay visa (more than 90 days).</p>
+</button>
+  </dfn> ("Remarks" line) and conditions of stay:</strong></span></h5>
+
+<p>&nbsp;</p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B7 / Exchange of students - Authorisation to stay strictly limited to the duration of the exchange&nbsp;</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>No renewal of the residence card because the duration of the authorisation to stay is strictly limited.</span></span></span></em></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B8 / Authorisation to stay strictly limited to the duration of the course at a private institution of higher education + name of educational institution – Art. 9 and 13 of the Act of 15/12/1980</span></span></span></strong>&nbsp;</span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A <dfn class="onomasticon onomasticon-extra-element onomasticon-orientation-below onomasticon-cursor-help" tabindex="0" title="foreigner">
+    <button disabled="disabled" class="onomasticon-term-description"><p>anyone who does not provide proof of Belgian nationality.</p>
+</button>
+  </dfn> applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have passed the final exams (certificate prepared by the private institution of higher education for which the visa_D was granted);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they are enrolled in the capacity of a regular student for the next academic year (certificate of enrolment drawn up by the private institution of higher education for which the&nbsp;visa_D was granted);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have sufficient means of subsistence;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have health insurance covering risks in Belgium;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>On the other hand, the foreigner may not excessively prolong their studies. [Act of 15/12/1980, Article 61/1/4. §2, 6°)</span></span></span></em></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B9 / Authorisation to stay limited to the duration of the academic year – Secondary education – Articles 9 and 13 of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have passed the final exams (certificate prepared by the institution of secondary education for which the visa_D was granted);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they are enrolled in the capacity of a regular student for the next academic year (certificate of enrolment drawn up by the institution of secondary education for which the visa_D was granted);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have sufficient means of subsistence;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have health insurance covering risks in Belgium;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record, if they are aged 18 or over).</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B10 / <dfn class="onomasticon onomasticon-extra-element onomasticon-orientation-below onomasticon-cursor-help" tabindex="0" title="Family reunification">
+    <button disabled="disabled" class="onomasticon-term-description"><p><span><span><span>A procedure that allows a foreigner to obtain a residence permit to join a family member legally residing in a country.</span></span></span></p>
+</button>
+  </dfn> – Art. 10bis. §1 of the Act of 15/12/1980 – Residence limited to the duration of the sponsor's studies</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record, if they are aged 18 or over).</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>evidence of efforts to integrate into Belgian society;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>evidence that the foreigner joining has stable, regular and sufficient means of subsistence;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>evidence that the foreigner joining has adequate housing (if they have moved since the granting of visa_D);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that the foreigner joining has health insurance covering risks in Belgium for the holder of the residence card and for themselves.</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>On the other hand, the foreigner must be effectively cohabiting with the foreigner joining (positive </span></span></span></em><span lang="EN-GB"><span><span>cohabitation investigation<em> conducted by the competent municipal authorities).</em></span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B11 / Family reunification – Art. 10. §1, 4° to 6° of the Act of 15/12/1980 – Sponsor admitted or authorised for a stay of unlimited duration in Belgium</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record, if they are aged 18 or over);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>evidence of efforts to integrate into Belgian society, </span></span></em><span lang="EN-GB"><span>if they are subject to this requirement</span></span><em><span lang="EN-GB"><span>;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>evidence that the foreigner joining has stable, regular and sufficient means of subsistence, unless they are exempt;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>evidence that the foreigner joining has adequate housing (if they have moved since the granting of visa_D);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that the foreigner joining has health insurance covering risks in Belgium for the holder of the residence card and for themselves.</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>On the other hand, the foreigner must be effectively cohabiting with the foreigner joining (positive </span></span></span></em><span lang="EN-GB"><span><span>cohabitation investigation<em> conducted by the competent municipal authorities).</em></span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B12 / Authorisation to stay limited to the duration of the activity for which exemption from a work permit is granted + duration of activity – Art. 9 and 13 of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they are exempt from a work permit for the activity performed;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have sufficient means of subsistence (employment contract, proof of actual deposit of salary in an account opened in their name);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have health insurance covering risks in Belgium;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B13 / Authorisation to stay limited to the duration of the guest agreement – Researcher – Art. 61/11 of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they are an investigator within the meaning of Article 61/11 of the Act of 15/12/1980 (valid guest agreement);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B14 / Authorisation to stay limited to the duration of labour card B – Salaried employee – Articles 9 and 13 of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have a work permit for the activity performed (valid labour card B renewed during a legal stay);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have sufficient means of subsistence (employment contract, proof of actual deposit of salary in an account opened in their name);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that their conduct has not endangered Belgian public order or Belgian national security (extract from criminal record).</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B15 / Authorisation to stay limited to the duration of the professional card + 3 months – Independent activity – Art. 9 and 13 of the Act of 15/12/1980</span></span></span></strong>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;</span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have a permit for the activity performed (valid professional card renewed during a legal stay);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that the activity is being performed as a business manager, director or active partner. An active partner must also submit their payslips and the company's certificate of incorporation or deed of transfer of shares;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof of payment of social security contributions (official certificate from the social insurance fund for self-employed people) and of VAT, if VAT applies to the activity performed</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B17 / Authorisation to stay limited to 1 year – Art. 9 and 13 of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<ol>
+	<li><span><span><span><span><span><span><strong><em><span lang="EN-GB"><span>For a foreigner authorised to reside in Belgium in the capacity of a rentier</span></span></em></strong></span></span></span></span></span></span></li>
+</ol>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have regular, stable and sufficient income in an amount at least equal to the living wage granted to a single person, this being €1.314,20&nbsp;(amount indexed on 01/02/2025);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they transferred this income to a bank account opened in Belgium in their name;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have health insurance covering risks in Belgium;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>evidence of efforts to integrate into Belgian society.</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<ol start="2">
+	<li><span><span><span><span><span><span><strong><em><span lang="EN-GB"><span>For a foreigner authorised to reside in Belgium in the capacity of a parent (father or mother), or adult child over 25 years of age, of a foreign diplomat who holds a special identity card issued by the Protocol Directorate (FPS Foreign Affairs)</span></span></em></strong></span></span></span></span></span></span></li>
+</ol>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>evidence that they are taken into the care of and effectively living with the accompanied or joined diplomat;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>copy of the valid special identity card issued to the diplomat by the Protocol Directorate;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have health insurance covering risks in Belgium;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>evidence of efforts to integrate into Belgian society.</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B19 / Temporary authorisation to stay – Long-term resident status obtained in another Member State of the European Union – Art. 61/7 of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<ol>
+	<li><span><span><span><span><span><span><strong><em><span lang="EN-GB"><span>For a foreigner who has come to Belgium to pursue an activity as an employee there</span></span></em></strong></span></span></span></span></span></span></li>
+</ol>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>The renewal of the combined permit must be requested from the competent Region. The A card will be renewed if the Region renews the work permit and the Immigration Office renews the authorisation to stay.</span></span></span></em></span></span></span></span></p>
+
+<ol start="2">
+	<li><span><span><span><span><span><span><strong><em><span lang="EN-GB"><span>For a foreigner who has come to Belgium to take on work other than as an employee there</span></span></em></strong></span></span></span></span></span></span></li>
+</ol>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have a permit for the activity being performed (professional card), or that they are exempt from this authorisation for the activity being performed;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<ol start="3">
+	<li><span><span><span><span><span><span><strong><em><span lang="EN-GB"><span>For a foreigner who has come to Belgium to study or to receive vocational training</span></span></em></strong></span></span></span></span></span></span></li>
+</ol>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>See national entry B40.</span></span></span></em></span></span></span></span></p>
+
+<ol start="4">
+	<li><span><span><span><span><span><span><strong><em><span lang="EN-GB"><span>For a foreigner who has come to Belgium for other purposes*</span></span></em></strong></span></span></span></span></span></span></li>
+</ol>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>*In general, this is a foreigner who has sufficient means of subsistence.</span></span></span></em></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they are receiving interest from investments or a pension in an amount at least equal to the living wage granted to a single person, this being €1.288,46&nbsp;(amount indexed on 01/05/2024);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they transferred this interest from investments or this pension to a bank account opened in Belgium in their name;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they have health insurance covering risks in Belgium;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>evidence of efforts to integrate into Belgian society.</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B20 / Family reunification – Art. 40bis* or 40ter of the Act of 15/12/1980 – The sponsor is an adult Belgian or EU citizen</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>The foreigner who is admitted to stay in Belgium for more than 90 days in the context of family reunification with an adult Belgian or an adult national of one of the Member States of the European Union (hereinafter EU citizen) must meet the following residence conditions:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>living in Belgium with the Belgian or EU citizen being joined;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record, if they are aged 18 or over);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>making efforts to integrate into Belgian society.</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>On the other hand, the Belgian or EU citizen being joined must:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>have stable, regular and sufficient means of subsistence, unless the foreigner is not required to meet this residence requirement;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>have adequate housing (if they have moved since the granting of visa_D);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>have health insurance covering risks in Belgium for the holder of the residence card and for themselves.</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>* Issuing a D <dfn class="onomasticon onomasticon-extra-element onomasticon-orientation-below onomasticon-cursor-help" tabindex="0" title="visa">
+    <button disabled="disabled" class="onomasticon-term-description"><p><span><span><span>an authorisation issued by a Member State or a decision taken by such State which is required with a view to entry for an intended stay in that Member State or in several Member States, or for transit through the territory of that Member State or several Member States.</span></span></span></p>
+</button>
+  </dfn> to a family member of an EU citizen is exceptional.</span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>Indeed, the entry conditions for such a foreigner are laid down in Directive 2004/38/EC. A foreigner <dfn class="onomasticon onomasticon-extra-element onomasticon-orientation-below onomasticon-cursor-help" tabindex="0" title="exempted">
+    <button disabled="disabled" class="onomasticon-term-description"><p>to excuse someone or something from a duty, payment, etc.</p>
+</button>
+  </dfn> from a short-stay visa generally travels with this exemption, and a foreigner subject to the short-stay visa requirement travels with a C visa. The conditions for a foreigner wishing to stay in Belgium for more than 90 days as a family member of an EU citizen are explained in further detail on the pages about EU citizens.</span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B21 / Family reunification – Art. 40bis or 40ter of the Act of 15/12/1980 – The sponsor is an underage Belgian or EU citizen</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>The foreigner who is admitted to stay in Belgium for more than 90 days in the context of family reunification with an underage Belgian or an underage national of one of the Member States of the European Union (hereinafter EU citizen) must meet the following residence conditions:</span></span></span></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>have a genuine connection with the joined Belgian or EU citizen;</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>making efforts to integrate into Belgian society.</span></span></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B22 / Family reunification – Art. 10, 10bis, 40bis or 40ter of the Act of 15/12/1980 – Return visa</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>This visa is granted to a foreigner who holds a certificate of immatriculation and is involved in a family reunification procedure, but who left Belgium before the decision was taken. The examination of the application will continue.</span></span></span></em></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B23 / Authorisation to stay limited to 6 months with a view to adoption – Art. 9 and 13 of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>The foreigner applying for the renewal of their residence card must present the proof of the clear progress in the adoption procedure (document from the Federal Central Authority or the Central Authority for the community competent for adoption).</span></span></span></em></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B24 / Authorisation to stay limited to 1 year – Art. 9 and 13 of the Act of 15/12/1980 – Working holiday procedure</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>No renewal of the residence card because the duration of the authorisation to stay is strictly limited to 1 year.</span></span></span></em></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B26 / Right of return – Art. 19 of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>The foreigner will be returned to the situation they were in before they left Belgium.</span></span></span></em></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B27 / Authorisation to return after 1 year – Art. 9 of the Act of 15/12/1980 + Royal Decree of 07/08/1995</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>The foreigner will receive an A card that is valid for 1 year, but is authorised to stay in Belgium indefinitely. They will receive a B card when their A card expires.(Circular of 05/02/1996, point V).</span></span></span></em></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B28 / Family reunification – Art. 10bis, §2 or §3 of the Act of 15/12/1980 – Residence limited to the duration of the sponsor's stay</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record, if they are aged 18 or over).</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>evidence of efforts to integrate into Belgian society;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>evidence that the foreigner joining has stable, regular and sufficient means of subsistence;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>evidence that the foreigner joining has adequate housing (if they have moved since the granting of visa_D);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that the foreigner joining has health insurance covering risks in Belgium for the holder of the residence card and for themselves.</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>On the other hand, the foreigner must be effectively cohabiting with the foreigner joining (positive </span></span></span></em><span lang="EN-GB"><span><span>cohabitation investigation<em> conducted by the competent municipal authorities).</em></span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B29 / Temporary authorisation to stay – Art. 61/27 of the Act of 15/12/1980 – Highly qualified worker (European Blue Card)</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>The renewal of the combined permit must be requested from the competent Region. The A card will be renewed if the Region renews the work permit and the Immigration Office renews the authorisation to stay.</span></span></span></em></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B30 / Family reunification – Art. 47/1 of the Act of 15/12/1980 – Other family member of an EU citizen</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>The foreigner who is admitted to stay in Belgium for more than 90 days in the capacity of another family member of a citizen of one of the Member States of the European Union (hereinafter EU citizen) must meet the following residence conditions:</span></span></span></em></span></span></span></span></p>
+
+<ol>
+	<li><span><span><span><span><span><span><strong><em><span lang="EN-GB"><span>For a genuine partner</span></span></em></strong></span></span></span></span></span></span></li>
+</ol>
+
+<ul>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>have an enduring relationship in Belgium with the joined EU citizen;</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></span></span></span></span></span></span></li>
+</ul>
+
+<ol start="2">
+	<li><span><span><span><span><span><span><strong><em><span lang="EN-GB"><span>For a family member who, due to serious health reasons, strictly requires personal care by the EU citizen</span></span></em></strong></span></span></span></span></span></span></li>
+</ol>
+
+<ul>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>have a serious health problem that justifies strict and personal care by the EU citizen;</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B31 / Authorisation to return after an absence of less than one year – Expired residence card – Art. 9 and 13 of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>The foreigner will be returned to the situation they were in before they left Belgium.</span></span></span></em></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B32 / Resettlement – Art. 9 and 13 of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>The foreign national will be invited to apply for <dfn class="onomasticon onomasticon-extra-element onomasticon-orientation-below onomasticon-cursor-help" tabindex="0" title="international protection">
+    <button disabled="disabled" class="onomasticon-term-description"><p>A person who flees his country due to a fear of persecution or a risk of serious harm, can obtain international protections within anoter country's borders. The person must ask&nbsp; for asylum in this other country.</p>
+</button>
+  </dfn> in Belgium.</span></span></span></em></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B33 / Authorisation to stay limited to 1 year – Art. 9 and 13 of the Act of 15/12/1980 – Humanitarian reasons</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they are pursuing studies or training or performing a professional activity;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>evidence of efforts to integrate into Belgian society.</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B34 / Combined permit</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>The renewal of the combined permit must be requested from the competent Region. The A card will be renewed if the Region renews the work permit and the Immigration Office renews the authorisation to stay.</span></span></span></em></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B35 / Student – Mobility</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>The duration of the residence card is limited to the duration of mobility, or up to 2 years. An extension is not possible when the residence card expires, unless the foreigner presents the documents listed under B40.&nbsp;</span></span></span></em></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B36 / Seasonal worker</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof of the renewal of the work permit issued by the competent Region;</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>proof that they will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></em></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><em><span lang="EN-GB"><span>their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></em></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B37 / Intra-Corporate Transferee (ICT)</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>The renewal of the combined permit must be requested from the competent Region. The A card will be renewed if the Region renews the work permit and the Immigration Office renews the authorisation to stay.</span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B38 / Family reunification – Art. 10. §1, 4° to 8° of the Act of 15/12/1980 – Family member of a beneficiary of international protection exempt from conditions (housing, insurance, MEX)</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>The foreigner who, in the context of a family reunification with a foreigner, beneficiary of international protection in Belgium and exempt from the conditions of residence with regard to means of subsistence, housing and health insurance, is admitted to stay in Belgium for more than 90 days must meet the following conditions of residence:</span></span></span></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>living with the joined foreigner, beneficiary of international protection;</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>The foreigner who applies for unrestricted residence (B card) (status independent of the status of the joined foreigner) must prove that they have sufficient means of subsistence and that they have not become a burden on the Belgian public authorities (certificate from the PCSW).</span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B39 / Authorisation to stay limited to 12 months – Year to look for work after studies – Article 61/1/9 of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>No extension possible when the residence card expires.</span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B40 / Authorisation to stay limited to the duration of the studies – Enrolment at an institution of higher education + name of the institution – Art. 60, §3, 3°, a) of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>a certificate drawn up [in accordance with the model of the </span></span><a href="https://dofi.ibz.be/sites/default/files/2022-06/Mod%C3%A8le%20de%20formulaire%20standard%20.pdf"><span><span><span>standard form</span></span></span></a><span lang="EN-GB"><span> established as per the Ministerial Decree of 28 March 2022] by an institution of higher education, proving that they are enrolled there to pursue higher studies;</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>the previous year's results (report);</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>a </span></span><a href="https://dofi.ibz.be/sites/default/files/2022-06/Progression%20des%20%C3%A9tudes%20FR.pdf"><span><span><span>certificate demonstrating the progress of studies</span></span></span></a><span lang="EN-GB"><span> and [in accordance with the template of the standard form established by the ministerial decree of 28 March 2022] prepared by the higher education institution;</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>proof that they have sufficient means of subsistence for the duration of their stay to avoid becoming a burden on the Belgian social assistance system during his stay;</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>proof that he has health insurance covering all risks in Belgium (certificate of registration with a healthcare fund).</span></span></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B41 / Temporary authorisation to stay – Admission to studies + name of institution – Art. 60. §3, 3°, b) of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<ol>
+	<li><span><span><span><span><span><span><strong><em><span lang="EN-GB"><span>B41 – Authorisation to stay valid for 4 months</span></span></em></strong></span></span></span></span></span></span></li>
+</ol>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>At least 15 days before the expiration of their certificate of immatriculation or their visa_D, the foreigner must go to the municipal administration and present a certificate prepared [in accordance with the model of the standard form established by the Ministerial Decree of 28 March 2022] proving that he they are enrolled to pursue full-time higher studies or a preparatory year of higher studies at the institution of higher education for which he received their visa.</span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>They must also submit proof that they have health insurance covering all risks in Belgium for the duration of their stay, if this proof was not submitted with the visa application.</span></span></span></span></span></span></span></p>
+
+<ol start="2">
+	<li><span><span><span><span><span><span><strong><em><span lang="EN-GB"><span>Extension of the A card</span></span></em></strong></span></span></span></span></span></span></li>
+</ol>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>See national entry B40.</span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B42 / Temporary authorisation to stay – Enrolment for an entrance exam or an entrance test + name of institution – Art. 60. §3, 3°, c) of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<ol>
+	<li><span><span><span><span><span><span><strong><em><span lang="EN-GB"><span>B42 – Authorisation to stay valid for 4 months</span></span></em></strong></span></span></span></span></span></span></li>
+</ol>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>At least 15 days before the expiration of their certificate of immatriculation or their visa_D, the foreigner must go to the municipal administration and present a certificate prepared [in accordance with the model of the standard form established by the Ministerial Decree of 28 March 2022] proving that he they are enrolled to pursue full-time higher studies or a preparatory year of higher studies at the institution of higher education for which he received their visa.</span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>They must also submit proof that they have health insurance covering all risks in Belgium for the duration of their stay, if this proof was not submitted with the visa application.</span></span></span></span></span></span></span></p>
+
+<ol start="2">
+	<li><span><span><span><span><span><span><strong><em><span lang="EN-GB"><span>Extension of the A card</span></span></em></strong></span></span></span></span></span></span></li>
+</ol>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>See national entry B40.</span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B43 / Temporary authorisation to stay – No health insurance – Art. 61/1/1. §4 of the Act of 15/12/1980</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>This statement is always associated with the statement B40, B41 or B42.</span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>At least 15 days before the expiration of their certificate of immatriculation or their visa_D, the foreigner must present proof that they have health insurance covering all risks in Belgium for the duration of their stay.</span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B44 / Authorisation to stay limited to the duration of the stay of the person joined – Art. 9 and 13 of the Act of 15/12/1980 – Humanitarian reasons&nbsp;</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>proof that they will not be a burden on the Belgian public authorities (certificate from the PCSW);</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>proof that they are pursuing studies or training or performing a professional activity;</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>evidence of efforts to integrate into Belgian society.</span></span></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>ATTENTION: if the person you are joining is authorized to stay in Belgium for a limited period, the duration of the residence permit cannot exceed the duration of validity of that person's residence permit, <u>with a maximum of one year.</u></span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span lang="EN-GB"><span><span>B45 / Family reunification – Art. 57/34 of the Act of 15/12/1980 – The sponsor is the beneficiary of temporary protection in Belgium</span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>Article 57/36 of the Act of 15/12/1980 determines the time when the regime of temporary protection ends.&nbsp;&nbsp;&nbsp;</span></span></span></span></span></span></span></p>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>If the A card of a family member, aged 18 or older, of a beneficiary of the regime of temporary protection expires before this regime ends, they must present proof that their conduct does not endanger Belgian public order or Belgian national security (extract from criminal record).</span></span></span></span></span></span></span></p>
+
+<p><strong><span><span><span><span><span lang="EN-GB"><span><span>B46 / EU-Passworld</span></span></span></span></span></span></span></strong></p>
+
+<p><span><span><span><span lang="EN-GB">Authorisation to stay limited to Master + one year to look for work after studies</span></span></span></span></p>
+
+<p><span><span><span><span><span lang="EN-GB"><span><span>A foreigner applying for the renewal of their residence card must submit the following documents:</span></span></span></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>a certificate drawn up [in accordance with the model of the </span></span><a href="https://dofi.ibz.be/sites/default/files/2022-06/Mod%C3%A8le%20de%20formulaire%20standard%20.pdf"><span><span><span>standard form</span></span></span></a><span lang="EN-GB"><span> established as per the Ministerial Decree of 28 March 2022] by an institution of higher education, proving that they are enrolled there to pursue higher studies;</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>the previous year's results (report);</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>a </span></span><a href="https://dofi.ibz.be/sites/default/files/2022-06/Progression%20des%20%C3%A9tudes%20FR.pdf"><span><span><span>certificate demonstrating the progress of studies</span></span></span></a><span lang="EN-GB"><span> and [in accordance with the template of the standard form established by the ministerial decree of 28 March 2022] prepared by the higher education institution;</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>proof that they have sufficient means of subsistence for the duration of their stay to avoid becoming a burden on the Belgian social assistance system during his stay;</span></span></span></span></span></span></span></span></li>
+	<li><span><span><span><span><span><span><span lang="EN-GB"><span>proof that he has health insurance covering all risks in Belgium (certificate of registration with a healthcare fund).</span></span></span></span></span></span></span></span></li>
+</ul>
+
+<p><span><span><span><span><strong><span><span><span lang="EN-GB"><span>B47 / </span></span></span></span><span lang="EN-GB"><span><span>Authorisation to stay limited to 6 months – Art. 9 and 13 of the Act of 15/12/1980 –&nbsp;</span></span></span><span><span><span lang="EN-GB"><span>Project of wedding in Belgium</span></span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>No renewal of the residence card because the duration of the authorisation to stay is strictly limited to 6 months.</span></span></span></em></span></span></span></span></p>
+
+<p><span><span><span><span><strong><span><span><span lang="EN-GB"><span>B48 / </span></span></span></span><span lang="EN-GB"><span><span>Authorisation to stay limited to 6 months – Art. 9 and 13 of the Act of 15/12/1980 –&nbsp;</span></span></span><span><span><span lang="EN-GB"><span>Project of legal cohabitation in Belgium</span></span></span></span></strong></span></span></span></span></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>No renewal of the residence card because the duration of the authorisation to stay is strictly limited to 6 months.</span></span></span></em></span></span></span></span></p>
+
+<p><strong><span><span><span><span><em><span lang="EN-GB"><span><span>B49 /&nbsp;</span></span></span></em></span></span></span></span><span><span><span><span><em><span lang="EN-GB"><span><span>Residence permit limited to 6 months - Art. 57/34 of the law of 15/12/1980 - Temporary protection &nbsp;&nbsp;</span></span></span></em></span></span></span></span></strong></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>The conditions for renewal of the residence permit are set out in article 57/30 of the law of 15/12/1980.</span></span></span></em></span></span></span></span></p>
+
+<p><strong><span><span><span><span><em><span lang="EN-GB"><span><span>B50 /&nbsp;</span></span></span></em></span></span></span></span><span><span><span><span><em><span lang="EN-GB"><span><span>Residence permit limited to duration of work permit - Art. 61/13/19 - Trainee permit&nbsp;</span></span></span></em></span></span></span></span></strong></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>Conditions for renewal, provided that the maximum duration of the possibility of working as a trainee is not exceeded (12 months): a new work permit for a traineeship.&nbsp;If the maximum duration for working as a trainee (12 months) is reached, the residence permit cannot be renewed. &nbsp;</span></span></span></em></span></span></span></span></p>
+
+<p><strong><span><span><span><span><em><span lang="EN-GB"><span><span>B51 /&nbsp;</span></span></span></em></span></span></span></span><span><span><span><span><em><span lang="EN-GB"><span><span>Residence permit limited to duration of work permit - Art. 61/13/28 of the law of 15/12/1980 - Permit for volunteers (European Voluntary Service)</span></span></span></em></span></span></span></span></strong></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>Residence permit cannot be renewed</span></span></span></em></span></span></span></span></p>
+
+<p><strong><span><span><span><span><em><span lang="EN-GB"><span><span>B52 /&nbsp;&nbsp;</span></span></span></em></span></span></span></span><span><span><span><span><em><span lang="EN-GB"><span><span>Residence permit limited to the duration of the work permit - Art. 9 &amp; 13 of the law of 15/12/1980 - Missionnaire</span></span></span></em></span></span></span></span></strong></p>
+
+<p><span><span><span><span><em><span lang="EN-GB"><span><span>Missionaries applying for renewal of their residence permit must present the following documents:</span></span></span></em></span></span></span></span></p>
+
+<ul>
+	<li><span><span><span><span><em><span lang="EN-GB"><span><span>an attestation issued by the religious community's hierarchy specifying the duration of the mission and showing that the applicant's activities take place within the religious community;</span></span></span></em></span></span></span></span></li>
+	<li><span><span><span><span><em><span lang="EN-GB"><span><span>if activities (also carried out as a volunteer) take place outside the religious community, a work permit is required;</span></span></span></em></span></span></span></span></li>
+	<li><span><span><span><span><em><span lang="EN-GB"><span><span>a recent undertaking of responsibility signed by the religious community's hierarchy, specifying that the said community undertakes to cover all the interested party's living and health expenses for the entire duration of his or her stay, as well as repatriation costs;&nbsp;</span></span></span></em></span></span></span></span></li>
+	<li><span><span><span><span><em><span lang="EN-GB"><span><span>proof of efforts to integrate into Belgian society (article 1/2, §3 of the law of 15/12/1980)</span></span></span></em></span></span></span></span></li>
+</ul></div>
+      <div class="accordion-container panel-group" role="tablist" aria-multiselectable="true" id="accordion">
+                </div>
+<div class="document-block-container"></div>
+  </div>
+
+</article>
+
+  </div>
+
+                  </main>
+
+                                                <div class="col-md-4 col-md-pull-8 col-sm-12">
+                <div class="region region-sidebar-first">
+    <nav aria-labelledby="block-mainmenu-2-menu"  id="block-mainmenuen-2" class="box box-sidebar">
+  
+  <h2 id="block-mainmenu-2-menu" class="block-title visually-hidden">Sidebar navigation</h2>
+  
+
+        <div class="body-container"><div class="list-container">
+      <ul class="triangle-list sidebar-list">
+                                <li>
+          <a href="/en/themes/faq/long-stay/medical-certificate" title="Medical certificate" hreflang="en" data-drupal-link-system-path="node/174">Medical certificate</a>
+                        </li>
+                                <li>
+          <a href="/en/themes/faq/long-stay/certificate-stating-absence-convictions-crimes-or-misdemeanors-under-common" title="Certificate stating absence of convictions for crimes or misdemeanors under common law" hreflang="en" data-drupal-link-system-path="node/253">Certificate stating absence of convictions for crimes or misdemeanors under common law</a>
+                        </li>
+                                <li>
+          <a href="/en/themes/faq/long-stay/efforts-integrate-belgian-society" title="Efforts to integrate into Belgian society" hreflang="en" data-drupal-link-system-path="node/564">Efforts to integrate into Belgian society</a>
+                        </li>
+                                <li class="current active">
+          <a href="/en/themes/faq/long-stay/national-entries-visa-d" title="National entries (visa D)" hreflang="en" data-drupal-link-system-path="node/543" class="is-active" aria-current="page">National statements (visa D)</a>
+                        </li>
+          </ul>
+  </div></div>
+  </nav>
+  </div>
+
+            </div>
+                  
+                    </div>
+  </div>
+
+    
+      <footer class="main-footer" role="contentinfo">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+            <div class="footer clearfix">
+              <div class="menu-container pull-left">
+                <div class="image-container pull-left">
+                  <img src="/themes/custom/dofi/images/ibz-small.png" srcset="/themes/custom/dofi/images/ibz-small.png 1x,
+               /themes/custom/dofi/images/ibz-small@2x.png 2x" alt="Federal Public Service Home Affairs" width="52" height="37" />
+                </div>
+                <div class="wrapper">
+                  <div class="copyright pull-left">&copy; DOFI 2026 -</div>
+                    <div class="region region-footer">
+    <nav aria-label="Footer navigation" id="block-footermenuen">
+  
+  
+
+        
+      <ul class="list-unstyled footer-list">
+                                <li>
+          <a href="/en/terms-use" data-drupal-link-system-path="node/214">Terms of Use</a>
+                        </li>
+                                <li>
+          <a href="/en/processing-personal-data" data-drupal-link-system-path="node/511">Processing of personal data</a>
+                        </li>
+                                <li>
+          <a href="/en/cookiepolicy" title="Cookiepolicy" hreflang="en" data-drupal-link-system-path="node/90">Cookiepolicy</a>
+                        </li>
+                                <li>
+          <a href="/en/accessibility-statement" title="Accessibility Statement" hreflang="en" data-drupal-link-system-path="node/301">Accessibility Statement</a>
+                        </li>
+                                <li>
+          <a href="/en/policy-external-links" data-drupal-link-system-path="node/569">Policy External links</a>
+                        </li>
+                                <li>
+          <a href="/en/social-networks" data-drupal-link-system-path="node/565">Facebook - Instagram - Linkedin </a>
+                        </li>
+                                <li>
+          <a href="https://ibz.be/">About IBZ</a>
+                        </li>
+          </ul>
+  
+  </nav>
+  </div>
+
+                </div>
+              </div>
+              <div class="european-symbol-container pull-right">
+                <div class="image-container">
+                  <img src="/themes/custom/dofi/images/flag-europe-2.jpg" srcset="/themes/custom/dofi/images/flag-europe-2.jpg 1x, /themes/custom/dofi/images/flag-europe-2.jpg 2x" alt="Flag of european union" width="240" height="50" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+  
+  </div>
+
+
+<script type="application/json" data-drupal-selector="drupal-settings-json">{"path":{"baseUrl":"\/","pathPrefix":"en\/","currentPath":"node\/543","currentPathIsAdmin":false,"isFront":false,"currentLanguage":"en"},"pluralDelimiter":"\u0003","suppressDeprecationErrors":true,"data":{"extlink":{"extTarget":false,"extTargetAppendNewWindowDisplay":true,"extTargetAppendNewWindowLabel":"(opens in a new window)","extTargetNoOverride":false,"extNofollow":false,"extTitleNoOverride":false,"extNoreferrer":false,"extFollowNoOverride":false,"extClass":"ext","extLabel":"(link is external)","extImgClass":false,"extSubdomains":true,"extExclude":"","extInclude":"","extCssExclude":"","extCssInclude":"","extCssExplicit":"","extAlert":false,"extAlertText":"This link will take you to an external web site. We are not responsible for their content.","extHideIcons":false,"mailtoClass":"mailto","telClass":"","mailtoLabel":"(link sends email)","telLabel":"(link is a phone number)","extUseFontAwesome":false,"extIconPlacement":"append","extPreventOrphan":false,"extFaLinkClasses":"fa fa-external-link","extFaMailtoClasses":"fa fa-envelope-o","extAdditionalLinkClasses":"","extAdditionalMailtoClasses":"","extAdditionalTelClasses":"","extFaTelClasses":"fa fa-phone","allowedDomains":null,"extExcludeNoreferrer":""}},"bootstrap":{"forms_has_error_value_toggle":1,"modal_animation":1,"modal_backdrop":"true","modal_focus_input":1,"modal_keyboard":1,"modal_select_text":1,"modal_show":1,"modal_size":"","popover_enabled":1,"popover_animation":1,"popover_auto_close":1,"popover_container":"body","popover_content":"","popover_delay":"0","popover_html":0,"popover_placement":"right","popover_selector":"","popover_title":"","popover_trigger":"click","tooltip_enabled":1,"tooltip_animation":1,"tooltip_container":"body","tooltip_delay":"0","tooltip_html":0,"tooltip_placement":"auto left","tooltip_selector":"","tooltip_trigger":"hover"},"ajaxTrustedUrl":{"\/en\/search":true},"user":{"uid":0,"permissionsHash":"9df7e63fadcfaca970d02e0ef8138e5e976e547b7d969a04be001e92d66b17f3"}}</script>
+<script src="/sites/default/files/js/js_1hlHbqlS2zaZXJheqHgEyXyyRsFbHl9UMS1QtiABlVo.js?scope=footer&amp;delta=0&amp;language=en&amp;theme=dofi&amp;include=eJxNyEkKgDAQRNELBXOkkEkojF1N0ore3oUD7v5_ibRhPapPbwXtNUBg7iOvVO61_8TIZlBXOMPHnOsYSGiw8yYK1zgMmeLqYQ2y-NI3jW169gIHcTFI"></script>
+<script src="https://cdn.jsdelivr.net/npm/entreprise7pro-bootstrap@3.4.8/dist/js/bootstrap.min.js" integrity="sha256-3XV0ZwG+520tCQ6I0AOlrGAFpZioT/AyPuX0Zq2i8QY=" crossorigin="anonymous"></script>
+<script src="/sites/default/files/js/js_HVSxS52yEW8_ty8ud7YbbVj57iJDE9gYiV68JfGEYBc.js?scope=footer&amp;delta=2&amp;language=en&amp;theme=dofi&amp;include=eJxNyEkKgDAQRNELBXOkkEkojF1N0ore3oUD7v5_ibRhPapPbwXtNUBg7iOvVO61_8TIZlBXOMPHnOsYSGiw8yYK1zgMmeLqYQ2y-NI3jW169gIHcTFI"></script>
+
+</body>
+</html>

--- a/sources/BE_NATIONALD_DOFI_2026-06-15.html.meta.json
+++ b/sources/BE_NATIONALD_DOFI_2026-06-15.html.meta.json
@@ -1,0 +1,7 @@
+{
+  "source_id": "BE_NATIONALD_DOFI_2026",
+  "url": "https://dofi.ibz.be/en/themes/faq/long-stay/national-entries-visa-d",
+  "retrieved_at": "2026-06-15T00:00:00Z",
+  "sha256": "c88285889ac5816b87cda1d1273538e9d69fa09d33274f4e56a614f84a88c4a8",
+  "local_path": "sources/BE_NATIONALD_DOFI_2026-06-15.html"
+}

--- a/tools/build_content_hubs.py
+++ b/tools/build_content_hubs.py
@@ -489,6 +489,20 @@ VISA_FAQS = {
             "answer": "The cover must run for the requested validity period of the visa. A month-to-month subscription that can lapse does not assure that, so it is YELLOW; full-period policies are GREEN.",
         },
     ],
+    "BE_NATIONALD_DOFI_2026": [
+        {
+            "question": "What insurance does a Belgium national entry (visa D) require?",
+            "answer": "The Immigration Office requires proof of health insurance covering all risks in Belgium; the example proof named is a certificate of registration with a healthcare fund.",
+        },
+        {
+            "question": "Why is only Genki Native GREEN for this route?",
+            "answer": "The policy must cover all risks in Belgium. Genki Native documents global comprehensive coverage that includes Belgium; the other products do not document Belgium all-risk coverage, so the engine records UNKNOWN rather than assuming a foreign policy qualifies.",
+        },
+        {
+            "question": "Is registration with a Belgian healthcare fund required?",
+            "answer": "The source names a certificate of registration with a healthcare fund as the example proof. Confirm with the Immigration Office which proof is accepted in your category; the engine models the all-risks-in-Belgium requirement and does not assume any tracked product is registered with a Belgian fund.",
+        },
+    ],
 }
 
 RELATED_POSTS = {
@@ -654,6 +668,11 @@ RELATED_POSTS = {
     "KZ_NEONOMAD_EGOV_2026": [
         ("/posts/kazakhstan-neo-nomad-insurance/", "Kazakhstan Neo Nomad Visa insurance requirements"),
         ("/posts/digital-nomad-insurance-asia/", "Digital nomad insurance in Asia"),
+        ("/guides/how-to-read-results/", "How to read compliance results"),
+    ],
+    "BE_NATIONALD_DOFI_2026": [
+        ("/posts/belgium-national-d-insurance/", "Belgium national entry (visa D) insurance requirements"),
+        ("/posts/digital-nomad-insurance-europe/", "Digital nomad insurance in Europe"),
         ("/guides/how-to-read-results/", "How to read compliance results"),
     ],
 }

--- a/tools/editorial_targets.json
+++ b/tools/editorial_targets.json
@@ -322,5 +322,13 @@
   "content/posts/kazakhstan-neo-nomad-insurance.md": [
     450,
     1200
+  ],
+  "content/visas/belgium/national-entry-visa-d/national-entries-visa-d-health-insurance-immigration-office/index.md": [
+    900,
+    1400
+  ],
+  "content/posts/belgium-national-d-insurance.md": [
+    450,
+    1200
   ]
 }


### PR DESCRIPTION
## Summary
- New route **BE_NATIONALD_DOFI_2026** — Belgium National Entry (Visa D)
- Primary source (byte-exact, sha256-validated): Immigration Office of Belgium national-entries (visa D) page (dofi.ibz.be)
- Rules encoded verbatim only: `insurance.mandatory`, `insurance.authorized_in_country`, `insurance.comprehensive` ("health insurance covering all risks in Belgium")
- Disclosed but NOT modeled: the example proof named is a certificate of registration with a Belgian healthcare fund
- Reuses the generic `AuthorizedInCountryRule`; Genki Native gains `jurisdiction_facts.BE`

## Mapping outcomes
Only **Genki Native GREEN**; all other products **UNKNOWN**. No existing mapping changed.

## Content
- Hub: /visas/belgium/national-entry-visa-d/national-entries-visa-d-health-insurance-immigration-office/
- Post: /posts/belgium-national-d-insurance/ (dated 2026-06-13, past in UTC)
- Affiliate: Genki Native paid link, after results only

## Gates
All gates + ui_compliance_tests.ps1 + mapping_engine_tests.ps1 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)