### PR TITLE
feat(route): add Dominica Work In Nature route (evidence-based)

### DIFF
--- a/content/posts/dominica-work-in-nature-insurance.md
+++ b/content/posts/dominica-work-in-nature-insurance.md
@@ -1,0 +1,101 @@
+---
+title: "Dominica Work In Nature insurance requirements (evidence-based)"
+date: 2026-06-13
+description: "Evidence-based summary of the insurance requirement for Dominica's Work In Nature (WIN) extended stay visa: health insurance valid in Dominica, per the Government of Dominica."
+tags: ["dominica", "work-in-nature", "extended-stay", "insurance", "compliance"]
+faq:
+  - question: "What insurance does the Dominica Work In Nature visa require?"
+    answer: "The Government of Dominica requires health insurance valid in Dominica and covering you and all your family members."
+  - question: "Why is only Genki Native GREEN for this route?"
+    answer: "The policy must be valid in Dominica. Genki Native documents global coverage that includes Dominica; the other products do not document Dominica validity, so the engine records UNKNOWN rather than assuming a foreign policy qualifies."
+  - question: "Is there a minimum coverage amount?"
+    answer: "The official application process states no coverage amount, so the engine encodes none and models that insurance is mandatory and must be valid in Dominica."
+---
+
+## Short answer
+
+Dominica's Work In Nature (WIN) extended stay visa requires health insurance valid in Dominica and covering you and all your family members (Source: `DM_WIN_GOVDM_2026`, Government of the Commonwealth of Dominica; verified 2026-06-13). The official application process states no coverage amount, so the engine models two rules: insurance is mandatory, and the policy must be valid in Dominica.
+
+## Key findings at a glance
+
+| Item | Value |
+|---|---|
+| Route | Dominica Work In Nature (WIN) Extended Stay Visa |
+| Authority | Government of the Commonwealth of Dominica |
+| Evidence verified | 2026-06-13 |
+| Snapshot | 2026-06-13 |
+| Modeled rules | Insurance mandatory; valid in Dominica |
+
+## What the authority requires
+
+- Health insurance is a required document for the application. (Source: `DM_WIN_GOVDM_2026`; verified 2026-06-13)
+- It must be valid in Dominica and cover the applicant and all family members. (Source: `DM_WIN_GOVDM_2026`; verified 2026-06-13)
+- The application process states no coverage amount, so that stays UNKNOWN.
+
+Normalized requirements table:
+
+| Requirement | Source URL | Locator | Verified date |
+|---|---|---|---|
+| Insurance is mandatory | https://windominica.gov.dm/details/application-process | Application Process, required documents | 2026-06-13 |
+| Valid in Dominica | https://windominica.gov.dm/details/application-process | Application Process, required documents | 2026-06-13 |
+
+## Verified requirements (PASS/FAIL/UNKNOWN)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Insurance is mandatory | PASS | Government of Dominica application process |
+| Valid in Dominica | PASS only for products documenting Dominica coverage; UNKNOWN otherwise | "Health insurance valid in Dominica and covering you and all your family members" |
+| Minimum coverage amount | UNKNOWN | Not stated in the application process |
+
+## How we evaluate
+
+The checker compares each modeled requirement against product evidence. Two rules are encoded from the Government of Dominica application process: insurance is mandatory, and the policy must be valid in Dominica. A product is only credited with Dominica validity when its own documentation states coverage that includes Dominica; the engine does not assume a worldwide or home-country policy is valid there. Products silent about Dominica stay UNKNOWN rather than GREEN, and no coverage amount is encoded because the page states none, following the UNKNOWN > Wrong principle. See /methodology/ for the full logic.
+
+## Proof package checklist
+
+- Health insurance documented to be valid in Dominica, covering the applicant and family members.
+- A certificate showing the policy holder, policy number and coverage dates.
+- The remaining Work In Nature application documents.
+
+## FAQ
+
+**Q: What is required?**
+**A:** Health insurance valid in Dominica covering you and your family (Source: `DM_WIN_GOVDM_2026`; verified 2026-06-13).
+
+**Q: Why is only Genki Native GREEN?**
+**A:** It documents global coverage including Dominica; the others do not state Dominica validity, so they are UNKNOWN.
+
+**Q: Is there a minimum amount?**
+**A:** The official page states none, so the engine encodes no figure.
+
+## Check in the engine
+
+Use [the compliance checker](/ui/) with the current snapshot for this route:
+
+{{< checker_cta visa="DM_WIN_GOVDM_2026" product="GENKI_NATIVE_2026" snapshot="2026-06-13" >}}
+
+## Related reading
+
+- [Dominica Work In Nature requirements (route page)](/visas/dominica/work-in-nature-win-extended-stay-visa/work-in-nature-application-process-government-of-dominica/)
+- [Digital nomad insurance in the Americas](/posts/digital-nomad-insurance-americas/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## Where to find compliant insurance for Dominica Work In Nature
+
+The official requirement is health insurance valid in Dominica covering the whole family. In the current snapshot, Genki Native shows GREEN: it documents global coverage that includes Dominica. The travel-medical and Spanish products show UNKNOWN because their documents do not state validity in Dominica.
+
+- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+
+> Use the compliance checker to confirm the current GREEN products for this route before you buy.
+
+## Disclaimer + Affiliate disclosure
+
+Not legal advice. Compliance results are evidence-based snapshots.
+
+If an affiliate link is present, it appears only after results and does not change the compliance outcome. The Genki link above is a paid affiliate link.
+
+Last updated: 2026-06-13
+
+## Evidence log
+
+- Source: DM_WIN_GOVDM_2026

--- a/content/visas/dominica/work-in-nature-win-extended-stay-visa/_index.md
+++ b/content/visas/dominica/work-in-nature-win-extended-stay-visa/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Dominica Work In Nature (WIN) Extended Stay Visa"
+visa_group: "dominica-work-in-nature-win-extended-stay-visa"
+description: "Insurance requirements for Dominica Work In Nature (WIN) Extended Stay Visa - evidence-based compliance checker"
+---
+
+## Dominica Work In Nature (WIN) Extended Stay Visa Requirements
+
+All requirements below are derived from official sources. Missing evidence means UNKNOWN.
+
+## Routes
+
+| Authority | Route | Last Verified | Details |
+| --- | --- | --- | --- |
+| Government of the Commonwealth of Dominica (Work In Nature) | Work In Nature application process (Government of Dominica) | 2026-06-15 | [View requirements](/visas/dominica/work-in-nature-win-extended-stay-visa/work-in-nature-application-process-government-of-dominica/) |
+
+## What the authority requires
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+## How we evaluate
+
+We compare these official requirements against insurance product specifications using our automated rule engine. Each requirement is matched to a product fact with evidence.
+
+## Check in the engine
+
+Try the compliance checker: [Open Checker](/ui/?visa=DM_WIN_GOVDM_2026&snapshot=2026-06-13)
+
+## Disclaimer
+
+This is not legal advice. VisaFact provides evidence-based compliance checking only. Final visa decisions are made by government authorities. A GREEN result does not ensure visa approval.
+
+## Affiliate disclosure
+
+If affiliate links appear, they are shown only after compliance results and do not influence the compliance evaluation in any way.
+
+## Evidence log
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+
+{{< checker_cta visa="DM_WIN_GOVDM_2026" snapshot="2026-06-13" >}}

--- a/content/visas/dominica/work-in-nature-win-extended-stay-visa/work-in-nature-application-process-government-of-dominica/index.md
+++ b/content/visas/dominica/work-in-nature-win-extended-stay-visa/work-in-nature-application-process-government-of-dominica/index.md
@@ -1,0 +1,103 @@
+---
+title: "Dominica Work In Nature (WIN) Extended Stay Visa - Work In Nature application process (Government of Dominica)"
+visa_id: "DM_WIN_GOVDM_2026"
+last_verified: "2026-06-15"
+source_ids: ["DM_WIN_GOVDM_2026"]
+description: "Official insurance requirements for Dominica Work In Nature (WIN) Extended Stay Visa via Work In Nature application process (Government of Dominica)"
+faq:
+  - question: "What insurance does the Dominica Work In Nature visa require?"
+    answer: "The Government of Dominica requires health insurance valid in Dominica and covering you and all your family members."
+  - question: "Why is only Genki Native GREEN for this route?"
+    answer: "The policy must be valid in Dominica. Genki Native documents global coverage that includes Dominica; the other products do not document Dominica validity, so the engine records UNKNOWN rather than assuming a foreign policy qualifies."
+  - question: "Is there a minimum coverage amount?"
+    answer: "The official application process states no coverage amount, so the engine encodes none and models that insurance is mandatory and must be valid in Dominica."
+---
+
+## Dominica Work In Nature (WIN) Extended Stay Visa
+
+**Route:** Work In Nature application process (Government of Dominica)  
+**Authority:** Government of the Commonwealth of Dominica (Work In Nature)  
+**Last Verified:** 2026-06-15
+
+## Requirements
+
+| Requirement | Operator | Value | Evidence |
+| --- | --- | --- | --- |
+| `insurance.mandatory` | `==` | Yes | *Application Process, required documents*: "Health insurance valid in Dominica and covering you and all your family members..." ([source](/sources/DM_WIN_GOVDM_2026-06-15.html)) |
+| `insurance.authorized_in_country` | `==` | Yes | *Application Process, required documents*: "Health insurance valid in Dominica and covering you and all your family members..." ([source](/sources/DM_WIN_GOVDM_2026-06-15.html)) |
+
+## Source Documents
+
+- **DM_WIN_GOVDM_2026**: [Local copy](/sources/DM_WIN_GOVDM_2026-06-15.html) | [Original](https://windominica.gov.dm/details/application-process) | Retrieved: 2026-06-15
+
+## Related reading
+
+- [Dominica Work In Nature insurance requirements](/posts/dominica-work-in-nature-insurance/)
+- [Digital nomad insurance in the Americas](/posts/digital-nomad-insurance-americas/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## What the authority requires
+
+The points below are taken directly from the official source for the Dominica Work In Nature (WIN) Extended Stay Visa (Work In Nature application process (Government of Dominica)) route. Each one is recorded with a source identifier and a locator so it can be traced back to the original document. Where the source is silent on a point, the engine records UNKNOWN instead of inferring an answer.
+
+- The authority requires that insurance is mandatory.
+- The authority requires that authorized in country.
+
+This route is defined by a small number of explicit insurance points, which keeps the evidence trail short but also unusually clear. A concise official requirement still has to be matched precisely: a product is only GREEN here when its documented terms line up with the wording above, and a route with few stated rules does not imply that any policy will be accepted. Where the authority is silent, the engine deliberately holds the status at UNKNOWN or NOT_REQUIRED rather than reading extra conditions into the source, so the page reflects exactly what the document states and nothing more. Applicants on routes like this one should still keep the underlying policy wording on hand, because a consular officer may ask to see how each stated point is met even when the published checklist is short.
+
+## How we evaluate
+
+Every requirement is compared against the documented specification of each insurance product using an automated rule engine. A product is marked GREEN for a requirement only when product evidence explicitly satisfies it; a conflict produces RED; and absent evidence produces UNKNOWN rather than a guess. The route status is the combination of its per-requirement outcomes.
+
+- Rule `insurance.mandatory == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+- Rule `insurance.authorized_in_country == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+
+## How each compliance status is decided for this route
+
+GREEN means every recorded requirement is satisfied by product evidence. RED means at least one requirement is contradicted by the product evidence. YELLOW means the evidence is partial: some requirements are met while others lack full proof. UNKNOWN means a requirement exists but the product evidence does not address it, so no claim is made. NOT_REQUIRED means the authority does not impose an insurance requirement for the route, which is itself an evidence-based finding drawn from the official document. A GREEN result reflects the evidence on the snapshot date and is not an assurance of a visa outcome, which always rests with the issuing authority.
+
+## Reading the evidence and snapshots
+
+Each requirement above links to a primary source through a source identifier and a locator (for example a page number, article, or section). The underlying documents are listed under Source Documents and are stored alongside this dataset so the wording can be checked directly. Results are tied to a dated snapshot (`2026-06-13`): a deep link to a past snapshot returns the same verdict even if the authority later changes its rules, which keeps every decision reproducible and auditable.
+
+## Proof package checklist
+
+Before applying for this route, prepare the following so the policy can be checked against each requirement:
+
+- A policy certificate that states the coverage limits, any deductible or co-payment, and the covered period.
+- Written confirmation of the insurer's status where the route requires authorization in a specific country.
+- Documentation that the coverage spans the full authorized stay rather than a partial term.
+- The official source wording for the route, so each clause can be matched to the requirements above.
+
+## Common questions
+
+**What insurance does the Dominica Work In Nature visa require?**  
+The Government of Dominica requires health insurance valid in Dominica and covering you and all your family members.
+
+**Why is only Genki Native GREEN for this route?**  
+The policy must be valid in Dominica. Genki Native documents global coverage that includes Dominica; the other products do not document Dominica validity, so the engine records UNKNOWN rather than assuming a foreign policy qualifies.
+
+**Is there a minimum coverage amount?**  
+The official application process states no coverage amount, so the engine encodes none and models that insurance is mandatory and must be valid in Dominica.
+
+## Check in the engine
+
+Run a specific product against this route in the compliance checker: [Open Checker](/ui/?visa=DM_WIN_GOVDM_2026&snapshot=2026-06-13). The checker shows the per-requirement outcome and the evidence behind each one.
+
+## Disclaimer
+
+This page is not legal advice. VisaFact provides evidence-based compliance checking only, and final visa decisions are made by government authorities. A GREEN result reflects documented evidence on the snapshot date; it does not ensure that a visa application will succeed. Always confirm the current requirements with the issuing authority before submitting an application.
+
+## Affiliate disclosure
+
+If affiliate links appear on related pages, they are shown only after the compliance result and never change the evaluation, which is generated independently from the official evidence.
+
+## Evidence log
+
+Each entry pairs a requirement with the source identifier and locator it was drawn from:
+
+- `insurance.mandatory` <- DM_WIN_GOVDM_2026 (Application Process, required documents): "Health insurance valid in Dominica and covering you and all your family members"
+- `insurance.authorized_in_country` <- DM_WIN_GOVDM_2026 (Application Process, required documents): "Health insurance valid in Dominica and covering you and all your family members"
+
+
+{{< checker_cta visa="DM_WIN_GOVDM_2026" snapshot="2026-06-13" >}}

--- a/data/mappings/DM_WIN_GOVDM_2026__ASISA_HEALTH_RESIDENTS_2026.json
+++ b/data/mappings/DM_WIN_GOVDM_2026__ASISA_HEALTH_RESIDENTS_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "DM_WIN_GOVDM_2026",
+  "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.DM.authorized"
+  ]
+}

--- a/data/mappings/DM_WIN_GOVDM_2026__DKV_VISADO_2026.json
+++ b/data/mappings/DM_WIN_GOVDM_2026__DKV_VISADO_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "DM_WIN_GOVDM_2026",
+  "product_id": "DKV_VISADO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.DM.authorized"
+  ]
+}

