### PR TITLE
feat(route): add Taiwan digital nomad visitor visa route (evidence-based)

### DIFF
--- a/content/posts/taiwan-dnv-insurance.md
+++ b/content/posts/taiwan-dnv-insurance.md
@@ -1,0 +1,101 @@
+---
+title: "Taiwan digital nomad visitor visa insurance requirements (evidence-based)"
+date: 2026-06-13
+description: "Evidence-based summary of the insurance requirement for Taiwan's digital nomad visitor visa: proof of health and full hospitalization insurance for the entire duration of stay, per the Bureau of Consular Affairs."
+tags: ["taiwan", "digital-nomad", "visitor-visa", "insurance", "compliance"]
+faq:
+  - question: "What insurance does the Taiwan digital nomad visitor visa require?"
+    answer: "The Bureau of Consular Affairs requires proof of health and full hospitalization insurance for the entire duration of stay in the R.O.C. (Taiwan)."
+  - question: "Is there a minimum coverage amount?"
+    answer: "The official page states no coverage amount, so the engine encodes none and models that insurance is mandatory and must cover the entire duration of stay."
+  - question: "Why is a monthly subscription marked YELLOW?"
+    answer: "The insurance must cover the entire duration of stay. A month-to-month policy that can lapse does not assure that, so it is YELLOW; a full-period policy is GREEN."
+---
+
+## Short answer
+
+Taiwan's digital nomad visitor visa requires proof of health and full hospitalization insurance for the entire duration of stay in the R.O.C. (Taiwan) (Source: `TW_DNV_BOCA_2026`, Bureau of Consular Affairs; verified 2026-06-13). The official page states no coverage amount, so the engine models two rules: insurance is mandatory, and it must cover the entire duration of stay.
+
+## Key findings at a glance
+
+| Item | Value |
+|---|---|
+| Route | Taiwan Digital Nomad Visitor Visa |
+| Authority | Bureau of Consular Affairs, Ministry of Foreign Affairs (R.O.C. Taiwan) |
+| Evidence verified | 2026-06-13 |
+| Snapshot | 2026-06-13 |
+| Modeled rules | Insurance mandatory; covers the entire duration of stay |
+
+## What the authority requires
+
+- Proof of health and full hospitalization insurance is a required document. (Source: `TW_DNV_BOCA_2026`; verified 2026-06-13)
+- It must cover the entire duration of stay in Taiwan. (Source: `TW_DNV_BOCA_2026`; verified 2026-06-13)
+- The official page states no coverage amount, so that stays UNKNOWN.
+
+Normalized requirements table:
+
+| Requirement | Source URL | Locator | Verified date |
+|---|---|---|---|
+| Insurance is mandatory | https://www.boca.gov.tw/cp-158-7718-c0382-2.html | Digital nomad visitor visa, required documents | 2026-06-13 |
+| Covers the entire duration of stay | https://www.boca.gov.tw/cp-158-7718-c0382-2.html | Digital nomad visitor visa, required documents | 2026-06-13 |
+
+## Verified requirements (PASS/FAIL/UNKNOWN)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Insurance is mandatory | PASS | BOCA required documents |
+| Covers the entire duration of stay | PASS for full-period policies; YELLOW for monthly subscriptions | "for the entire duration of stay in the R.O.C. (Taiwan)" |
+| Minimum coverage amount | UNKNOWN | Not stated on the official page |
+
+## How we evaluate
+
+The checker compares each modeled requirement against product evidence. Two rules are encoded from the BOCA page: insurance is mandatory, and it must cover the entire duration of stay. A monthly subscription that can lapse does not assure full-period coverage, so it is YELLOW; a policy covering the whole stay is GREEN. The page mentions health and full hospitalization insurance but states no amount, so the engine encodes no coverage figure, following the UNKNOWN > Wrong principle. See /methodology/ for the full logic.
+
+## Proof package checklist
+
+- Health and full hospitalization insurance whose dates cover the entire stay in Taiwan.
+- A certificate showing the policy holder, policy number and coverage dates.
+- The remaining digital nomad visitor visa documents (proof of income, activity plan).
+
+## FAQ
+
+**Q: What is required?**
+**A:** Health and full hospitalization insurance for the entire duration of stay (Source: `TW_DNV_BOCA_2026`; verified 2026-06-13).
+
+**Q: Is there a minimum amount?**
+**A:** The official page states none, so the engine encodes no figure.
+
+**Q: Why is a monthly subscription YELLOW?**
+**A:** It can lapse before the stay ends, so it does not assure full-period coverage; a full-period policy is GREEN.
+
+## Check in the engine
+
+Use [the compliance checker](/ui/) with the current snapshot for this route:
+
+{{< checker_cta visa="TW_DNV_BOCA_2026" product="GENKI_TRAVELER_2026" snapshot="2026-06-13" >}}
+
+## Related reading
+
+- [Taiwan digital nomad visitor visa requirements (route page)](/visas/taiwan/digital-nomad-visitor-visa/digital-nomad-visitor-visa-bureau-of-consular-affairs/)
+- [Digital nomad insurance in Asia](/posts/digital-nomad-insurance-asia/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## Where to find compliant insurance for the Taiwan digital nomad visitor visa
+
+The official requirement is health and full hospitalization insurance covering the entire stay, so a full-period policy is what to look for. In the current snapshot, most full-period products show GREEN, including Genki Traveler and Genki Native. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the stay ends.
+
+- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+
+> Use the compliance checker to confirm the current GREEN products for this route before you buy.
+
+## Disclaimer + Affiliate disclosure
+
+Not legal advice. Compliance results are evidence-based snapshots.
+
+If an affiliate link is present, it appears only after results and does not change the compliance outcome. The Genki link above is a paid affiliate link.
+
+Last updated: 2026-06-13
+
+## Evidence log
+
+- Source: TW_DNV_BOCA_2026

--- a/content/visas/taiwan/digital-nomad-visitor-visa/_index.md
+++ b/content/visas/taiwan/digital-nomad-visitor-visa/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Taiwan Digital Nomad Visitor Visa"
+visa_group: "taiwan-digital-nomad-visitor-visa"
+description: "Insurance requirements for Taiwan Digital Nomad Visitor Visa - evidence-based compliance checker"
+---
+
+## Taiwan Digital Nomad Visitor Visa Requirements
+
+All requirements below are derived from official sources. Missing evidence means UNKNOWN.
+
+## Routes
+
+| Authority | Route | Last Verified | Details |
+| --- | --- | --- | --- |
+| Bureau of Consular Affairs, Ministry of Foreign Affairs (R.O.C. Taiwan) | Digital nomad visitor visa (Bureau of Consular Affairs) | 2026-06-15 | [View requirements](/visas/taiwan/digital-nomad-visitor-visa/digital-nomad-visitor-visa-bureau-of-consular-affairs/) |
+
+## What the authority requires
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+## How we evaluate
+
+We compare these official requirements against insurance product specifications using our automated rule engine. Each requirement is matched to a product fact with evidence.
+
+## Check in the engine
+
+Try the compliance checker: [Open Checker](/ui/?visa=TW_DNV_BOCA_2026&snapshot=2026-06-13)
+
+## Disclaimer
+
+This is not legal advice. VisaFact provides evidence-based compliance checking only. Final visa decisions are made by government authorities. A GREEN result does not ensure visa approval.
+
+## Affiliate disclosure
+
+If affiliate links appear, they are shown only after compliance results and do not influence the compliance evaluation in any way.
+
+## Evidence log
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+
+{{< checker_cta visa="TW_DNV_BOCA_2026" snapshot="2026-06-13" >}}

--- a/content/visas/taiwan/digital-nomad-visitor-visa/digital-nomad-visitor-visa-bureau-of-consular-affairs/index.md
+++ b/content/visas/taiwan/digital-nomad-visitor-visa/digital-nomad-visitor-visa-bureau-of-consular-affairs/index.md
@@ -1,0 +1,103 @@
+---
+title: "Taiwan Digital Nomad Visitor Visa - Digital nomad visitor visa (Bureau of Consular Affairs)"
+visa_id: "TW_DNV_BOCA_2026"
+last_verified: "2026-06-15"
+source_ids: ["TW_DNV_BOCA_2026"]
+description: "Official insurance requirements for Taiwan Digital Nomad Visitor Visa via Digital nomad visitor visa (Bureau of Consular Affairs)"
+faq:
+  - question: "What insurance does the Taiwan digital nomad visitor visa require?"
+    answer: "The Bureau of Consular Affairs requires proof of health and full hospitalization insurance for the entire duration of stay in the R.O.C. (Taiwan)."
+  - question: "Is there a minimum coverage amount?"
+    answer: "The official page states no coverage amount, so the engine encodes none and models that insurance is mandatory and must cover the entire duration of stay."
+  - question: "Why is SafetyWing YELLOW while other products are GREEN?"
+    answer: "The insurance must cover the entire duration of stay. A month-to-month subscription that can lapse does not assure that, so it is YELLOW; full-period policies are GREEN."
+---
+
+## Taiwan Digital Nomad Visitor Visa
+
+**Route:** Digital nomad visitor visa (Bureau of Consular Affairs)  
+**Authority:** Bureau of Consular Affairs, Ministry of Foreign Affairs (R.O.C. Taiwan)  
+**Last Verified:** 2026-06-15
+
+## Requirements
+
+| Requirement | Operator | Value | Evidence |
+| --- | --- | --- | --- |
+| `insurance.mandatory` | `==` | Yes | *Digital nomad visitor visa, required documents*: "Proof of health and full hospitalization insurance for the entire duration of st..." ([source](/sources/TW_DNV_BOCA_2026-06-15.html)) |
+| `insurance.must_cover_full_period` | `==` | Yes | *Digital nomad visitor visa, required documents*: "for the entire duration of stay in the R.O.C. (Taiwan)..." ([source](/sources/TW_DNV_BOCA_2026-06-15.html)) |
+
+## Source Documents
+
+- **TW_DNV_BOCA_2026**: [Local copy](/sources/TW_DNV_BOCA_2026-06-15.html) | [Original](https://www.boca.gov.tw/cp-158-7718-c0382-2.html) | Retrieved: 2026-06-15
+
+## Related reading
+
+- [Taiwan digital nomad visitor visa insurance requirements](/posts/taiwan-dnv-insurance/)
+- [Digital nomad insurance in Asia](/posts/digital-nomad-insurance-asia/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## What the authority requires
+
+The points below are taken directly from the official source for the Taiwan Digital Nomad Visitor Visa (Digital nomad visitor visa (Bureau of Consular Affairs)) route. Each one is recorded with a source identifier and a locator so it can be traced back to the original document. Where the source is silent on a point, the engine records UNKNOWN instead of inferring an answer.
+
+- The authority requires that insurance is mandatory.
+- The authority requires that the policy covers the full authorized stay.
+
+This route is defined by a small number of explicit insurance points, which keeps the evidence trail short but also unusually clear. A concise official requirement still has to be matched precisely: a product is only GREEN here when its documented terms line up with the wording above, and a route with few stated rules does not imply that any policy will be accepted. Where the authority is silent, the engine deliberately holds the status at UNKNOWN or NOT_REQUIRED rather than reading extra conditions into the source, so the page reflects exactly what the document states and nothing more. Applicants on routes like this one should still keep the underlying policy wording on hand, because a consular officer may ask to see how each stated point is met even when the published checklist is short.
+
+## How we evaluate
+
+Every requirement is compared against the documented specification of each insurance product using an automated rule engine. A product is marked GREEN for a requirement only when product evidence explicitly satisfies it; a conflict produces RED; and absent evidence produces UNKNOWN rather than a guess. The route status is the combination of its per-requirement outcomes.
+
+- Rule `insurance.mandatory == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+- Rule `insurance.must_cover_full_period == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+
+## How each compliance status is decided for this route
+
+GREEN means every recorded requirement is satisfied by product evidence. RED means at least one requirement is contradicted by the product evidence. YELLOW means the evidence is partial: some requirements are met while others lack full proof. UNKNOWN means a requirement exists but the product evidence does not address it, so no claim is made. NOT_REQUIRED means the authority does not impose an insurance requirement for the route, which is itself an evidence-based finding drawn from the official document. A GREEN result reflects the evidence on the snapshot date and is not an assurance of a visa outcome, which always rests with the issuing authority.
+
+## Reading the evidence and snapshots
+
+Each requirement above links to a primary source through a source identifier and a locator (for example a page number, article, or section). The underlying documents are listed under Source Documents and are stored alongside this dataset so the wording can be checked directly. Results are tied to a dated snapshot (`2026-06-13`): a deep link to a past snapshot returns the same verdict even if the authority later changes its rules, which keeps every decision reproducible and auditable.
+
+## Proof package checklist
+
+Before applying for this route, prepare the following so the policy can be checked against each requirement:
+
+- A policy certificate that states the coverage limits, any deductible or co-payment, and the covered period.
+- Written confirmation of the insurer's status where the route requires authorization in a specific country.
+- Documentation that the coverage spans the full authorized stay rather than a partial term.
+- The official source wording for the route, so each clause can be matched to the requirements above.
+
+## Common questions
+
+**What insurance does the Taiwan digital nomad visitor visa require?**  
+The Bureau of Consular Affairs requires proof of health and full hospitalization insurance for the entire duration of stay in the R.O.C. (Taiwan).
+
+**Is there a minimum coverage amount?**  
+The official page states no coverage amount, so the engine encodes none and models that insurance is mandatory and must cover the entire duration of stay.
+
+**Why is SafetyWing YELLOW while other products are GREEN?**  
+The insurance must cover the entire duration of stay. A month-to-month subscription that can lapse does not assure that, so it is YELLOW; full-period policies are GREEN.
+
+## Check in the engine
+
+Run a specific product against this route in the compliance checker: [Open Checker](/ui/?visa=TW_DNV_BOCA_2026&snapshot=2026-06-13). The checker shows the per-requirement outcome and the evidence behind each one.
+
+## Disclaimer
+
+This page is not legal advice. VisaFact provides evidence-based compliance checking only, and final visa decisions are made by government authorities. A GREEN result reflects documented evidence on the snapshot date; it does not ensure that a visa application will succeed. Always confirm the current requirements with the issuing authority before submitting an application.
+
+## Affiliate disclosure
+
+If affiliate links appear on related pages, they are shown only after the compliance result and never change the evaluation, which is generated independently from the official evidence.
+
+## Evidence log
+
+Each entry pairs a requirement with the source identifier and locator it was drawn from:
+
+- `insurance.mandatory` <- TW_DNV_BOCA_2026 (Digital nomad visitor visa, required documents): "Proof of health and full hospitalization insurance for the entire duration of stay in the R.O.C. (Ta"
+- `insurance.must_cover_full_period` <- TW_DNV_BOCA_2026 (Digital nomad visitor visa, required documents): "for the entire duration of stay in the R.O.C. (Taiwan)"
+
+
+{{< checker_cta visa="TW_DNV_BOCA_2026" snapshot="2026-06-13" >}}

--- a/data/mappings/TW_DNV_BOCA_2026__ASISA_HEALTH_RESIDENTS_2026.json
+++ b/data/mappings/TW_DNV_BOCA_2026__ASISA_HEALTH_RESIDENTS_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "TW_DNV_BOCA_2026",
+  "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/TW_DNV_BOCA_2026__DKV_VISADO_2026.json
+++ b/data/mappings/TW_DNV_BOCA_2026__DKV_VISADO_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "TW_DNV_BOCA_2026",
+  "product_id": "DKV_VISADO_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/TW_DNV_BOCA_2026__GENERIC_EXPAT_COMPLETE_2026.json
+++ b/data/mappings/TW_DNV_BOCA_2026__GENERIC_EXPAT_COMPLETE_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "TW_DNV_BOCA_2026",
+  "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/TW_DNV_BOCA_2026__GENKI_NATIVE_2026.json
+++ b/data/mappings/TW_DNV_BOCA_2026__GENKI_NATIVE_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "TW_DNV_BOCA_2026",
+  "product_id": "GENKI_NATIVE_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/TW_DNV_BOCA_2026__GENKI_TRAVELER_2026.json
+++ b/data/mappings/TW_DNV_BOCA_2026__GENKI_TRAVELER_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "TW_DNV_BOCA_2026",
+  "product_id": "GENKI_TRAVELER_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/TW_DNV_BOCA_2026__SAFETYWING_NOMAD_2026.json
+++ b/data/mappings/TW_DNV_BOCA_2026__SAFETYWING_NOMAD_2026.json
@@ -1,0 +1,18 @@
+{
+  "visa_id": "TW_DNV_BOCA_2026",
+  "product_id": "SAFETYWING_NOMAD_2026",
+  "status": "YELLOW",
+  "reasons": [
+    {
+      "text": "Visa requires coverage for full legal stay, monthly subscriptions can be cancelled",
+      "evidence": [
+        {
+          "source_id": "TW_DNV_BOCA_2026",
+          "locator": "Digital nomad visitor visa, required documents",
+          "excerpt": "for the entire duration of stay in the R.O.C. (Taiwan)"
+        }
+      ]
+    }
+  ],
+  "missing": []
+}

--- a/data/mappings/TW_DNV_BOCA_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
+++ b/data/mappings/TW_DNV_BOCA_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "TW_DNV_BOCA_2026",
+  "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/TW_DNV_BOCA_2026__WORLDNOMADS_EXPLORER_2026.json
+++ b/data/mappings/TW_DNV_BOCA_2026__WORLDNOMADS_EXPLORER_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "TW_DNV_BOCA_2026",
+  "product_id": "WORLDNOMADS_EXPLORER_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/ui_index.json
+++ b/data/ui_index.json
@@ -1,5 +1,5 @@
 {
-  "built_at": "2026-06-15T13:55:16.235111+00:00",
+  "built_at": "2026-06-15T13:59:51.079699+00:00",
   "snapshot_id": "2026-06-15",
   "visas": [
     {
@@ -1907,6 +1907,49 @@
           ]
         }
       ]
+    },
+    {
+      "id": "TW_DNV_BOCA_2026",
+      "country": "Taiwan",
+      "visa_name": "Digital Nomad Visitor Visa",
+      "route": "Digital nomad visitor visa (Bureau of Consular Affairs)",
+      "authority": "Bureau of Consular Affairs, Ministry of Foreign Affairs (R.O.C. Taiwan)",
+      "last_verified": "2026-06-15",
+      "sources": [
+        {
+          "source_id": "TW_DNV_BOCA_2026",
+          "url": "https://www.boca.gov.tw/cp-158-7718-c0382-2.html",
+          "retrieved_at": "2026-06-15T00:00:00Z",
+          "sha256": "51392397072072c60ad02e166a6fbe0f8b29f8d9ddebf930c8a4939a55dab9fa",
+          "local_path": "sources/TW_DNV_BOCA_2026-06-15.html"
+        }
+      ],
+      "requirements": [
+        {
+          "key": "insurance.mandatory",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "TW_DNV_BOCA_2026",
+              "locator": "Digital nomad visitor visa, required documents",
+              "excerpt": "Proof of health and full hospitalization insurance for the entire duration of stay in the R.O.C. (Taiwan)"
+            }
+          ]
+        },
+        {
+          "key": "insurance.must_cover_full_period",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "TW_DNV_BOCA_2026",
+              "locator": "Digital nomad visitor visa, required documents",
+              "excerpt": "for the entire duration of stay in the R.O.C. (Taiwan)"
+            }
+          ]
+        }
+      ]
     }
   ],
   "products": [
@@ -3214,7 +3257,7 @@
       "missing": [
         "specs.jurisdiction_facts.DM.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "DM_WIN_GOVDM_2026",
@@ -3224,7 +3267,7 @@
       "missing": [
         "specs.jurisdiction_facts.DM.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "DM_WIN_GOVDM_2026",
@@ -3234,7 +3277,7 @@
       "missing": [
         "specs.jurisdiction_facts.DM.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "DM_WIN_GOVDM_2026",
@@ -3242,7 +3285,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "DM_WIN_GOVDM_2026",
@@ -3252,7 +3295,7 @@
       "missing": [
         "specs.jurisdiction_facts.DM.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "DM_WIN_GOVDM_2026",
@@ -3262,7 +3305,7 @@
       "missing": [
         "specs.jurisdiction_facts.DM.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "DM_WIN_GOVDM_2026",
@@ -3272,7 +3315,7 @@
       "missing": [
         "specs.jurisdiction_facts.DM.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "DM_WIN_GOVDM_2026",
@@ -3282,7 +3325,7 @@
       "missing": [
         "specs.jurisdiction_facts.DM.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-15"
     },
     {
       "visa_id": "EC_NOMAD_CANCILLERIA_2026",
@@ -5638,6 +5681,81 @@
       "reasons": [],
       "missing": [],
       "last_verified": "2026-06-15"
+    },
+    {
+      "visa_id": "TW_DNV_BOCA_2026",
+      "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "TW_DNV_BOCA_2026",
+      "product_id": "DKV_VISADO_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "TW_DNV_BOCA_2026",
+      "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "TW_DNV_BOCA_2026",
+      "product_id": "GENKI_NATIVE_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "TW_DNV_BOCA_2026",
+      "product_id": "GENKI_TRAVELER_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "TW_DNV_BOCA_2026",
+      "product_id": "SAFETYWING_NOMAD_2026",
+      "status": "YELLOW",
+      "reasons": [
+        {
+          "text": "Visa requires coverage for full legal stay, monthly subscriptions can be cancelled",
+          "evidence": [
+            {
+              "source_id": "TW_DNV_BOCA_2026",
+              "locator": "Digital nomad visitor visa, required documents",
+              "excerpt": "for the entire duration of stay in the R.O.C. (Taiwan)"
+            }
+          ]
+        }
+      ],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "TW_DNV_BOCA_2026",
+      "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "TW_DNV_BOCA_2026",
+      "product_id": "WORLDNOMADS_EXPLORER_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
     }
   ],
   "offers": [
@@ -6113,6 +6231,13 @@
       "retrieved_at": "2026-06-15T00:00:00Z",
       "sha256": "bfdc87174f4049b1e6cc3e065c6b18ed9a5b66deeeb6144b15a69b3de07b9305",
       "local_path": "sources/TR_RESIDENCE_PMM_2026-06-15.html"
+    },
+    "TW_DNV_BOCA_2026": {
+      "source_id": "TW_DNV_BOCA_2026",
+      "url": "https://www.boca.gov.tw/cp-158-7718-c0382-2.html",
+      "retrieved_at": "2026-06-15T00:00:00Z",
+      "sha256": "51392397072072c60ad02e166a6fbe0f8b29f8d9ddebf930c8a4939a55dab9fa",
+      "local_path": "sources/TW_DNV_BOCA_2026-06-15.html"
     },
     "WORLDNOMADS_COMPARE_2026": {
       "source_id": "WORLDNOMADS_COMPARE_2026",

--- a/data/visas/TW/DNV/boca/2026-06-15/visa_facts.json
+++ b/data/visas/TW/DNV/boca/2026-06-15/visa_facts.json
@@ -1,0 +1,43 @@
+{
+  "id": "TW_DNV_BOCA_2026",
+  "country": "Taiwan",
+  "visa_name": "Digital Nomad Visitor Visa",
+  "route": "Digital nomad visitor visa (Bureau of Consular Affairs)",
+  "authority": "Bureau of Consular Affairs, Ministry of Foreign Affairs (R.O.C. Taiwan)",
+  "last_verified": "2026-06-15",
+  "sources": [
+    {
+      "source_id": "TW_DNV_BOCA_2026",
+      "url": "https://www.boca.gov.tw/cp-158-7718-c0382-2.html",
+      "retrieved_at": "2026-06-15T00:00:00Z",
+      "sha256": "51392397072072c60ad02e166a6fbe0f8b29f8d9ddebf930c8a4939a55dab9fa",
+      "local_path": "sources/TW_DNV_BOCA_2026-06-15.html"
+    }
+  ],
+  "requirements": [
+    {
+      "key": "insurance.mandatory",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "TW_DNV_BOCA_2026",
+          "locator": "Digital nomad visitor visa, required documents",
+          "excerpt": "Proof of health and full hospitalization insurance for the entire duration of stay in the R.O.C. (Taiwan)"
+        }
+      ]
+    },
+    {
+      "key": "insurance.must_cover_full_period",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "TW_DNV_BOCA_2026",
+          "locator": "Digital nomad visitor visa, required documents",
+          "excerpt": "for the entire duration of stay in the R.O.C. (Taiwan)"
+        }
+      ]
+    }
+  ]
+}

--- a/sources/TW_DNV_BOCA_2026-06-15.html
+++ b/sources/TW_DNV_BOCA_2026-06-15.html
@@ -1,0 +1,432 @@
+<!DOCTYPE html><html lang="en" class="no-js">
+  <head>
+    <META http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1"><!-- Google Tag Manager --><script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-MB627Z2');</script><!-- End Google Tag Manager --><meta name="DC.Title" content="Bureau of Consular Affairs, Ministry of Foreign Affairs, Republic of China(Taiwan)" /><meta name="DC.Subject" content="Bureau of Consular Affairs, Ministry of Foreign Affairs, Republic of China(Taiwan)" /><meta name="DC.Creator" content="外交部領事事務局" /><meta name="DC.Publisher" content="外交部領事事務局" /><meta name="DC.Date" content="2017-07-31" /><meta name="DC.Identifier" content="" /><meta name="DC.Type" content="文字" /><meta name="DC.Description" content="Bureau of Consular Affairs, Ministry of Foreign Affairs, Republic of China(Taiwan)" /><meta name="DC.Contributor" content="外交部領事事務局" /><meta name="DC.Format" content="Text" /><meta name="DC.Relation" content="" /><meta name="DC.Source" content="外交部領事事務局" /><meta name="DC.Language" content="中文" /><meta name="DC.coverage.t.min" content="2017-07-31" /><meta name="DC.coverage.t.max" content="" /><meta name="DC.Rights" content="外交部領事事務局" /><meta name="Category.Theme" content="770" /><meta name="Category.Cake" content="C00" /><meta name="Category.Service" content="E00" /><meta name="Keywords" content="Bureau of Consular Affairs, Ministry of Foreign Affairs, Republic of China(Taiwan)" /><title>Bureau of Consular Affairs, Ministry of Foreign Affairs, Republic of China(Taiwan)-Digital nomad visitor visa</title><script src="Styles/Unit002/js/jquery-3.6.0.min.js"></script><style>
+      @counter-style CusTCI {
+      system: extends trad-chinese-informal;
+      prefix: "(";
+      suffix: ") ";
+      }
+      .extends {
+      list-style: CusTCI;
+      }
+    </style>
+    <link rel="stylesheet" href="Styles/Unit002/css/animate.css">
+    <link rel="stylesheet" type="text/css" href="Styles/Unit002/vendor/slick/slick.css">
+    <link rel="stylesheet" type="text/css" href="Styles/Unit002/vendor/slick/slick-theme.css">
+    <link rel="stylesheet" type="text/css" href="Styles/Unit002/vendor/fancybox/jquery.fancybox.min.css">
+    <link rel="stylesheet" href="Styles/Unit002/css/hyui_e.css">
+    <link href="Styles/Unit002/images/favicon.png" rel="icon" type="image/x-icon">
+  </head>
+  <body>
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MB627Z2" height="0" width="0" title="GTM" style="display:none;visibility:hidden"></iframe>
+    </noscript><a class="goCenter" href="#center" tabindex="1">Go to main content area</a><div class="wrapper"><header class="header full"><div class="container"><a class="accesskey" href="#aU" id="aU" accesskey="U" title="WebSite Title" tabindex="2">:::</a><h1><a href="
+              mp-2.html
+            " title="Bureau of Consular Affairs, Ministry of Foreign Affairs, Republic of China(Taiwan)" alt="Bureau of Consular Affairs, Ministry of Foreign Affairs, Republic of China(Taiwan)"><img src="Styles/Unit002/images/logo_e.png" class="img-responsive" alt="Bureau of Consular Affairs, Ministry of Foreign Affairs, Republic of China(Taiwan)"></a></h1><nav class="navigation" role="navigation" aria-label="Site"><div class="navlist">
+              <ul>
+                <li><a href="/mp-2.html" title="Home">Home</a></li>
+                <li><a href="/sitemap-2.html" title="Sitemap">Sitemap</a></li>
+                <li><a href="/np-360-2.html" title="Bilingual Glossary">Bilingual Glossary</a></li>
+                <li><a href="/mp-1.html" title="中文版">中文版</a></li>
+              </ul>
+            </div>
+            <div class="font_size"><span>字級大小：</span><button type="button" title="medium" class="medium fontselect">Ａ</button><ul>
+                <li><button type="button" title="small" class="small">
+              Ａ<sup>-</sup></button></li>
+                <li><button type="button" title="large" class="large">
+              Ａ<sup>+</sup></button></li>
+              </ul>
+            </div></nav><div class="search_btnblock"><button type="button" class="search_btn" title="Search">search</button><div class="search" role="search"><label for="mustSameAsId">Full site search</label><div class="search_content">
+                <div class="form_grp"><input name="qStr" id="qStr" type="text" placeholder="Keyword" accesskey="S" title="Keyword" aria-label="search site content">
+            &nbsp;<input name="GSearchSend" id="GSearchSend" type="submit" value="Search" title="Search" class="btn btn-search" onclick="search(getValue())"></div>
+                <div class="btn_grp"><input name="" type="button" value="advanced search" class="btn" title="advanced(open in a new window)" onclick="window.open('https://www.google.com.tw/advanced_search?as_sitesearch=www.boca.gov.tw')"></div>
+                <div class="keywordHot"><span>Popular keywords：</span><ul>
+                    <li><a href="
+                      javascript:search('Visa');
+                    " title="Visa">Visa</a></li>
+                    <li><a href="
+                      javascript:search('Passport');
+                    " title="Passport">Passport</a></li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div><script>
+      function search(value){
+          if(value != ""){
+              window.location.href = "/sp-gs-2.html?Query=" + encodeURIComponent(value);
+          }
+      }
+      function getValue(){
+      var qStrList = document.getElementsByName('qStr');
+      for(let i = 0; i < qStrList.length; i++) {
+              if(qStrList[i].value!=""){ return qStrList[i].value; }
+          }
+          return "";
+      }
+      $(function(){
+          let GSearchSendList = document.getElementsByName('GSearchSend');
+          let qStrList = document.getElementsByName('qStr');
+          for(let i = 0; i < GSearchSendList.length; i++) {
+              GSearchSendList[i].addEventListener("click", function() {
+                  if(getValue() !=""){
+                      window.location.href = "/sp-gs-2.html?Query=" + encodeURIComponent(getValue());
+                  }else{
+                      alert("Keyword")
+                  }
+              });
+          }
+
+      for(let i = 0; i < qStrList.length; i++) {
+          qStrList[i].addEventListener("keypress", function(e) {
+              if( e.keyCode == 13) {
+                  //e.preventDefault();
+                  if(getValue() !=""){
+                      search(getValue());
+                  }else{
+                      alert("Keyword");
+                  }
+              }
+          });
+          qStrList[i].addEventListener("keypress", function(e) {
+              if( qStrList[i].value=="全站搜尋") {
+                  qStrList[i].value="";
+              }
+          });
+      }
+      /*
+      function search(value){
+      window.location.href = "/sp-gs-2.html?Query=" + encodeURIComponent(value);
+      }
+      $(function(){
+      $("#GSearchSend").click(function(){
+      window.location.href = "/sp-gs-2.html?Query=" + encodeURIComponent($("#qStr").val());
+      });
+      $("#qStr").keypress(function (e) {
+      if( e.which == 13) {
+      e.preventDefault();
+      $("#GSearchSend").click();
+      }
+      });
+      $("#qStr").click(function (e) {
+      if( $(this).val()=="全站搜尋") {
+      $(this).val("");
+      }
+      });
+      */
+      $(".icon-mic").click(function(){
+      if (window.hasOwnProperty('webkitSpeechRecognition')) {
+      var recognition = new webkitSpeechRecognition();
+      recognition.continuous = false;
+      recognition.interimResults = false;
+      recognition.lang = "cmn-Hant-TW";
+      recognition.start();
+      recognition.onresult = function(e) {
+      //document.getElementById('transcript').value = e.results[0][0].transcript;
+      $("#qStr").val(e.results[0][0].transcript);
+      recognition.stop();
+      //document.getElementById('labnol').submit();
+      $("#GSearchSend").click();
+      };
+      recognition.onerror = function(e) {
+      recognition.stop();
+      }
+      }
+      });
+      });
+    </script><noscript>
+          Your browser does not seem to support JavaScript syntax, but it does not matter, it
+          does not affect the presentation of the content.
+        </noscript><nav class="menu" role="navigation" aria-label="Header"><ul>
+              <li class="dropdown"><a data-hover="dropdown" class="active dropdown-toggle" aria-expanded="false" href="/np-136-2.html" title="Passport">Passport<b class="caret"></b></a><ul hasChild="dropdown-menu">
+                  <li><a href="/np-353-2.html" title="Apply for a Passport(Taiwan)">Apply for a Passport(Taiwan)</a></li>
+                  <li><a href="/lp-139-2.html" title="Apply for a Passport(Abroad)">Apply for a Passport(Abroad)</a></li>
+                  <li><a href="/np-140-2.html" title="Passport Photos">Passport Photos</a></li>
+                  <li><a href="/lp-236-2.html" title="Application Directions for a Second ROC Passport">Application Directions for a Second ROC Passport</a></li>
+                  <li><a href="/np-244-2.html" title="Applying for Past Passport Records">Applying for Past Passport Records</a></li>
+                  <li><a href="/lp-145-2.html" title="Passport FAQs">Passport FAQs</a></li>
+                  <li><a href="/lp-143-2.html" title="Application Forms">Application Forms</a></li>
+                  <li><a href="/lp-144-2.html" title="Passport Act and Regulations">Passport Act and Regulations</a></li>
+                  <li><a href="/np-142-2.html" title="ePassport Project">ePassport Project</a></li>
+                  <li><a href="/np-287-2.html" title="Operating Directions for Issuance of Entry Permits">Operating Directions for Issuance of Entry Permits</a></li>
+                  <li><a href="/cp-243-4449-23912-2.html" title="Country Signing CA (CSCA) Information">Country Signing CA (CSCA) Information</a></li>
+                </ul>
+              </li>
+              <li class="dropdown"><a data-hover="dropdown" class="active dropdown-toggle" aria-expanded="false" href="/np-137-2.html" title="Visa">Visa<b class="caret"></b></a><ul hasChild="dropdown-menu">
+                  <li><a href="/np-146-2.html" title="General Information">General Information</a></li>
+                  <li><a target="_blank" href="https://visawebapp.boca.gov.tw/" title="On-line Application Forms (not applicable to Hong Kong, Macau and PRC passport holders)(open in a new window)">On-line Application Forms (not applicable to Hong Kong, Macau and PRC passport holders)</a></li>
+                  <li><a href="/lp-149-2.html" title="Visa-Exempt Entry, Landing Visa and eVisa">Visa-Exempt Entry, Landing Visa and eVisa</a></li>
+                  <li><a href="/np-147-2.html" title="Visitor Visas">Visitor Visas</a></li>
+                  <li><a href="/np-150-2.html" title="Resident Visas">Resident Visas</a></li>
+                  <li><a href="/lp-166-2-xCat-3.html" title="Study in Taiwan">Study in Taiwan</a></li>
+                  <li><a href="/np-152-2.html" title="Southeast Asian Countries">Southeast Asian Countries</a></li>
+                  <li><a href="/lp-153-2.html" title="Working Holidays Scheme">Working Holidays Scheme</a></li>
+                  <li><a href="/lp-154-2.html" title="Entrepreneur">Entrepreneur</a></li>
+                  <li><a href="/cp-158-4158-09d5a-2.html" title="Employment-Seeking">Employment-Seeking</a></li>
+                  <li><a href="/lp-181-2.html" title="Visa FAQs">Visa FAQs</a></li>
+                </ul>
+              </li>
+              <li class="dropdown"><a data-hover="dropdown" class="active dropdown-toggle" aria-expanded="false" href="/np-138-2.html" title="Authentication">Authentication<b class="caret"></b></a><ul hasChild="dropdown-menu">
+                  <li><a href="/np-202-2.html" title="Document Authentication in ROC(Taiwan)">Document Authentication in ROC(Taiwan)</a></li>
+                  <li><a href="/np-203-2.html" title="Document Authentication Services">Document Authentication Services</a></li>
+                  <li><a href="/np-204-2.html" title="Authentication of domestic documents">Authentication of domestic documents</a></li>
+                  <li><a href="/lp-209-2.html" title="Authentication of foreign documents">Authentication of foreign documents</a></li>
+                  <li><a href="/lp-205-2.html" title="Authentication Regulations">Authentication Regulations</a></li>
+                  <li><a href="/lp-206-2.html" title="Consular District">Consular District</a></li>
+                  <li><a href="/lp-207-2.html" title="Application Forms">Application Forms</a></li>
+                  <li><a href="/lp-208-2.html" title="Authentication FAQs">Authentication FAQs</a></li>
+                  <li><a href="/lp-230-2.html" title="E-register">E-register</a></li>
+                </ul>
+              </li>
+              <li class="dropdown"><a data-hover="dropdown" class="active dropdown-toggle" aria-expanded="false" href="/np-411-2.html" title="Online Service">Online Service<b class="caret"></b></a><ul hasChild="dropdown-menu">
+                  <li><a target="_blank" href="https://visawebapp.boca.gov.tw/" title="On-line Application Forms(not applicable to Hong Kong,Macau and PRC passport holders)(open in a new window)">On-line Application Forms(not applicable to Hong Kong,Macau and PRC passport holders)</a></li>
+                  <li><a target="_blank" href="https://docauth.boca.gov.tw/BOCAWeb/index3" title="Authentication-Application Progress(open in a new window)">Authentication-Application Progress</a></li>
+                  <li><a target="_blank" href="https://docauth.boca.gov.tw/BOCAWeb/index4/qry" title="Authentication-Verification of Authentication(open in a new window)">Authentication-Verification of Authentication</a></li>
+                </ul>
+              </li>
+              <li><a data-hover="dropdown" class="active dropdown-toggle" aria-expanded="false" href="/lp-220-2.html" title="News & Events">News & Events</a></li>
+              <li><a data-hover="dropdown" class="active dropdown-toggle" aria-expanded="false" href="/lp-191-2.html" title="Our Locations">Our Locations</a></li>
+              <li><a data-hover="dropdown" class="active dropdown-toggle" aria-expanded="false" href="/sp-foof-countrylp-01-2.html" title="Embassies and Missions">Embassies and Missions</a></li>
+              <li class="dropdown"><a data-hover="dropdown" class="active dropdown-toggle" aria-expanded="false" href="/np-193-2.html" title="About Us">About Us<b class="caret"></b></a><ul hasChild="dropdown-menu">
+                  <li><a href="/np-218-2.html" title="Organizational Structure">Organizational Structure</a></li>
+                  <li><a href="/np-365-2.html" title="Deputy Director General">Deputy Director General</a></li>
+                </ul>
+              </li>
+            </ul></nav></div></header><div id="center" class="main innerpage"><a class="accesskey" href="#aC" id="aC" accesskey="C" title="Main content area">:::</a><section class="fixed_share_group_right wow fadeInRightBig" data-wow-delay="0s" data-wow-duration="1s" style="visibility: visible; animation-duration: 1s; animation-delay: 0s; animation-name: fadeInRightBig;"><div class="share_btn"><a href="#">分享鈕</a></div><div class="sidebar_group"><div class="sidebar_list"><div class="line"><a href="/np-91-1.html" title="Line"><img alt="" src="/Public/Images/202302/7512302221305f2b41.png" /><span>Line</span></a></div></div><div class="sidebar_list"><div class="app"><a href="/np-92-1.html" title="Travel Emergency Guidance APP"><img alt="" src="/Public/Images/202302/969230222130573f96.png" /><span>Travel Emergency Guidance APP</span></a></div></div><div class="sidebar_list"><div class="mail"><a href="/sp-mimb-main-2.html" title="Contact us"><img alt="" src="/Public/Images/202302/2042302221305fe7e7.png" /><span>Contact us</span></a></div></div><div class="sidebar_list"><div class="Youtube"><a href="https://www.youtube.com/channel/UC5b9P_CvxCqXTPT2KxusYhA" target="_blank" title="Youtube(open in a new window)"><img alt="" src="/Public/Images/202302/4232302221305e80c3.png" /><span>Youtube</span></a></div></div><div class="sidebar_list"><div class="rss"><a href="/rss-220-2.xml" target="_blank" title="RSS(open in a new window)"><img alt="" src="/Public/Images/202302/876230222130586ca1.png" /><span>RSS</span></a></div></div></div></section><div class="container">
+          <div class="center_block">
+            <div class="breadcrumb">
+              <ul>
+                <li><a title="Home" href="mp-2.html">Home</a></li>
+                <li><a title="Visa" href="
+                np-137-2.html
+              ">Visa</a></li>
+                <li><a title="Visitor Visas" href="
+                np-147-2.html
+              ">Visitor Visas</a></li>
+                <li><a title="Detailed Information on Republic of China Visitor Visas" href="
+                np-158-2.html
+              ">Detailed Information on Republic of China Visitor Visas</a></li>
+              </ul>
+            </div>
+            <h2 class="title"><span>Digital nomad visitor visa</span></h2><script>
+      function FBShare(link) {
+      window.open("http://www.facebook.com/sharer.php?u=" + encodeURIComponent(link) + "&t=" + encodeURIComponent(document.title) ,'FBLIKE',config='height=500,width=500');
+      }
+      
+      function TwitterShare(link) {
+      window.open("https://twitter.com/home?status=" + encodeURIComponent(link) ,'Twitter',config='height=500,width=500');
+      }
+      function LineShare(link) {
+      window.open("http://line.naver.jp/R/msg/text/" + encodeURIComponent(document.title) + " :: " + encodeURIComponent(link) ,'Line',config='height=500,width=500');
+      }
+    </script><div class="function_panel">
+              <div class="function">
+                <ul>
+                  <li class="facebook"><a title="Facebook(open in a new window)" href="
+                javascript:FBShare('https://www.boca.gov.tw/cp-158-7718-c0382-2.html')
+              ">
+              facebook
+            </a></li>
+                  <li class="twitter"><a title="twitter(open in a new window)" href="
+                javascript:TwitterShare('https://www.boca.gov.tw/cp-158-7718-c0382-2.html')
+              ">
+              twitter
+            </a></li>
+                  <li class="line"><a title="line(open in a new window)" href="
+                javascript:LineShare('https://www.boca.gov.tw/cp-158-7718-c0382-2.html')
+              ">line
+            </a></li>
+                  <li class="print"><a title="Print(open in a new window)" target="_blank" href="https://www.boca.gov.tw/fp-158-7718-c0382-2.html
+              ">
+              Print
+            </a></li>
+                  <li class="back"><a href="javascript:history.back();" title="Go Back">Go Back</a><NOSCRIPT>( alt + ← Go Back)</NOSCRIPT>
+                  </li>
+                </ul>
+              </div>
+            </div><section class="cp"><ul class="publish_info">
+                <li>Created：2025-01-02</li>
+                <li>Data Source：Bureau Of Consular Affairs</li>
+                <li>Counter：43250</li>
+              </ul><div class="table_unchanged">
+<table border="1" cellpadding="1" cellspacing="1" class="table table-bordered table-hover table-striped" style="width: 100%;">
+	<caption>Application process for the digital nomad visitor visa</caption>
+	<thead>
+		<tr>
+			<th colspan="2" scope="col">Eligibility</th>
+		</tr>
+		<tr>
+			<td colspan="2" scope="col">
+			<p style="text-align: center;">Only nationals from <a href="https://www.boca.gov.tw/cp-149-4486-7785a-2.html" title="visa-exempt countries">visa-exempt countries</a> are eligible for the digital nomad visitor visa.</p>
+			</td>
+		</tr>
+		<tr>
+			<th scope="col">Requirements</th>
+			<th scope="col">Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Completed and signed application form</td>
+			<td>Please complete an application form on the following website, print it out, and sign it: <a href="https://visawebapp.boca.gov.tw/" title="online appilcation form">https://visawebapp.boca.gov.tw/</a>.</td>
+		</tr>
+		<tr>
+			<td>Two identical color passport photos (45 mm in height and 35 mm in width) taken within the last six months</td>
+			<td>Photos should feature a plain white background.</td>
+		</tr>
+		<tr>
+			<td>Passport (original and photocopy)</td>
+			<td>
+			<ol>
+				<li>Passports must be valid for at least six months and have blank pages. (Temporary and emergency passports are excluded.)</li>
+				<li>Please photocopy the passport information page containing your photo.</li>
+			</ol>
+			</td>
+		</tr>
+		<tr>
+			<td>Proof of remote work experience</td>
+			<td>
+			<p>Please provide the following documents:</p>
+
+			<ol>
+				<li>Personal resume or portfolio, including academic background and work experience</li>
+				<li>Valid work contract (Employees: please provide contract with employer. Freelance workers: please provide contracts for current cases.)</li>
+				<li>Completed <a href="https://www.boca.gov.tw/dl-4404-cce506ae0e0446549937af1d61a416f8.html" title="Description of Intended Activities form">Description of Intended Activities form</a></li>
+			</ol>
+			</td>
+		</tr>
+		<tr>
+			<td>
+			<p>Proof of meeting one of the following conditions:</p>
+
+			<ul>
+				<li>Proof of having obtained digital nomad visa issued by another country&nbsp;</li>
+				<li>For those 30 years of age and older: proof of earning an annual salary of at least US$40,000 or its equivalent in one of the last two years</li>
+				<li>For those between 20 and 29 years of age: proof of having earned an annual salary of at least US$20,000 or its equivalent in one of the last two years</li>
+			</ul>
+			</td>
+			<td>
+			<ul>
+				<li>Related passport annotation or proof of having obtained digital nomad visa issued by another country</li>
+				<li>Proof of annual salary (either of the following):</li>
+			</ul>
+
+			<ol>
+				<li>Tax certificate (e.g., PAYG payment summary from Australia, T4 slip from Canada, 106 form from Israel, 2-NDFL from Russia, PIT-11 from Poland, P60 from the United Kingdom, W-2 from the United States)</li>
+				<li>Salary certificate issued by the employer</li>
+			</ol>
+			</td>
+		</tr>
+		<tr>
+			<td>Proof of bank account balance over the last six months</td>
+			<td>Account balance must average at least US$10,000 or its equivalent each month</td>
+		</tr>
+		<tr>
+			<td>Proof of international health insurance</td>
+			<td>Proof of health and full hospitalization insurance for the entire duration of stay in the R.O.C. (Taiwan) as indicated in the Description of Intended Activities form</td>
+		</tr>
+		<tr>
+			<td>Other supporting documents (if requested)</td>
+			<td>
+			<p>These will be determined by the R.O.C. (Taiwan) overseas mission on a case-by-case basis.</p>
+
+			<p>Applicants currently in the R.O.C. (Taiwan) must also provide photocopies of the passport pages containing their most recent visitor visa and immigration entry stamp. (Applicants who entered the country via visa exemption only need to provide a photocopy of their most recent immigration entry stamp.)</p>
+			</td>
+		</tr>
+	</tbody>
+</table>
+</div>
+
+<p>&nbsp;</p>
+
+<h2>Procedures：</h2>
+
+<ol>
+	<li>Visa applicants outside of the R.O.C. (Taiwan) should submit their applications to an R.O.C. (Taiwan) overseas mission, which will send the application materials to the National Development Council (NDC) to review the applicants&#39;&nbsp;qualifications. Afterwards, the NDC will send the results back to the mission, which will further review the visa applications.</li>
+	<li>Applicants who have already entered the R.O.C. (Taiwan) via visa exemption or a non-extendable visitor visa for other purposes (e.g., social visit, tourism, or business) must submit their digital nomad visa applications 10 working days before the current duration of stay expires to the Bureau of Consular Affairs (BOCA) or one of the Central, Southwestern, Southern, or Eastern Taiwan Offices of the Ministry of Foreign Affairs (MOFA), which will send the application materials to the NDC to review the applicants&#39;&nbsp;qualifications. Afterwards, the NDC will send the results back to BOCA or one of MOFA&#39;s Central, Southwestern, Southern, or Eastern Taiwan Offices for further review. Applicants who fail to obtain the visa must leave the R.O.C. (Taiwan) before their legal duration of stay expires.</li>
+	<li>An interview may be required.</li>
+</ol>
+
+<h2>Notices：</h2>
+
+<ol>
+	<li>The issuance of visas is a sovereign power of the state. The government of the R.O.C. (Taiwan) has the right to refuse to grant a visa without explanation. The visa application fee is nonrefundable, even if a visa is not granted.</li>
+	<li>Applicants who are requested to submit additional documents must do so within three working days of notification. If the applicant&#39;s legal duration of stay expires during the review process and the applicant&#39;s application in the end is denied, the applicant must assume sole responsibility for any overstay and subsequent penalties issued by the competent authorities in accordance with the law.</li>
+	<li>For information on visa application fees, please refer to &quot;<a href="https://www.boca.gov.tw/cp-76-32-4a369-1.html" target="_blank" title="Fees">Standard Fees for Republic of China (Taiwan) Visas in Foreign Passports(pdf file)</a>.&quot;</li>
+</ol><div class="file_download">
+                <h3>Attachment</h3>
+                <ul>
+                  <li>
+                    <div class="file_name">來臺停留期間計畫說明表Description of intended activities</div>
+                    <div class="file_odt"><a href="https://www.boca.gov.tw/dl-4404-cce506ae0e0446549937af1d61a416f8.html" title="來臺停留期間計畫說明表Description of intended activities.odtAttachment">odt</a><span>(15 KB)</span><span>Last Updated：2025-01-02</span><span>Download Counter：2743</span></div>
+                  </li>
+                </ul>
+              </div></section></div>
+        </div>
+      </div><section class="fatfooter"><div class="container"><button type="button" name="OPEN" aria-label="Close" class="btn btn-fatfooter" title="Close">Close</button><nav aria-label="fatfooter"><ul>
+              <li><a href="/np-136-2.html" title="Passport">Passport</a><ul>
+                  <li><a href="/np-353-2.html" title="Apply for a Passport(Taiwan)">Apply for a Passport(Taiwan)</a></li>
+                  <li><a href="/lp-139-2.html" title="Apply for a Passport(Abroad)">Apply for a Passport(Abroad)</a></li>
+                  <li><a href="/np-140-2.html" title="Passport Photos">Passport Photos</a></li>
+                  <li><a href="/lp-236-2.html" title="Application Directions for a Second ROC Passport">Application Directions for a Second ROC Passport</a></li>
+                  <li><a href="/np-244-2.html" title="Applying for Past Passport Records">Applying for Past Passport Records</a></li>
+                  <li><a href="/lp-145-2.html" title="Passport FAQs">Passport FAQs</a></li>
+                  <li><a href="/lp-143-2.html" title="Application Forms">Application Forms</a></li>
+                  <li><a href="/lp-144-2.html" title="Passport Act and Regulations">Passport Act and Regulations</a></li>
+                  <li><a href="/np-142-2.html" title="ePassport Project">ePassport Project</a></li>
+                  <li><a href="/np-287-2.html" title="Operating Directions for Issuance of Entry Permits">Operating Directions for Issuance of Entry Permits</a></li>
+                  <li><a href="/cp-243-4449-23912-2.html" title="Country Signing CA (CSCA) Information">Country Signing CA (CSCA) Information</a></li>
+                </ul>
+              </li>
+              <li><a href="/np-137-2.html" title="Visa">Visa</a><ul>
+                  <li><a href="/np-146-2.html" title="General Information">General Information</a></li>
+                  <li><a target="_blank" href="https://visawebapp.boca.gov.tw/" title="On-line Application Forms (not applicable to Hong Kong, Macau and PRC passport holders)(open in a new window)">On-line Application Forms (not applicable to Hong Kong, Macau and PRC passport holders)</a></li>
+                  <li><a href="/lp-149-2.html" title="Visa-Exempt Entry, Landing Visa and eVisa">Visa-Exempt Entry, Landing Visa and eVisa</a></li>
+                  <li><a href="/np-147-2.html" title="Visitor Visas">Visitor Visas</a></li>
+                  <li><a href="/np-150-2.html" title="Resident Visas">Resident Visas</a></li>
+                  <li><a href="/lp-166-2-xCat-3.html" title="Study in Taiwan">Study in Taiwan</a></li>
+                  <li><a href="/np-152-2.html" title="Southeast Asian Countries">Southeast Asian Countries</a></li>
+                  <li><a href="/lp-153-2.html" title="Working Holidays Scheme">Working Holidays Scheme</a></li>
+                  <li><a href="/lp-154-2.html" title="Entrepreneur">Entrepreneur</a></li>
+                  <li><a href="/cp-158-4158-09d5a-2.html" title="Employment-Seeking">Employment-Seeking</a></li>
+                  <li><a href="/lp-181-2.html" title="Visa FAQs">Visa FAQs</a></li>
+                </ul>
+              </li>
+              <li><a href="/np-138-2.html" title="Authentication">Authentication</a><ul>
+                  <li><a href="/np-202-2.html" title="Document Authentication in ROC(Taiwan)">Document Authentication in ROC(Taiwan)</a></li>
+                  <li><a href="/np-203-2.html" title="Document Authentication Services">Document Authentication Services</a></li>
+                  <li><a href="/np-204-2.html" title="Authentication of domestic documents">Authentication of domestic documents</a></li>
+                  <li><a href="/lp-209-2.html" title="Authentication of foreign documents">Authentication of foreign documents</a></li>
+                  <li><a href="/lp-205-2.html" title="Authentication Regulations">Authentication Regulations</a></li>
+                  <li><a href="/lp-206-2.html" title="Consular District">Consular District</a></li>
+                  <li><a href="/lp-207-2.html" title="Application Forms">Application Forms</a></li>
+                  <li><a href="/lp-208-2.html" title="Authentication FAQs">Authentication FAQs</a></li>
+                  <li><a href="/lp-230-2.html" title="E-register">E-register</a></li>
+                </ul>
+              </li>
+              <li><a href="/np-411-2.html" title="Online Service">Online Service</a><ul>
+                  <li><a target="_blank" href="https://visawebapp.boca.gov.tw/" title="On-line Application Forms(not applicable to Hong Kong,Macau and PRC passport holders)(open in a new window)">On-line Application Forms(not applicable to Hong Kong,Macau and PRC passport holders)</a></li>
+                  <li><a target="_blank" href="https://docauth.boca.gov.tw/BOCAWeb/index3" title="Authentication-Application Progress(open in a new window)">Authentication-Application Progress</a></li>
+                  <li><a target="_blank" href="https://docauth.boca.gov.tw/BOCAWeb/index4/qry" title="Authentication-Verification of Authentication(open in a new window)">Authentication-Verification of Authentication</a></li>
+                </ul>
+              </li>
+              <li><a href="/lp-220-2.html" title="News & Events">News & Events</a></li>
+              <li><a href="/lp-191-2.html" title="Our Locations">Our Locations</a></li>
+              <li><a href="/sp-foof-countrylp-01-2.html" title="Embassies and Missions">Embassies and Missions</a></li>
+              <li><a href="/np-193-2.html" title="About Us">About Us</a><ul>
+                  <li><a href="/np-218-2.html" title="Organizational Structure">Organizational Structure</a></li>
+                  <li><a href="/np-219-2.html" title="Director General">Director General</a></li>
+                  <li><a href="/np-365-2.html" title="Deputy Director General">Deputy Director General</a></li>
+                  <li><a href="/np-367-2.html" title="Deputy Director General">Deputy Director General</a></li>
+                </ul>
+              </li>
+              <li><a href="/np-243-2.html" title="Certificate Revocation Lists(CRLs)">Certificate Revocation Lists(CRLs)</a></li>
+            </ul></nav></div></section><footer><div class="container"><a accesskey="Z" class="accesskey" href="#aZ" id="aZ" title="Bottom Link area">:::</a><div class="footer_info"><p>Address：3-5F, 2-2, Sec.1, Jinan Rd., Zhongzheng Dist., Taipei City 100219, Taiwan（R.O.C.） TEL：(+886) 2-2343-2888</p><div class="footer_contact_us"><span>Our Location：</span><ul>	<li><a href="/cp-191-1859-b011f-2.html" title="Boca Taipei Headquarter">Boca Taipei Headquarter</a></li>	<li><a href="/cp-191-1856-4c577-2.html" title="Central Taiwan Office">Central Taiwan Office</a></li>	<li><a href="/cp-191-1858-01bf8-2.html" title="Southwestern Taiwan Office">Southwestern Taiwan Office</a></li>	<li><a href="/cp-191-1857-bd28d-2.html" title="Southern Taiwan Office">Southern Taiwan Office</a></li>	<li><a href="/cp-191-1855-f8b0d-2.html" title="Eastern Taiwan Office">Eastern Taiwan Office</a></li>	<li><a href="/cp-191-3823-f8654-2.html" title="Taoyuan Airport Office">Taoyuan Airport Office</a></li></ul></div><span class="update" id="UpdateTime">Updated Date：<em>2022-06-21</em></span> <span class="counter" id="Counter">Counter：<em>46476653</em></span></div><div class="footer_icon"><ul class="footer_link">	<li><a href="/np-358-2.html" title="Privacy Protection and Information Security Policies">Privacy Protection and Information Security Policies</a></li>	<li><a href="/np-359-2.html" title="Government Website Open Information Announcement">Government Website Open Information Announcement</a></li>	<!-- <li><a  data-cke-saved-href="javascript:;" href="javascript:;" title="Security Safeguard and Restoration Mechanism">Security Safeguard and Restoration Mechanism</a></li>--></ul><a href="https://www.gov.tw/" target="_blank" title="My eGov portal(open in a new window"><img alt="My eGov portal(open in a new window" src="/Public/Images/202302/6512302221309d2b02.png" /> </a>  <a href="https://accessibility.moda.gov.tw/Applications/Detail?category=20230412135026" target="_blank" title="Accessibility,AA(open new window)"><img alt="Accessibility,AA(open new window)" src="/Public/Images/202302/401230222130954afd.jpg" /> </a></div></div></footer><script>
+      $('#UpdateTime').html('Updated Date：<em>2026-05-20</em>');
+      $('#Counter').html('Counter：<em>17493379</em>');
+		</script></div><a href="#" title="Go Top" class="scrollToTop" role="button">Go Top</a><script src="Styles/Unit002/js/jquery-3.6.0.min.js"></script><script src="Styles/Unit002/vendor/jquery.easing.min.js"></script><script src="Styles/Unit002/vendor/slick/slick.min.js "></script><script src="Styles/Unit002/vendor/slick/slick-lightbox.js "></script><script src="Styles/Unit002/vendor/lazyload/lazyload.js"></script><script src="Styles/Unit002/vendor/picturefill/picturefill.min.js" async=""></script><script src="Styles/Unit002/vendor/scrolltable/jquery.scroltable.min.js"></script><script src="Styles/Unit002/vendor/sticky-sidebar/sticky-sidebar.js"></script><script src="Styles/Unit002/vendor/sticky-sidebar/ResizeSensor.js"></script><script src="Styles/Unit002/vendor/fancybox/jquery.fancybox.min.js"></script><script src="Styles/Unit002/js/wow.min.js"></script><script>
+      new WOW().init();
+    </script><script src="Styles/Unit002/js/hyui.js"></script><script src="Styles/Unit002/js/customize_e.js"></script></body>
+</html>

--- a/sources/TW_DNV_BOCA_2026-06-15.html.meta.json
+++ b/sources/TW_DNV_BOCA_2026-06-15.html.meta.json
@@ -1,0 +1,7 @@
+{
+  "source_id": "TW_DNV_BOCA_2026",
+  "url": "https://www.boca.gov.tw/cp-158-7718-c0382-2.html",
+  "retrieved_at": "2026-06-15T00:00:00Z",
+  "sha256": "51392397072072c60ad02e166a6fbe0f8b29f8d9ddebf930c8a4939a55dab9fa",
+  "local_path": "sources/TW_DNV_BOCA_2026-06-15.html"
+}

--- a/tools/build_content_hubs.py
+++ b/tools/build_content_hubs.py
@@ -531,6 +531,20 @@ VISA_FAQS = {
             "answer": "The official application process states no coverage amount, so the engine encodes none and models that insurance is mandatory and must be valid in Dominica.",
         },
     ],
+    "TW_DNV_BOCA_2026": [
+        {
+            "question": "What insurance does the Taiwan digital nomad visitor visa require?",
+            "answer": "The Bureau of Consular Affairs requires proof of health and full hospitalization insurance for the entire duration of stay in the R.O.C. (Taiwan).",
+        },
+        {
+            "question": "Is there a minimum coverage amount?",
+            "answer": "The official page states no coverage amount, so the engine encodes none and models that insurance is mandatory and must cover the entire duration of stay.",
+        },
+        {
+            "question": "Why is SafetyWing YELLOW while other products are GREEN?",
+            "answer": "The insurance must cover the entire duration of stay. A month-to-month subscription that can lapse does not assure that, so it is YELLOW; full-period policies are GREEN.",
+        },
+    ],
 }
 
 RELATED_POSTS = {
@@ -711,6 +725,11 @@ RELATED_POSTS = {
     "DM_WIN_GOVDM_2026": [
         ("/posts/dominica-work-in-nature-insurance/", "Dominica Work In Nature insurance requirements"),
         ("/posts/digital-nomad-insurance-americas/", "Digital nomad insurance in the Americas"),
+        ("/guides/how-to-read-results/", "How to read compliance results"),
+    ],
+    "TW_DNV_BOCA_2026": [
+        ("/posts/taiwan-dnv-insurance/", "Taiwan digital nomad visitor visa insurance requirements"),
+        ("/posts/digital-nomad-insurance-asia/", "Digital nomad insurance in Asia"),
         ("/guides/how-to-read-results/", "How to read compliance results"),
     ],
 }

--- a/tools/editorial_targets.json
+++ b/tools/editorial_targets.json
@@ -346,5 +346,13 @@
   "content/posts/dominica-work-in-nature-insurance.md": [
     450,
     1200
+  ],
+  "content/visas/taiwan/digital-nomad-visitor-visa/digital-nomad-visitor-visa-bureau-of-consular-affairs/index.md": [
+    900,
+    1400
+  ],
+  "content/posts/taiwan-dnv-insurance.md": [
+    450,
+    1200
   ]
 }


### PR DESCRIPTION
## Summary
- New route **TW_DNV_BOCA_2026** — Taiwan Digital Nomad Visitor Visa
- Primary source (byte-exact, sha256-validated): Bureau of Consular Affairs (boca.gov.tw)
- Rules encoded verbatim only: `insurance.mandatory`, `insurance.must_cover_full_period` ("Proof of health and full hospitalization insurance for the entire duration of stay in the R.O.C. (Taiwan)")
- No coverage amount stated, so none encoded (UNKNOWN > Wrong)

## Mapping outcomes
Full-period products **GREEN**; SafetyWing **YELLOW** (monthly). No existing mapping changed.

## Content
- Hub: /visas/taiwan/digital-nomad-visitor-visa/digital-nomad-visitor-visa-bureau-of-consular-affairs/
- Post: /posts/taiwan-dnv-insurance/ (dated 2026-06-13, past in UTC)
- Affiliate: Genki Traveler paid link, after results only

## Gates
All gates + ui_compliance_tests.ps1 + mapping_engine_tests.ps1 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)