--- a/data/mappings/DM_WIN_GOVDM_2026__GENERIC_EXPAT_COMPLETE_2026.json
+++ b/data/mappings/DM_WIN_GOVDM_2026__GENERIC_EXPAT_COMPLETE_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "DM_WIN_GOVDM_2026",
+  "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.DM.authorized"
+  ]
+}

--- a/data/mappings/DM_WIN_GOVDM_2026__GENKI_NATIVE_2026.json
+++ b/data/mappings/DM_WIN_GOVDM_2026__GENKI_NATIVE_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "DM_WIN_GOVDM_2026",
+  "product_id": "GENKI_NATIVE_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/DM_WIN_GOVDM_2026__GENKI_TRAVELER_2026.json
+++ b/data/mappings/DM_WIN_GOVDM_2026__GENKI_TRAVELER_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "DM_WIN_GOVDM_2026",
+  "product_id": "GENKI_TRAVELER_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.DM.authorized"
+  ]
+}

--- a/data/mappings/DM_WIN_GOVDM_2026__SAFETYWING_NOMAD_2026.json
+++ b/data/mappings/DM_WIN_GOVDM_2026__SAFETYWING_NOMAD_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "DM_WIN_GOVDM_2026",
+  "product_id": "SAFETYWING_NOMAD_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.DM.authorized"
+  ]
+}

--- a/data/mappings/DM_WIN_GOVDM_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
+++ b/data/mappings/DM_WIN_GOVDM_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "DM_WIN_GOVDM_2026",
+  "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.DM.authorized"
+  ]
+}

--- a/data/mappings/DM_WIN_GOVDM_2026__WORLDNOMADS_EXPLORER_2026.json
+++ b/data/mappings/DM_WIN_GOVDM_2026__WORLDNOMADS_EXPLORER_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "DM_WIN_GOVDM_2026",
+  "product_id": "WORLDNOMADS_EXPLORER_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.DM.authorized"
+  ]
+}

--- a/data/products/Genki/Native/2026-06-08/product_facts.json
+++ b/data/products/Genki/Native/2026-06-08/product_facts.json
@@ -106,6 +106,16 @@
             "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
           }
         ]
+      },
+      "DM": {
+        "authorized": true,
+        "evidence": [
+          {
+            "source_id": "GENKI_NATIVE_COVERAGE_2026",
+            "locator": "Global Coverage",
+            "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
+          }
+        ]
       }
     }
   },

--- a/data/ui_index.json
+++ b/data/ui_index.json
@@ -1,5 +1,5 @@
 {
-  "built_at": "2026-06-15T13:50:49.944091+00:00",
+  "built_at": "2026-06-15T13:55:16.235111+00:00",
   "snapshot_id": "2026-06-15",
   "visas": [
     {
@@ -489,6 +489,49 @@
               "source_id": "DE_D_VISA_HEALTH_INSURANCE_2026",
               "locator": "Health insurance requirements for national (category D) visas",
               "excerpt": "Travel insurance is not sufficient for any D visa application."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "DM_WIN_GOVDM_2026",
+      "country": "Dominica",
+      "visa_name": "Work In Nature (WIN) Extended Stay Visa",
+      "route": "Work In Nature application process (Government of Dominica)",
+      "authority": "Government of the Commonwealth of Dominica (Work In Nature)",
+      "last_verified": "2026-06-15",
+      "sources": [
+        {
+          "source_id": "DM_WIN_GOVDM_2026",
+          "url": "https://windominica.gov.dm/details/application-process",
+          "retrieved_at": "2026-06-15T00:00:00Z",
+          "sha256": "770819044a7d713797d90d140f77d7dced5f7e4a54cdc3b1f2aa884949089b38",
+          "local_path": "sources/DM_WIN_GOVDM_2026-06-15.html"
+        }
+      ],
+      "requirements": [
+        {
+          "key": "insurance.mandatory",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "DM_WIN_GOVDM_2026",
+              "locator": "Application Process, required documents",
+              "excerpt": "Health insurance valid in Dominica and covering you and all your family members"
+            }
+          ]
+        },
+        {
+          "key": "insurance.authorized_in_country",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "DM_WIN_GOVDM_2026",
+              "locator": "Application Process, required documents",
+              "excerpt": "Health insurance valid in Dominica and covering you and all your family members"
             }
           ]
         }
@@ -2139,6 +2182,16 @@
                 "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
               }
             ]
+          },
+          "DM": {
+            "authorized": true,
+            "evidence": [
+              {
+                "source_id": "GENKI_NATIVE_COVERAGE_2026",
+                "locator": "Global Coverage",
+                "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
+              }
+            ]
           }
         }
       },
@@ -2633,7 +2686,7 @@
       "missing": [
         "specs.overall_limit"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "BZ_LONGSTAY_IMMIG_2026",
@@ -2643,7 +2696,7 @@
       "missing": [
         "specs.overall_limit"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "BZ_LONGSTAY_IMMIG_2026",
@@ -2653,7 +2706,7 @@
       "missing": [
         "specs.overall_limit"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "BZ_LONGSTAY_IMMIG_2026",
@@ -2661,7 +2714,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "BZ_LONGSTAY_IMMIG_2026",
@@ -2669,7 +2722,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "BZ_LONGSTAY_IMMIG_2026",
@@ -2677,7 +2730,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "BZ_LONGSTAY_IMMIG_2026",
@@ -2687,7 +2740,7 @@
       "missing": [
         "specs.overall_limit"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "BZ_LONGSTAY_IMMIG_2026",
@@ -2695,7 +2748,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "CO_DNV_CANCILLERIA_2026",
@@ -3152,6 +3205,84 @@
       ],
       "missing": [],
       "last_verified": "2026-01-15"
+    },
+    {
+      "visa_id": "DM_WIN_GOVDM_2026",
+      "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.DM.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "DM_WIN_GOVDM_2026",
+      "product_id": "DKV_VISADO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.DM.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "DM_WIN_GOVDM_2026",
+      "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.DM.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "DM_WIN_GOVDM_2026",
+      "product_id": "GENKI_NATIVE_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "DM_WIN_GOVDM_2026",
+      "product_id": "GENKI_TRAVELER_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.DM.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "DM_WIN_GOVDM_2026",
+      "product_id": "SAFETYWING_NOMAD_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.DM.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "DM_WIN_GOVDM_2026",
+      "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.DM.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "DM_WIN_GOVDM_2026",
+      "product_id": "WORLDNOMADS_EXPLORER_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.DM.authorized"
+      ],
+      "last_verified": ""
     },
     {
       "visa_id": "EC_NOMAD_CANCILLERIA_2026",
@@ -5703,6 +5834,13 @@
       "retrieved_at": "2026-01-16T00:00:00Z",
       "sha256": "823c9d4c993824cdcf9e47b3b6bf9a45848e70dd0b9cd54b304ff8aa19116560",
       "local_path": "sources/DKV_VISADO_CONDICIONES_2026-01-16.pdf"
+    },
+    "DM_WIN_GOVDM_2026": {
+      "source_id": "DM_WIN_GOVDM_2026",
+      "url": "https://windominica.gov.dm/details/application-process",
+      "retrieved_at": "2026-06-15T00:00:00Z",
+      "sha256": "770819044a7d713797d90d140f77d7dced5f7e4a54cdc3b1f2aa884949089b38",
+      "local_path": "sources/DM_WIN_GOVDM_2026-06-15.html"
     },
     "EC_NOMAD_CANCILLERIA_2026": {
       "source_id": "EC_NOMAD_CANCILLERIA_2026",

--- a/data/visas/DM/WIN/govdm/2026-06-15/visa_facts.json
+++ b/data/visas/DM/WIN/govdm/2026-06-15/visa_facts.json
@@ -1,0 +1,43 @@
+{
+  "id": "DM_WIN_GOVDM_2026",
+  "country": "Dominica",
+  "visa_name": "Work In Nature (WIN) Extended Stay Visa",
+  "route": "Work In Nature application process (Government of Dominica)",
+  "authority": "Government of the Commonwealth of Dominica (Work In Nature)",
+  "last_verified": "2026-06-15",
+  "sources": [
+    {
+      "source_id": "DM_WIN_GOVDM_2026",
+      "url": "https://windominica.gov.dm/details/application-process",
+      "retrieved_at": "2026-06-15T00:00:00Z",
+      "sha256": "770819044a7d713797d90d140f77d7dced5f7e4a54cdc3b1f2aa884949089b38",
+      "local_path": "sources/DM_WIN_GOVDM_2026-06-15.html"
+    }
+  ],
+  "requirements": [
+    {
+      "key": "insurance.mandatory",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "DM_WIN_GOVDM_2026",
+          "locator": "Application Process, required documents",
+          "excerpt": "Health insurance valid in Dominica and covering you and all your family members"
+        }
+      ]
+    },
+    {
+      "key": "insurance.authorized_in_country",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "DM_WIN_GOVDM_2026",
+          "locator": "Application Process, required documents",
+          "excerpt": "Health insurance valid in Dominica and covering you and all your family members"
+        }
+      ]
+    }
+  ]
+}

--- a/sources/DM_WIN_GOVDM_2026-06-15.html
+++ b/sources/DM_WIN_GOVDM_2026-06-15.html
@@ -1,0 +1,343 @@
+
+<!doctype html>
+<html lang="en-gb" dir="ltr">
+	<head>
+		
+		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+		<meta charset="utf-8">
+	<meta name="author" content="Zamar Thomas">
+	<meta name="description" content="Work in Nature's official website.">
+	<meta name="generator" content="Joomla! - Open Source Content Management">
+	<title>Application Process - Work in Nature</title>
+	<link href="/images/zt_win2.png" rel="icon" type="image/png">
+	<link href="https://windominica.gov.dm/component/search/?id=25&amp;Itemid=147&amp;format=opensearch" rel="search" title="Search Work in Nature" type="application/opensearchdescription+xml">
+<link href="/media/vendor/joomla-custom-elements/css/joomla-alert.min.css?0.4.1" rel="stylesheet">
+	<link href="/templates/shaper_helixultimate/css/bootstrap.min.css" rel="stylesheet">
+	<link href="/plugins/system/helixultimate/assets/css/system-j4.min.css" rel="stylesheet">
+	<link href="/media/system/css/joomla-fontawesome.min.css?b2d731" rel="stylesheet">
+	<link href="/templates/shaper_helixultimate/css/template.css" rel="stylesheet">
+	<link href="/templates/shaper_helixultimate/css/presets/default.css" rel="stylesheet">
+	<style>h1{font-family: 'Arial', sans-serif;text-decoration: none;}
+</style>
+	<style>.logo-image {height:36px;}.logo-image-phone {height:36px;}</style>
+<script src="/media/vendor/jquery/js/jquery.min.js?3.7.1"></script>
+	<script src="/media/legacy/js/jquery-noconflict.min.js?504da4"></script>
+	<script type="application/json" class="joomla-script-options new">{"data":{"breakpoints":{"tablet":991,"mobile":480},"header":{"stickyOffset":"100"}},"joomla.jtext":{"ERROR":"Error","MESSAGE":"Message","NOTICE":"Notice","WARNING":"Warning","JCLOSE":"Close","JOK":"OK","JOPEN":"Open"},"system.paths":{"root":"","rootFull":"https:\/\/windominica.gov.dm\/","base":"","baseFull":"https:\/\/windominica.gov.dm\/"},"csrf.token":"5721b60c0b4ff2640f983937a0d8585f"}</script>
+	<script src="/media/system/js/core.min.js?a3d8f8"></script>
+	<script src="/media/vendor/bootstrap/js/alert.min.js?5.3.8" type="module"></script>
+	<script src="/media/vendor/bootstrap/js/button.min.js?5.3.8" type="module"></script>
+	<script src="/media/vendor/bootstrap/js/carousel.min.js?5.3.8" type="module"></script>
+	<script src="/media/vendor/bootstrap/js/collapse.min.js?5.3.8" type="module"></script>
+	<script src="/media/vendor/bootstrap/js/dropdown.min.js?5.3.8" type="module"></script>
+	<script src="/media/vendor/bootstrap/js/modal.min.js?5.3.8" type="module"></script>
+	<script src="/media/vendor/bootstrap/js/offcanvas.min.js?5.3.8" type="module"></script>
+	<script src="/media/vendor/bootstrap/js/popover.min.js?5.3.8" type="module"></script>
+	<script src="/media/vendor/bootstrap/js/scrollspy.min.js?5.3.8" type="module"></script>
+	<script src="/media/vendor/bootstrap/js/tab.min.js?5.3.8" type="module"></script>
+	<script src="/media/vendor/bootstrap/js/toast.min.js?5.3.8" type="module"></script>
+	<script src="/media/system/js/showon.min.js?e51227" type="module"></script>
+	<script src="/media/system/js/messages.min.js?9a4811" type="module"></script>
+	<script src="/templates/shaper_helixultimate/js/main.js"></script>
+	<script type="application/ld+json">{"@context":"https://schema.org","@type":"BreadcrumbList","@id":"https://windominica.gov.dm/#/schema/BreadcrumbList/17","itemListElement":[{"@type":"ListItem","position":1,"item":{"@id":"https://windominica.gov.dm/","name":"HOME"}},{"@type":"ListItem","position":2,"item":{"@id":"https://windominica.gov.dm/details/eligibility","name":"VISA DETAILS"}},{"@type":"ListItem","position":3,"item":{"@id":"https://windominica.gov.dm/details/application-process","name":"APPLICATION PROCESS "}}]}</script>
+	<script type="application/ld+json">{"@context":"https://schema.org","@graph":[{"@type":"Organization","@id":"https://windominica.gov.dm/#/schema/Organization/base","name":"Work in Nature","url":"https://windominica.gov.dm/"},{"@type":"WebSite","@id":"https://windominica.gov.dm/#/schema/WebSite/base","url":"https://windominica.gov.dm/","name":"Work in Nature","publisher":{"@id":"https://windominica.gov.dm/#/schema/Organization/base"}},{"@type":"WebPage","@id":"https://windominica.gov.dm/#/schema/WebPage/base","url":"https://windominica.gov.dm/details/application-process","name":"Application Process - Work in Nature","description":"Work in Nature's official website.","isPartOf":{"@id":"https://windominica.gov.dm/#/schema/WebSite/base"},"about":{"@id":"https://windominica.gov.dm/#/schema/Organization/base"},"inLanguage":"en-GB"},{"@type":"Article","@id":"https://windominica.gov.dm/#/schema/com_content/article/25","name":"Application Process","headline":"Application Process","inLanguage":"en-GB","isPartOf":{"@id":"https://windominica.gov.dm/#/schema/WebPage/base"}}]}</script>
+	<script>template="shaper_helixultimate";</script>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Shadows+Into+Light&display=swap" rel="stylesheet" />
+<link href="/templates/shaper_helixultimate/css/style.css" rel="stylesheet" type="text/css" />
+			<link rel="stylesheet" type="text/css" href="/media/smartslider3/src/SmartSlider3/Application/Frontend/Assets/dist/smartslider.min.css?ver=c397fa89" media="all">
+<style data-related="n2-ss-5">div#n2-ss-5 .n2-ss-slider-1{display:grid;box-sizing:border-box;position:relative;background-repeat:repeat;background-position:50% 50%;background-size:cover;background-attachment:scroll;border:0px solid RGBA(62,62,62,1);border-radius:0px;overflow:hidden;}div#n2-ss-5:not(.n2-ss-loaded) .n2-ss-slider-1{background-image:none !important;}div#n2-ss-5 .n2-ss-slider-2{display:grid;place-items:center;position:relative;overflow:hidden;z-index:10;}div#n2-ss-5 .n2-ss-slider-3{position:relative;width:100%;height:100%;z-index:20;display:grid;grid-template-areas:'slide';}div#n2-ss-5 .n2-ss-slider-3 > *{grid-area:slide;}div#n2-ss-5.n2-ss-full-page--constrain-ratio .n2-ss-slider-3{height:auto;}div#n2-ss-5 .n2-ss-slide-backgrounds{position:absolute;left:0;top:0;width:100%;height:100%;}div#n2-ss-5 .n2-ss-slide-backgrounds{z-index:10;}div#n2-ss-5 .n2-ss-slide{display:grid;place-items:center;grid-auto-columns:100%;position:relative;width:100%;height:100%;-webkit-backface-visibility:hidden;z-index:20;}div#n2-ss-5 .n2-ss-slide{perspective:1500px;}div#n2-ss-5 .n2-ss-slide-limiter{max-width:1200px;}div#n2-ss-5 .n-uc-1Kj6ivYs1V6C{padding:10px 10px 10px 10px}@media (min-width: 1200px){div#n2-ss-5 [data-hide-desktopportrait="1"]{display: none !important;}}@media (orientation: landscape) and (max-width: 1199px) and (min-width: 901px),(orientation: portrait) and (max-width: 1199px) and (min-width: 701px){div#n2-ss-5 [data-hide-tabletportrait="1"]{display: none !important;}}@media (orientation: landscape) and (max-width: 900px),(orientation: portrait) and (max-width: 700px){div#n2-ss-5 [data-hide-mobileportrait="1"]{display: none !important;}}</style>
+<script>(function(){this._N2=this._N2||{_r:[],_d:[],r:function(){this._r.push(arguments)},d:function(){this._d.push(arguments)}}}).call(window);</script><script src="/media/smartslider3/src/SmartSlider3/Application/Frontend/Assets/dist/n2.min.js?ver=c397fa89" defer async></script>
+<script src="/media/smartslider3/src/SmartSlider3/Application/Frontend/Assets/dist/smartslider-frontend.min.js?ver=c397fa89" defer async></script>
+<script src="/media/smartslider3/src/SmartSlider3/Slider/SliderType/Block/Assets/dist/ss-block.min.js?ver=c397fa89" defer async></script>
+<script>_N2.r('documentReady',function(){_N2.r(["documentReady","smartslider-frontend","ss-block"],function(){new _N2.SmartSliderBlock('n2-ss-5',{"admin":false,"background.video.mobile":1,"loadingTime":2000,"callbacks":"","alias":{"id":0,"smoothScroll":0,"slideSwitch":0,"scroll":1},"align":"normal","isDelayed":0,"responsive":{"mediaQueries":{"all":false,"desktopportrait":["(min-width: 1200px)"],"tabletportrait":["(orientation: landscape) and (max-width: 1199px) and (min-width: 901px)","(orientation: portrait) and (max-width: 1199px) and (min-width: 701px)"],"mobileportrait":["(orientation: landscape) and (max-width: 900px)","(orientation: portrait) and (max-width: 700px)"]},"base":{"slideOuterWidth":1200,"slideOuterHeight":305,"sliderWidth":1200,"sliderHeight":305,"slideWidth":1200,"slideHeight":305},"hideOn":{"desktopLandscape":false,"desktopPortrait":false,"tabletLandscape":false,"tabletPortrait":false,"mobileLandscape":false,"mobilePortrait":false},"onResizeEnabled":true,"type":"fullwidth","sliderHeightBasedOn":"real","focusUser":1,"focusEdge":"auto","breakpoints":[{"device":"tabletPortrait","type":"max-screen-width","portraitWidth":1199,"landscapeWidth":1199},{"device":"mobilePortrait","type":"max-screen-width","portraitWidth":700,"landscapeWidth":900}],"enabledDevices":{"desktopLandscape":0,"desktopPortrait":1,"tabletLandscape":0,"tabletPortrait":1,"mobileLandscape":0,"mobilePortrait":1},"sizes":{"desktopPortrait":{"width":1200,"height":305,"max":3000,"min":1200},"tabletPortrait":{"width":701,"height":178,"customHeight":false,"max":1199,"min":701},"mobilePortrait":{"width":320,"height":81,"customHeight":false,"max":900,"min":320}},"overflowHiddenPage":0,"focus":{"offsetTop":"","offsetBottom":""}},"controls":{"mousewheel":0,"touch":0,"keyboard":0,"blockCarouselInteraction":1},"playWhenVisible":1,"playWhenVisibleAt":0.5,"lazyLoad":0,"lazyLoadNeighbor":0,"blockrightclick":0,"maintainSession":0,"autoplay":{"enabled":0,"start":0,"duration":8000,"autoplayLoop":1,"allowReStart":0,"reverse":0,"pause":{"click":1,"mouse":"enter","mediaStarted":1},"resume":{"click":0,"mouse":0,"mediaEnded":1,"slidechanged":0},"interval":1,"intervalModifier":"loop","intervalSlide":"current"},"perspective":1500,"layerMode":{"playOnce":0,"playFirstLayer":1,"mode":"skippable","inAnimation":"mainInEnd"},"initCallbacks":function(){}})})});</script></head>
+	<body class="site helix-ultimate hu com_content com-content view-article layout-default task-none itemid-147 en-gb ltr layout-fluid offcanvas-init offcanvs-position-right">
+
+		
+		
+		<div class="body-wrapper">
+			<div class="body-innerwrapper">
+								<main id="sp-main">
+					
+<section id="sp-travel-protocols" >
+
+						<div class="container">
+				<div class="container-inner">
+			
+	
+<div class="row">
+	<div id="sp-position1" class="col-lg-12 "><div class="sp-column "><div class="sp-module zt_nothomesearch"><div class="sp-module-content"><div class="search">
+	<form action="/details/application-process" method="post">
+		<label for="mod-search-searchword104" class="hide-label">Search ...</label> <input name="searchword" id="mod-search-searchword104" class="form-control" type="search" placeholder="Search ...">		<input type="hidden" name="task" value="search">
+		<input type="hidden" name="option" value="com_search">
+		<input type="hidden" name="Itemid" value="147">
+	</form>
+</div>
+</div></div></div></div></div>
+							</div>
+			</div>
+			
+	</section>
+
+<section id="sp-logo" >
+
+						<div class="container">
+				<div class="container-inner">
+			
+	
+<div class="row">
+	<div id="sp-position3" class="col-lg-12 "><div class="sp-column "><div class="sp-module "><div class="sp-module-content">
+<div id="mod-custom156" class="mod-custom custom">
+    <div class="row py-3">
+<div class="col d-flex align-items-center"><a href="/"> <img class="zt_crest_logo" src="/images/gocd_coa.png" alt="" /> </a></div>
+<div class="col"><a href="/"> <img class="zt_win_logo" src="/images/zt_win2.png" alt="" /> </a></div>
+<div class="col zt_social_logo d-flex align-items-center justify-content-center"><a href="https:/www.youtube.com/channel/UCZocTjk6ud1IWHELGqeirCA" target="_blank" rel="noopener noreferrer"> <img class="zt_youtube_logo" src="/images/zt_youtube.png" alt="" /> </a> <a href="https://twitter.com/WorkInNatureDom" target="_blank" rel="noopener noreferrer"> <img class="zt_twitter_logo" src="/images/zt_twitter.png" alt="" /> </a> <a href="https://www.facebook.com/WorkInNature.Dominica" target="_blank" rel="noopener noreferrer"> <img class="zt_fb_logo" src="/images/zt_facebook.png" alt="" /> </a></div>
+</div></div>
+</div></div></div></div></div>
+							</div>
+			</div>
+			
+	</section>
+
+<section id="sp-main-menu" >
+
+						<div class="container">
+				<div class="container-inner">
+			
+	
+<div class="row">
+	<div id="sp-menu" class="col-lg-8 "><div class="sp-column "><div class="sp-module menu-apply-now-btn"><div class="sp-module-content">
+<div id="mod-custom125" class="mod-custom custom">
+    <p> <a class="btn btn-primary" href="/payments">Apply Now</a></p></div>
+</div></div><nav class="sp-megamenu-wrapper d-flex" role="navigation" aria-label="navigation"><ul class="sp-megamenu-parent menu-animation-fade-up d-none d-lg-block"><li class="sp-menu-item"><a   href="/"  >HOME</a></li><li class="sp-menu-item sp-has-child active"><a   href="/details/eligibility"  >VISA DETAILS</a><div class="sp-dropdown sp-dropdown-main sp-menu-right" style="width: 240px;"><div class="sp-dropdown-inner"><ul class="sp-dropdown-items"><li class="sp-menu-item"><a   href="/details/eligibility"  >ELIGIBILITY</a></li><li class="sp-menu-item current-item active"><a aria-current="page"  href="/details/application-process"  >APPLICATION PROCESS </a></li><li class="sp-menu-item"><a   href="/details/fees"  >FEES</a></li><li class="sp-menu-item"><a   href="/details/processing-times"  >PROCESSING TIMES </a></li></ul></div></div></li><li class="sp-menu-item"><a   href="/faq"  >FAQ</a></li><li class="sp-menu-item sp-has-child"><a   href="/life-in-dominica"  >LIFE IN DOMINICA</a><div class="sp-dropdown sp-dropdown-main sp-menu-right" style="width: 240px;"><div class="sp-dropdown-inner"><ul class="sp-dropdown-items"><li class="sp-menu-item"><a  rel="noopener noreferrer" href="https://hub.touchstay.com/guest/uxVf63aXAELOg/info/#i_subcategory_item204446" target="_blank"  >INCENTIVES</a></li><li class="sp-menu-item sp-has-child"><a   href="/life-in-dominica/where-to-stay"  >WHERE TO STAY?</a><div class="sp-dropdown sp-dropdown-sub sp-menu-right" style="width: 240px;"><div class="sp-dropdown-inner"><ul class="sp-dropdown-items"><li class="sp-menu-item"><a  rel="noopener noreferrer" href="https://hub.touchstay.com/guest/uxVf63aXAELOg/info/" target="_blank"  >EXTENDED STAY PACKAGES</a></li><li class="sp-menu-item"><a   href="/life-in-dominica/where-to-stay/accomodation"  > ACCOMODATION</a></li><li class="sp-menu-item"><a   href="/life-in-dominica/where-to-stay/real-estate-companies"  >REAL ESTATE COMPANIES</a></li></ul></div></div></li><li class="sp-menu-item"><a   href="/life-in-dominica/health-care"  >HEALTH CARE</a></li><li class="sp-menu-item"><a   href="/life-in-dominica/education"  >EDUCATION</a></li><li class="sp-menu-item"><a   href="/life-in-dominica/coworking-spaces"  >COWORKING SPACES</a></li><li class="sp-menu-item"><a   href="/life-in-dominica/make-an-impact-with-win"  >MAKE AN IMPACT</a></li><li class="sp-menu-item"><a  rel="noopener noreferrer" href="https://discoverdominica.com/travel-advisory-for-dominica" target="_blank"  >LATEST TRAVEL ADVISORY</a></li><li class="sp-menu-item"><a   href="/life-in-dominica/photo-gallery"  >PHOTO GALLERY</a></li></ul></div></div></li><li class="sp-menu-item"><a   href="/contact"  >CONTACT</a></li><li class="sp-menu-item"><a   href="/blog"  >BLOG</a></li></ul><a id="offcanvas-toggler" aria-label="Menu" class="offcanvas-toggler-right offcanvas-toggler-custom d-lg-none" href="#" title="Menu"><div class="burger-icon" aria-hidden="true"><span></span><span></span><span></span></div></a></nav></div></div><div id="sp-position6" class="col-lg-4 "><div class="sp-column "><div class="sp-module zt_applynow"><div class="sp-module-content">
+<div id="mod-custom107" class="mod-custom custom">
+    <p> <a class="btn btn-primary" href="/details/application-process?view=article&amp;id=10:apply-now&amp;catid=2">Apply Now</a></p></div>
+</div></div></div></div></div>
+							</div>
+			</div>
+			
+	</section>
+
+<section id="sp-page-title" >
+
+				
+	
+<div class="row">
+	<div id="sp-position7" class="col-lg-12 "><div class="sp-column "><div class="sp-module zt_mediaheader"><h3 class="sp-module-title">VISA DETAILS</h3><div class="sp-module-content"><div><div class="n2_clear"><ss3-force-full-width data-overflow-x="body" data-horizontal-selector="body"><div class="n2-section-smartslider fitvidsignore  n2_clear" data-ssid="5" tabindex="0" role="region" aria-label="Slider"><div id="n2-ss-5-align" class="n2-ss-align"><div class="n2-padding"><div id="n2-ss-5" data-creator="Smart Slider 3" data-responsive="fullwidth" class="n2-ss-slider n2-ow n2-has-hover n2notransition  ">
+        <div class="n2-ss-slider-1 n2-ow">
+            <div class="n2-ss-slider-2 n2-ow">
+                <div class="n2-ss-slide-backgrounds n2-ow-all"><div class="n2-ss-slide-background" data-public-id="1" data-mode="fill"><div class="n2-ss-slide-background-image" data-blur="0" data-opacity="100" data-x="71" data-y="74" data-alt="" data-title="" style="--ss-o-pos-x:71%;--ss-o-pos-y:74%"><picture class="skip-lazy" data-skip-lazy="1"><img src="/images/optimization/Dominica_-_Roseau_Filter.jpg" alt="" title="" loading="lazy" class="skip-lazy" data-skip-lazy="1"></picture></div><div data-color="RGBA(255,255,255,0)" style="background-color: RGBA(255,255,255,0);" class="n2-ss-slide-background-color"></div></div></div>                <div class="n2-ss-slider-3 n2-ow">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 305" data-related-device="desktopPortrait" class="n2-ow n2-ss-preserve-size n2-ss-preserve-size--slider n2-ss-slide-limiter"></svg><div data-first="1" data-slide-duration="0" data-id="25" data-slide-public-id="1" data-title="Slide" class="n2-ss-slide n2-ow  n2-ss-slide-25"><div role="note" class="n2-ss-slide--focus" tabindex="-1">Slide</div><div class="n2-ss-layers-container n2-ss-slide-limiter n2-ow"><div class="n2-ss-layer n2-ow n-uc-1Kj6ivYs1V6C" data-sstype="slide" data-pm="default"></div></div></div>                </div>
+                            </div>
+        </div>
+        </div><ss3-loader></ss3-loader></div></div><div class="n2_clear"></div></div></ss3-force-full-width></div></div></div></div></div></div></div>
+				
+	</section>
+
+<section id="sp-breadcrumb" >
+
+						<div class="container">
+				<div class="container-inner">
+			
+	
+<div class="row">
+	<div id="sp-breadcrumb" class="col-lg-12 "><div class="sp-column "><div class="sp-module "><div class="sp-module-content"><nav class="mod-breadcrumbs__wrapper" aria-label="Breadcrumbs">
+    <ol class="mod-breadcrumbs breadcrumb px-3 py-2">
+                    <li class="mod-breadcrumbs__here float-start">
+                You are here: &#160;
+            </li>
+        
+        <li class="mod-breadcrumbs__item breadcrumb-item"><a href="/" class="pathway"><span>HOME</span></a></li><li class="mod-breadcrumbs__item breadcrumb-item"><a href="/details/eligibility" class="pathway"><span>VISA DETAILS</span></a></li><li class="mod-breadcrumbs__item breadcrumb-item active"><span>APPLICATION PROCESS </span></li>    </ol>
+    </nav>
+</div></div></div></div></div>
+							</div>
+			</div>
+			
+	</section>
+
+<section id="sp-main-body" >
+
+										<div class="container">
+					<div class="container-inner">
+						
+	
+<div class="row">
+	
+<div id="sp-component" class="col-lg-8 ">
+	<div class="sp-column ">
+		<div id="system-message-container" aria-live="polite"></div>
+
+
+		
+		<div class="article-details " itemscope itemtype="https://schema.org/Article">
+    <meta itemprop="inLanguage" content="en-GB">
+
+    
+    
+    
+    
+            <div class="article-header">
+                            <h1 itemprop="headline">
+                    Application Process                </h1>
+            
+            
+            
+                    </div>
+    
+    <div class="article-can-edit d-flex flex-wrap justify-content-between">
+                
+            </div>
+
+    
+        
+                
+    
+        
+        
+        
+        <div itemprop="articleBody">
+            <p><strong>STEP 1:</strong></p>
+<p>You must submit your WIN Extended Stay <a href="http://apply.windominica.gov.dm/Account/Login?ReturnUrl=%2F" target="_blank" rel="alternate noopener noreferrer">Visa Application Form</a> online and pay the <a href="https://epayment.dominica.gov.dm/Services/Addpayment/3744" target="_blank" rel="alternate noopener noreferrer">non-refundable Application Fee</a></p>
+<p><em><br /> </em><strong>STEP 2:</strong></p>
+<p>You must also upload the following documentation for yourself and any family member who is accompanying you, where relevant:</p>
+<ol>
+<li>Bio data page of valid passport (for yourself and all your family members)</li>
+<li>Proof of relationship of dependants (i.e. your family members). This can include, for example, a marriage, birth, or adoption certificate, depending on which family member is joining you.</li>
+<li>Police record(s) (for yourself and all your family members over the age of 18). A police record must be obtained from all the jurisdictions in which you/your family member lived in the past five years</li>
+<li>Bank reference letter</li>
+<li>Employment letter. If your income is not from a regular employment salary, then you must also provide a recent bank statement and certificate of good standing and/or credit report</li>
+<li>Passport-sized photos (for yourself and all your family members over the age of 18)</li>
+<li>Visa to Dominica (only if you/your family member is a passport holder of a country where a visa is required for entry to Dominica)</li>
+<li>Health insurance valid in Dominica and covering you and all your family members</li>
+</ol>
+<p> </p>
+<p>For documents not in English, a translated and certified copy is required.</p>
+<p>Once your application is received by a WIN Tourism Technical Officer, you will be automatically assigned an ID number.</p>
+<p> </p>
+<p><strong>STEP 3:</strong></p>
+<p>Your application is reviewed for completeness by the WIN Tourism Department. A WIN Information Officer will liaise with you if necessary.</p>
+<p> </p>
+<p><strong>STEP 4:</strong></p>
+<p>Once your application has been checked for completeness, it is submitted to the Permanent Secretary or Tourism Authority for recommendation, and to the Joint Regional Communications Centre (JRCC) for due diligence processing.</p>
+<p> </p>
+<p><strong>STEP 5:</strong></p>
+<p>Your application, the recommendation, and the JRCC Report is reviewed by the National Security and Home Affairs Department. Your application will be then approved or disapproved by the Minister for National Security and Home Affairs.</p>
+<p> </p>
+<p><strong>STEP 6:</strong></p>
+<p>If you are successful, you will receive an approval letter from the Permanent Secretary or the Tourism Authority.</p>
+<p> </p>
+<p><strong>STEP 7:</strong></p>
+<p>You will then be asked to pay the relevant WIN Visa Fee online within 30 days. Once the payment is verified, you will receive an automated receipt.</p>
+<p> </p>
+<p><strong>STEP 8:</strong></p>
+<p>Travel to Dominica, letting your WIN Information Officer know your flight and arrival details.</p>         </div>
+
+        
+        
+        
+    
+
+        
+    
+
+   
+                </div>
+
+			</div>
+</div>
+<aside id="sp-right" class="col-lg-4 "><div class="sp-column "><div class="sp-module zt_rightmenu"><h3 class="sp-module-title">Visa Information</h3><div class="sp-module-content"><ul class="mod-articlescategory category-module mod-list">
+                    <li>
+                                    <a href="/details/eligibility" class="mod-articles-category-title ">Eligibility</a>    
+    
+    
+    
+    
+    
+    
+    </li>
+<li>
+                                    <a href="/details/application-process" class="mod-articles-category-title active">Application Process</a>    
+    
+    
+    
+    
+    
+    
+    </li>
+<li>
+                                    <a href="/details/fees" class="mod-articles-category-title ">Fees</a>    
+    
+    
+    
+    
+    
+    
+    </li>
+<li>
+                                    <a href="/details/processing-times" class="mod-articles-category-title ">Processing Times</a>    
+    
+    
+    
+    
+    
+    
+    </li>
+    </ul>
+</div></div></div></aside></div>
+											</div>
+				</div>
+						
+	</section>
+
+<footer id="sp-footer" >
+
+						<div class="container">
+				<div class="container-inner">
+			
+	
+<div class="row">
+	<div id="sp-footer1" class="col-lg-12 "><div class="sp-column "><div class="sp-module zt_copyright"><div class="sp-module-content">
+<div id="mod-custom100" class="mod-custom custom">
+    <p><span style="font-family: courier new, courier, monospace;"> <a style="display: none;" href="https://adventurely.app/" target="_blank" rel="noopener noreferrer"> <img class="adv_logo footer_logo" src="/images/optimization/adventurely_logo.png" alt="" width="434" height="113"> </a> <a href="https://hub.touchstay.com/guest/uxVf63aXAELOg/info/" target="_blank" rel="noopener noreferrer"> <img class="footer_logo" src="/images/optimization/experience_dominica_logo.png" alt="" width="362" height="94"> </a> <br>Copyright © <span id="jsyr">2021</span> - Government of the Commonwealth of Dominica. All rights reserved. </span></p>
+<p><script> 
+const wzd = new Date(); 
+document.getElementById("jsyr").innerText = wzd.getFullYear(); 
+</script></p></div>
+</div></div></div></div></div>
+							</div>
+			</div>
+			
+	</footer>
+				</main>
+			</div>
+		</div>
+
+		<!-- Off Canvas Menu -->
+		<div class="offcanvas-overlay"></div>
+		<!-- Rendering the offcanvas style -->
+		<!-- If canvas style selected then render the style -->
+		<!-- otherwise (for old templates) attach the offcanvas module position -->
+									
+
+		<!-- Matomo -->
+<script>
+  var _paq = window._paq = window._paq || [];
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//windominica.gov.dm/stats/";
+    _paq.push(['setTrackerUrl', u+'matomo.php']);
+    _paq.push(['setSiteId', '1']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Code -->
+
+		
+
+		<!-- Go to top -->
+					<a href="#" class="sp-scroll-up" aria-label="Scroll to top"><span class="fas fa-angle-up" aria-hidden="true"></span></a>
+					</body>
+</html>

--- a/sources/DM_WIN_GOVDM_2026-06-15.html.meta.json
+++ b/sources/DM_WIN_GOVDM_2026-06-15.html.meta.json
@@ -1,0 +1,7 @@
+{
+  "source_id": "DM_WIN_GOVDM_2026",
+  "url": "https://windominica.gov.dm/details/application-process",
+  "retrieved_at": "2026-06-15T00:00:00Z",
+  "sha256": "770819044a7d713797d90d140f77d7dced5f7e4a54cdc3b1f2aa884949089b38",
+  "local_path": "sources/DM_WIN_GOVDM_2026-06-15.html"
+}

--- a/tools/build_content_hubs.py
+++ b/tools/build_content_hubs.py
@@ -517,6 +517,20 @@ VISA_FAQS = {
             "answer": "Products whose documents state no overall coverage limit (the Spanish health policies) stay UNKNOWN rather than being assumed to clear the USD 50,000 floor.",
         },
     ],
+    "DM_WIN_GOVDM_2026": [
+        {
+            "question": "What insurance does the Dominica Work In Nature visa require?",
+            "answer": "The Government of Dominica requires health insurance valid in Dominica and covering you and all your family members.",
+        },
+        {
+            "question": "Why is only Genki Native GREEN for this route?",
+            "answer": "The policy must be valid in Dominica. Genki Native documents global coverage that includes Dominica; the other products do not document Dominica validity, so the engine records UNKNOWN rather than assuming a foreign policy qualifies.",
+        },
+        {
+            "question": "Is there a minimum coverage amount?",
+            "answer": "The official application process states no coverage amount, so the engine encodes none and models that insurance is mandatory and must be valid in Dominica.",
+        },
+    ],
 }
 
 RELATED_POSTS = {
@@ -691,6 +705,11 @@ RELATED_POSTS = {
     ],
     "BZ_LONGSTAY_IMMIG_2026": [
         ("/posts/belize-long-stay-insurance/", "Belize Long Stay Permit insurance requirements"),
+        ("/posts/digital-nomad-insurance-americas/", "Digital nomad insurance in the Americas"),
+        ("/guides/how-to-read-results/", "How to read compliance results"),
+    ],
+    "DM_WIN_GOVDM_2026": [
+        ("/posts/dominica-work-in-nature-insurance/", "Dominica Work In Nature insurance requirements"),
         ("/posts/digital-nomad-insurance-americas/", "Digital nomad insurance in the Americas"),
         ("/guides/how-to-read-results/", "How to read compliance results"),
     ],

--- a/tools/editorial_targets.json
+++ b/tools/editorial_targets.json
@@ -338,5 +338,13 @@
   "content/posts/belize-long-stay-insurance.md": [
     450,
     1200
+  ],
+  "content/visas/dominica/work-in-nature-win-extended-stay-visa/work-in-nature-application-process-government-of-dominica/index.md": [
+    900,
+    1400
+  ],
+  "content/posts/dominica-work-in-nature-insurance.md": [
+    450,
+    1200
   ]
 }


### PR DESCRIPTION
## Summary
- New route **DM_WIN_GOVDM_2026** — Dominica Work In Nature (WIN) extended stay visa
- Primary source (byte-exact, sha256-validated): Government of Dominica Work In Nature application process (windominica.gov.dm)
- Rules encoded verbatim only: `insurance.mandatory`, `insurance.authorized_in_country` ("Health insurance valid in Dominica and covering you and all your family members")
- No coverage amount stated, so none encoded (UNKNOWN > Wrong)
- Reuses the generic `AuthorizedInCountryRule`; Genki Native gains `jurisdiction_facts.DM`

## Mapping outcomes
Only **Genki Native GREEN**; all other products **UNKNOWN**. No existing mapping changed.

## Content
- Hub: /visas/dominica/work-in-nature-win-extended-stay-visa/work-in-nature-application-process-government-of-dominica/
- Post: /posts/dominica-work-in-nature-insurance/ (dated 2026-06-13, past in UTC)
- Affiliate: Genki Native paid link, after results only

## Gates
All gates + ui_compliance_tests.ps1 + mapping_engine_tests.ps1 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)