### PR TITLE
feat(route): add Austria residence permit route (evidence-based)

### DIFF
--- a/content/posts/austria-residence-insurance.md
+++ b/content/posts/austria-residence-insurance.md
@@ -1,0 +1,106 @@
+---
+title: "Austria residence permit insurance requirements (evidence-based)"
+date: 2026-06-14
+description: "Evidence-based summary of the health insurance requirement for Austrian residence permits: health insurance covering all risks in Austria, with travel health insurance not sufficient, per the Federal Ministry of the Interior."
+tags: ["austria", "residence-permit", "insurance", "compliance"]
+faq:
+  - question: "What insurance does an Austrian residence permit require?"
+    answer: "The Federal Ministry of the Interior states third-country nationals must have health insurance that covers all risks in Austria, and that a travel health insurance is not sufficient."
+  - question: "Why do SafetyWing and World Nomads show RED?"
+    answer: "The source states that a travel health insurance is not sufficient. Travel-medical products are therefore RED, while a comprehensive health policy that documents coverage in Austria (such as Genki Native) is GREEN."
+  - question: "Does this apply to every residence permit?"
+    answer: "The health-insurance condition is a general granting requirement, but several permit types are exempt from demonstrating it (Red-White-Red card, EU Blue Card, researchers, students, ICT workers). Confirm your specific permit type."
+---
+
+## Short answer
+
+Austria's general granting requirements for residence permits state that third-country nationals must have health insurance that covers all risks in Austria, and that the presentation of a travel health insurance is not sufficient (Source: `AT_RESIDENCE_BMI_2026`, Federal Ministry of the Interior; verified 2026-06-14). The engine models four rules: insurance is mandatory, it must cover Austria, it must be comprehensive (all risks), and travel insurance is not accepted.
+
+## Key findings at a glance
+
+| Item | Value |
+|---|---|
+| Route | Austria Residence Permit (third-country nationals) |
+| Authority | Federal Ministry of the Interior of Austria (BMI) |
+| Evidence verified | 2026-06-14 |
+| Snapshot | 2026-06-13 |
+| Modeled rules | Insurance mandatory; covers all risks in Austria; comprehensive; travel insurance not accepted |
+
+## What the authority requires
+
+- Third-country nationals must have health insurance that covers all risks in Austria. (Source: `AT_RESIDENCE_BMI_2026`; verified 2026-06-14)
+- The presentation of a travel health insurance is not sufficient. (Source: `AT_RESIDENCE_BMI_2026`; verified 2026-06-14)
+- This is a general granting requirement; several permit types are exempt from demonstrating it (Red-White-Red card, EU Blue Card, researchers, students, ICT workers, cross-border workers). (Source: `AT_RESIDENCE_BMI_2026`)
+
+Normalized requirements table:
+
+| Requirement | Source URL | Locator | Verified date |
+|---|---|---|---|
+| Insurance is mandatory | https://www.bmi.gv.at/312_en/04/start.html | General granting requirements, Health insurance | 2026-06-14 |
+| Covers all risks in Austria | https://www.bmi.gv.at/312_en/04/start.html | General granting requirements, Health insurance | 2026-06-14 |
+| Comprehensive (all risks) | https://www.bmi.gv.at/312_en/04/start.html | General granting requirements, Health insurance | 2026-06-14 |
+| Travel insurance not accepted | https://www.bmi.gv.at/312_en/04/start.html | General granting requirements, Health insurance | 2026-06-14 |
+
+## Verified requirements (PASS/FAIL/UNKNOWN)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Insurance is mandatory | PASS | BMI general granting requirements |
+| Covers all risks in Austria | PASS only for products documenting Austria coverage; UNKNOWN otherwise | "health insurance that covers all risks in Austria" |
+| Comprehensive (all risks) | PASS for products documenting comprehensive cover; UNKNOWN otherwise | "covers all risks in Austria" |
+| Travel insurance not accepted | RED for travel-medical products | "The presentation of a travel health insurance is not sufficient" |
+
+## How we evaluate
+
+The checker compares each modeled requirement against product evidence. Four rules are encoded from the BMI page: insurance is mandatory, it must cover all risks in Austria, it must be comprehensive, and a travel health insurance is not sufficient. Travel-medical products are therefore marked RED. A comprehensive health policy that documents coverage in Austria is GREEN; products that do not document Austria coverage stay UNKNOWN rather than being assumed valid. This follows the UNKNOWN > Wrong principle.
+
+A scope note, disclosed rather than over-modeled: this health-insurance condition is a general granting requirement, and the source lists several exempt permit types (Red-White-Red card, EU Blue Card, researchers, students, ICT workers, cross-border workers). Confirm your specific permit type before relying on this route. See /methodology/ for the full logic.
+
+## Proof package checklist
+
+- A comprehensive health insurance policy documented to cover all risks in Austria.
+- Not a travel health insurance, which the Ministry states is not sufficient.
+- Confirmation of whether your permit type is exempt from this requirement.
+
+## FAQ
+
+**Q: What is required?**
+**A:** Health insurance covering all risks in Austria; travel insurance is not sufficient (Source: `AT_RESIDENCE_BMI_2026`; verified 2026-06-14).
+
+**Q: Why are travel products RED?**
+**A:** The Ministry states travel health insurance is not sufficient, so the engine marks travel-medical products RED.
+
+**Q: Does it apply to every permit?**
+**A:** It is a general requirement with several exempt permit types; confirm your category.
+
+## Check in the engine
+
+Use [the compliance checker](/ui/) with the current snapshot for this route:
+
+{{< checker_cta visa="AT_RESIDENCE_BMI_2026" product="GENKI_NATIVE_2026" snapshot="2026-06-13" >}}
+
+## Related reading
+
+- [Austria residence permit requirements (route page)](/visas/austria/residence-permit-third-country-nationals/residence-permit-granting-requirements-federal-ministry-of-the-interior/)
+- [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## Where to find compliant insurance for an Austrian residence permit
+
+The requirement is a comprehensive health policy covering all risks in Austria, and travel insurance is explicitly not sufficient. In the current snapshot, Genki Native shows GREEN: it documents global comprehensive coverage that includes Austria. SafetyWing and World Nomads show RED because they are travel-medical products, which the Ministry states are not sufficient. Confirm your permit type, since some are exempt.
+
+- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+
+> Use the compliance checker to confirm the current GREEN products for this route before you buy.
+
+## Disclaimer + Affiliate disclosure
+
+Not legal advice. Compliance results are evidence-based snapshots.
+
+If an affiliate link is present, it appears only after results and does not change the compliance outcome. The Genki link above is a paid affiliate link.
+
+Last updated: 2026-06-14
+
+## Evidence log
+
+- Source: AT_RESIDENCE_BMI_2026

--- a/content/visas/austria/residence-permit-third-country-nationals/_index.md
+++ b/content/visas/austria/residence-permit-third-country-nationals/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Austria Residence Permit (third-country nationals)"
+visa_group: "austria-residence-permit-third-country-nationals"
+description: "Insurance requirements for Austria Residence Permit (third-country nationals) - evidence-based compliance checker"
+---
+
+## Austria Residence Permit (third-country nationals) Requirements
+
+All requirements below are derived from official sources. Missing evidence means UNKNOWN.
+
+## Routes
+
+| Authority | Route | Last Verified | Details |
+| --- | --- | --- | --- |
+| Federal Ministry of the Interior of Austria (BMI) | Residence permit granting requirements (Federal Ministry of the Interior) | 2026-06-16 | [View requirements](/visas/austria/residence-permit-third-country-nationals/residence-permit-granting-requirements-federal-ministry-of-the-interior/) |
+
+## What the authority requires
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+## How we evaluate
+
+We compare these official requirements against insurance product specifications using our automated rule engine. Each requirement is matched to a product fact with evidence.
+
+## Check in the engine
+
+Try the compliance checker: [Open Checker](/ui/?visa=AT_RESIDENCE_BMI_2026&snapshot=2026-06-13)
+
+## Disclaimer
+
+This is not legal advice. VisaFact provides evidence-based compliance checking only. Final visa decisions are made by government authorities. A GREEN result does not ensure visa approval.
+
+## Affiliate disclosure
+
+If affiliate links appear, they are shown only after compliance results and do not influence the compliance evaluation in any way.
+
+## Evidence log
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+
+{{< checker_cta visa="AT_RESIDENCE_BMI_2026" snapshot="2026-06-13" >}}

--- a/content/visas/austria/residence-permit-third-country-nationals/residence-permit-granting-requirements-federal-ministry-of-the-interior/index.md
+++ b/content/visas/austria/residence-permit-third-country-nationals/residence-permit-granting-requirements-federal-ministry-of-the-interior/index.md
@@ -1,0 +1,109 @@
+---
+title: "Austria Residence Permit (third-country nationals) - Residence permit granting requirements (Federal Ministry of the Interior)"
+visa_id: "AT_RESIDENCE_BMI_2026"
+last_verified: "2026-06-16"
+source_ids: ["AT_RESIDENCE_BMI_2026"]
+description: "Official insurance requirements for Austria Residence Permit (third-country nationals) via Residence permit granting requirements (Federal Ministry of the Interior)"
+faq:
+  - question: "What insurance does an Austrian residence permit require?"
+    answer: "The Federal Ministry of the Interior states third-country nationals must have health insurance that covers all risks in Austria, and that a travel health insurance is not sufficient."
+  - question: "Why do SafetyWing and World Nomads show RED?"
+    answer: "The source states that a travel health insurance is not sufficient. Travel-medical products are therefore RED, while a comprehensive health policy that documents coverage in Austria (such as Genki Native) is GREEN."
+  - question: "Does this apply to every residence permit?"
+    answer: "The health-insurance condition is a general granting requirement, but the source notes several permit types are exempt from demonstrating it (such as the Red-White-Red card, EU Blue Card, researchers, students and ICT workers). Confirm your specific permit type."
+---
+
+## Austria Residence Permit (third-country nationals)
+
+**Route:** Residence permit granting requirements (Federal Ministry of the Interior)  
+**Authority:** Federal Ministry of the Interior of Austria (BMI)  
+**Last Verified:** 2026-06-16
+
+## Requirements
+
+| Requirement | Operator | Value | Evidence |
+| --- | --- | --- | --- |
+| `insurance.mandatory` | `==` | Yes | *General granting requirements, Health insurance*: "Third-country nationals must have health insurance that covers all risks in Aust..." ([source](/sources/AT_RESIDENCE_BMI_2026-06-16.html)) |
+| `insurance.authorized_in_country` | `==` | Yes | *General granting requirements, Health insurance*: "health insurance that covers all risks in Austria..." ([source](/sources/AT_RESIDENCE_BMI_2026-06-16.html)) |
+| `insurance.comprehensive` | `==` | Yes | *General granting requirements, Health insurance*: "health insurance that covers all risks in Austria..." ([source](/sources/AT_RESIDENCE_BMI_2026-06-16.html)) |
+| `insurance.travel_insurance_accepted` | `==` | No | *General granting requirements, Health insurance*: "The presentation of a travel health insurance is not sufficient...." ([source](/sources/AT_RESIDENCE_BMI_2026-06-16.html)) |
+
+## Source Documents
+
+- **AT_RESIDENCE_BMI_2026**: [Local copy](/sources/AT_RESIDENCE_BMI_2026-06-16.html) | [Original](https://www.bmi.gv.at/312_en/04/start.html) | Retrieved: 2026-06-16
+
+## Related reading
+
+- [Austria residence permit insurance requirements](/posts/austria-residence-insurance/)
+- [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## What the authority requires
+
+The points below are taken directly from the official source for the Austria Residence Permit (third-country nationals) (Residence permit granting requirements (Federal Ministry of the Interior)) route. Each one is recorded with a source identifier and a locator so it can be traced back to the original document. Where the source is silent on a point, the engine records UNKNOWN instead of inferring an answer.
+
+- The authority requires that insurance is mandatory.
+- The authority requires that authorized in country.
+- The authority requires that the coverage is comprehensive.
+- The authority requires that travel insurance accepted does not apply.
+
+## How we evaluate
+
+Every requirement is compared against the documented specification of each insurance product using an automated rule engine. A product is marked GREEN for a requirement only when product evidence explicitly satisfies it; a conflict produces RED; and absent evidence produces UNKNOWN rather than a guess. The route status is the combination of its per-requirement outcomes.
+
+- Rule `insurance.mandatory == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+- Rule `insurance.authorized_in_country == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+- Rule `insurance.comprehensive == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+- Rule `insurance.travel_insurance_accepted == No` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+
+## How each compliance status is decided for this route
+
+GREEN means every recorded requirement is satisfied by product evidence. RED means at least one requirement is contradicted by the product evidence. YELLOW means the evidence is partial: some requirements are met while others lack full proof. UNKNOWN means a requirement exists but the product evidence does not address it, so no claim is made. NOT_REQUIRED means the authority does not impose an insurance requirement for the route, which is itself an evidence-based finding drawn from the official document. A GREEN result reflects the evidence on the snapshot date and is not an assurance of a visa outcome, which always rests with the issuing authority.
+
+## Reading the evidence and snapshots
+
+Each requirement above links to a primary source through a source identifier and a locator (for example a page number, article, or section). The underlying documents are listed under Source Documents and are stored alongside this dataset so the wording can be checked directly. Results are tied to a dated snapshot (`2026-06-13`): a deep link to a past snapshot returns the same verdict even if the authority later changes its rules, which keeps every decision reproducible and auditable.
+
+## Proof package checklist
+
+Before applying for this route, prepare the following so the policy can be checked against each requirement:
+
+- A policy certificate that states the coverage limits, any deductible or co-payment, and the covered period.
+- Written confirmation of the insurer's status where the route requires authorization in a specific country.
+- Documentation that the coverage spans the full authorized stay rather than a partial term.
+- The official source wording for the route, so each clause can be matched to the requirements above.
+
+## Common questions
+
+**What insurance does an Austrian residence permit require?**  
+The Federal Ministry of the Interior states third-country nationals must have health insurance that covers all risks in Austria, and that a travel health insurance is not sufficient.
+
+**Why do SafetyWing and World Nomads show RED?**  
+The source states that a travel health insurance is not sufficient. Travel-medical products are therefore RED, while a comprehensive health policy that documents coverage in Austria (such as Genki Native) is GREEN.
+
+**Does this apply to every residence permit?**  
+The health-insurance condition is a general granting requirement, but the source notes several permit types are exempt from demonstrating it (such as the Red-White-Red card, EU Blue Card, researchers, students and ICT workers). Confirm your specific permit type.
+
+## Check in the engine
+
+Run a specific product against this route in the compliance checker: [Open Checker](/ui/?visa=AT_RESIDENCE_BMI_2026&snapshot=2026-06-13). The checker shows the per-requirement outcome and the evidence behind each one.
+
+## Disclaimer
+
+This page is not legal advice. VisaFact provides evidence-based compliance checking only, and final visa decisions are made by government authorities. A GREEN result reflects documented evidence on the snapshot date; it does not ensure that a visa application will succeed. Always confirm the current requirements with the issuing authority before submitting an application.
+
+## Affiliate disclosure
+
+If affiliate links appear on related pages, they are shown only after the compliance result and never change the evaluation, which is generated independently from the official evidence.
+
+## Evidence log
+
+Each entry pairs a requirement with the source identifier and locator it was drawn from:
+
+- `insurance.mandatory` <- AT_RESIDENCE_BMI_2026 (General granting requirements, Health insurance): "Third-country nationals must have health insurance that covers all risks in Austria."
+- `insurance.authorized_in_country` <- AT_RESIDENCE_BMI_2026 (General granting requirements, Health insurance): "health insurance that covers all risks in Austria"
+- `insurance.comprehensive` <- AT_RESIDENCE_BMI_2026 (General granting requirements, Health insurance): "health insurance that covers all risks in Austria"
+- `insurance.travel_insurance_accepted` <- AT_RESIDENCE_BMI_2026 (General granting requirements, Health insurance): "The presentation of a travel health insurance is not sufficient."
+
+
+{{< checker_cta visa="AT_RESIDENCE_BMI_2026" snapshot="2026-06-13" >}}

--- a/data/mappings/AT_RESIDENCE_BMI_2026__ASISA_HEALTH_RESIDENTS_2026.json
+++ b/data/mappings/AT_RESIDENCE_BMI_2026__ASISA_HEALTH_RESIDENTS_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "AT_RESIDENCE_BMI_2026",
+  "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.AT.authorized"
+  ]
+}

--- a/data/mappings/AT_RESIDENCE_BMI_2026__DKV_VISADO_2026.json
+++ b/data/mappings/AT_RESIDENCE_BMI_2026__DKV_VISADO_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "AT_RESIDENCE_BMI_2026",
+  "product_id": "DKV_VISADO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.AT.authorized"
+  ]
+}

--- a/data/mappings/AT_RESIDENCE_BMI_2026__GENERIC_EXPAT_COMPLETE_2026.json
+++ b/data/mappings/AT_RESIDENCE_BMI_2026__GENERIC_EXPAT_COMPLETE_2026.json
@@ -1,0 +1,10 @@
+{
+  "visa_id": "AT_RESIDENCE_BMI_2026",
+  "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.AT.authorized",
+    "specs.comprehensive"
+  ]
+}

--- a/data/mappings/AT_RESIDENCE_BMI_2026__GENKI_NATIVE_2026.json
+++ b/data/mappings/AT_RESIDENCE_BMI_2026__GENKI_NATIVE_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "AT_RESIDENCE_BMI_2026",
+  "product_id": "GENKI_NATIVE_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/AT_RESIDENCE_BMI_2026__GENKI_TRAVELER_2026.json
+++ b/data/mappings/AT_RESIDENCE_BMI_2026__GENKI_TRAVELER_2026.json
@@ -1,0 +1,11 @@
+{
+  "visa_id": "AT_RESIDENCE_BMI_2026",
+  "product_id": "GENKI_TRAVELER_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.type",
+    "specs.jurisdiction_facts.AT.authorized",
+    "specs.comprehensive"
+  ]
+}

--- a/data/mappings/AT_RESIDENCE_BMI_2026__SAFETYWING_NOMAD_2026.json
+++ b/data/mappings/AT_RESIDENCE_BMI_2026__SAFETYWING_NOMAD_2026.json
@@ -1,0 +1,21 @@
+{
+  "visa_id": "AT_RESIDENCE_BMI_2026",
+  "product_id": "SAFETYWING_NOMAD_2026",
+  "status": "RED",
+  "reasons": [
+    {
+      "text": "Travel insurance is not accepted for this visa",
+      "evidence": [
+        {
+          "source_id": "AT_RESIDENCE_BMI_2026",
+          "locator": "General granting requirements, Health insurance",
+          "excerpt": "The presentation of a travel health insurance is not sufficient."
+        }
+      ]
+    }
+  ],
+  "missing": [
+    "specs.jurisdiction_facts.AT.authorized",
+    "specs.comprehensive"
+  ]
+}

--- a/data/mappings/AT_RESIDENCE_BMI_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
+++ b/data/mappings/AT_RESIDENCE_BMI_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "AT_RESIDENCE_BMI_2026",
+  "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.AT.authorized"
+  ]
+}

--- a/data/mappings/AT_RESIDENCE_BMI_2026__WORLDNOMADS_EXPLORER_2026.json
+++ b/data/mappings/AT_RESIDENCE_BMI_2026__WORLDNOMADS_EXPLORER_2026.json
@@ -1,0 +1,21 @@
+{
+  "visa_id": "AT_RESIDENCE_BMI_2026",
+  "product_id": "WORLDNOMADS_EXPLORER_2026",
+  "status": "RED",
+  "reasons": [
+    {
+      "text": "Travel insurance is not accepted for this visa",
+      "evidence": [
+        {
+          "source_id": "AT_RESIDENCE_BMI_2026",
+          "locator": "General granting requirements, Health insurance",
+          "excerpt": "The presentation of a travel health insurance is not sufficient."
+        }
+      ]
+    }
+  ],
+  "missing": [
+    "specs.jurisdiction_facts.AT.authorized",
+    "specs.comprehensive"
+  ]
+}

--- a/data/products/Genki/Native/2026-06-08/product_facts.json
+++ b/data/products/Genki/Native/2026-06-08/product_facts.json
@@ -136,6 +136,16 @@
             "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
           }
         ]
+      },
+      "AT": {
+        "authorized": true,
+        "evidence": [
+          {
+            "source_id": "GENKI_NATIVE_COVERAGE_2026",
+            "locator": "Global Coverage",
+            "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
+          }
+        ]
       }
     }
   },

--- a/data/ui_index.json
+++ b/data/ui_index.json
@@ -1,5 +1,5 @@
 {
-  "built_at": "2026-06-15T23:34:34.745343+00:00",
+  "built_at": "2026-06-15T23:58:19.374431+00:00",
   "snapshot_id": "2026-06-15",
   "visas": [
     {
@@ -71,6 +71,73 @@
               "source_id": "AL_LEJE_UNIKE_MB_2026",
               "locator": "Official checklist, insurance requirement (valid for the permit period)",
               "excerpt": "Health-insurance policy valid for at least 1 year."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "AT_RESIDENCE_BMI_2026",
+      "country": "Austria",
+      "visa_name": "Residence Permit (third-country nationals)",
+      "route": "Residence permit granting requirements (Federal Ministry of the Interior)",
+      "authority": "Federal Ministry of the Interior of Austria (BMI)",
+      "last_verified": "2026-06-16",
+      "sources": [
+        {
+          "source_id": "AT_RESIDENCE_BMI_2026",
+          "url": "https://www.bmi.gv.at/312_en/04/start.html",
+          "retrieved_at": "2026-06-16T00:00:00Z",
+          "sha256": "bf81b905be6263443f34825a4f6a748ce062689b8f19a97b54a1924e2c17f9a8",
+          "local_path": "sources/AT_RESIDENCE_BMI_2026-06-16.html"
+        }
+      ],
+      "requirements": [
+        {
+          "key": "insurance.mandatory",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "AT_RESIDENCE_BMI_2026",
+              "locator": "General granting requirements, Health insurance",
+              "excerpt": "Third-country nationals must have health insurance that covers all risks in Austria."
+            }
+          ]
+        },
+        {
+          "key": "insurance.authorized_in_country",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "AT_RESIDENCE_BMI_2026",
+              "locator": "General granting requirements, Health insurance",
+              "excerpt": "health insurance that covers all risks in Austria"
+            }
+          ]
+        },
+        {
+          "key": "insurance.comprehensive",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "AT_RESIDENCE_BMI_2026",
+              "locator": "General granting requirements, Health insurance",
+              "excerpt": "health insurance that covers all risks in Austria"
+            }
+          ]
+        },
+        {
+          "key": "insurance.travel_insurance_accepted",
+          "op": "==",
+          "value": false,
+          "evidence": [
+            {
+              "source_id": "AT_RESIDENCE_BMI_2026",
+              "locator": "General granting requirements, Health insurance",
+              "excerpt": "The presentation of a travel health insurance is not sufficient."
             }
           ]
         }
@@ -2526,6 +2593,16 @@
                 "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
               }
             ]
+          },
+          "AT": {
+            "authorized": true,
+            "evidence": [
+              {
+                "source_id": "GENKI_NATIVE_COVERAGE_2026",
+                "locator": "Global Coverage",
+                "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
+              }
+            ]
           }
         }
       },
@@ -2835,6 +2912,111 @@
       "reasons": [],
       "missing": [],
       "last_verified": "2026-06-10"
+    },
+    {
+      "visa_id": "AT_RESIDENCE_BMI_2026",
+      "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.AT.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "AT_RESIDENCE_BMI_2026",
+      "product_id": "DKV_VISADO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.AT.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "AT_RESIDENCE_BMI_2026",
+      "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.AT.authorized",
+        "specs.comprehensive"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "AT_RESIDENCE_BMI_2026",
+      "product_id": "GENKI_NATIVE_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "AT_RESIDENCE_BMI_2026",
+      "product_id": "GENKI_TRAVELER_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.type",
+        "specs.jurisdiction_facts.AT.authorized",
+        "specs.comprehensive"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "AT_RESIDENCE_BMI_2026",
+      "product_id": "SAFETYWING_NOMAD_2026",
+      "status": "RED",
+      "reasons": [
+        {
+          "text": "Travel insurance is not accepted for this visa",
+          "evidence": [
+            {
+              "source_id": "AT_RESIDENCE_BMI_2026",
+              "locator": "General granting requirements, Health insurance",
+              "excerpt": "The presentation of a travel health insurance is not sufficient."
+            }
+          ]
+        }
+      ],
+      "missing": [
+        "specs.jurisdiction_facts.AT.authorized",
+        "specs.comprehensive"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "AT_RESIDENCE_BMI_2026",
+      "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.AT.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "AT_RESIDENCE_BMI_2026",
+      "product_id": "WORLDNOMADS_EXPLORER_2026",
+      "status": "RED",
+      "reasons": [
+        {
+          "text": "Travel insurance is not accepted for this visa",
+          "evidence": [
+            {
+              "source_id": "AT_RESIDENCE_BMI_2026",
+              "locator": "General granting requirements, Health insurance",
+              "excerpt": "The presentation of a travel health insurance is not sufficient."
+            }
+          ]
+        }
+      ],
+      "missing": [
+        "specs.jurisdiction_facts.AT.authorized",
+        "specs.comprehensive"
+      ],
+      "last_verified": ""
     },
     {
       "visa_id": "BB_WELCOMESTAMP_OAG_2026",
@@ -4425,7 +4607,7 @@
       "missing": [
         "specs.jurisdiction_facts.GE.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "GE_LONGVISA_GEOCONSUL_2026",
@@ -4435,7 +4617,7 @@
       "missing": [
         "specs.jurisdiction_facts.GE.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "GE_LONGVISA_GEOCONSUL_2026",
@@ -4445,7 +4627,7 @@
       "missing": [
         "specs.jurisdiction_facts.GE.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "GE_LONGVISA_GEOCONSUL_2026",
@@ -4453,7 +4635,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "GE_LONGVISA_GEOCONSUL_2026",
@@ -4463,7 +4645,7 @@
       "missing": [
         "specs.jurisdiction_facts.GE.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "GE_LONGVISA_GEOCONSUL_2026",
@@ -4484,7 +4666,7 @@
       "missing": [
         "specs.jurisdiction_facts.GE.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "GE_LONGVISA_GEOCONSUL_2026",
@@ -4494,7 +4676,7 @@
       "missing": [
         "specs.jurisdiction_facts.GE.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "GE_LONGVISA_GEOCONSUL_2026",
@@ -4504,7 +4686,7 @@
       "missing": [
         "specs.jurisdiction_facts.GE.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "GR_DNV_MFA_2026",
@@ -6622,6 +6804,13 @@
       "retrieved_at": "2026-01-16T00:00:00Z",
       "sha256": "4a1c4e1c4f74fc8ded05482ea171df962320632d846c70bf287ceebc235f36f1",
       "local_path": "sources/ASISA_HEALTH_RESIDENTS_2026-01-16.html"
+    },
+    "AT_RESIDENCE_BMI_2026": {
+      "source_id": "AT_RESIDENCE_BMI_2026",
+      "url": "https://www.bmi.gv.at/312_en/04/start.html",
+      "retrieved_at": "2026-06-16T00:00:00Z",
+      "sha256": "bf81b905be6263443f34825a4f6a748ce062689b8f19a97b54a1924e2c17f9a8",
+      "local_path": "sources/AT_RESIDENCE_BMI_2026-06-16.html"
     },
     "BB_WELCOMESTAMP_OAG_2026": {
       "source_id": "BB_WELCOMESTAMP_OAG_2026",

--- a/data/visas/AT/RESIDENCE/bmi/2026-06-16/visa_facts.json
+++ b/data/visas/AT/RESIDENCE/bmi/2026-06-16/visa_facts.json
@@ -1,0 +1,67 @@
+{
+  "id": "AT_RESIDENCE_BMI_2026",
+  "country": "Austria",
+  "visa_name": "Residence Permit (third-country nationals)",
+  "route": "Residence permit granting requirements (Federal Ministry of the Interior)",
+  "authority": "Federal Ministry of the Interior of Austria (BMI)",
+  "last_verified": "2026-06-16",
+  "sources": [
+    {
+      "source_id": "AT_RESIDENCE_BMI_2026",
+      "url": "https://www.bmi.gv.at/312_en/04/start.html",
+      "retrieved_at": "2026-06-16T00:00:00Z",
+      "sha256": "bf81b905be6263443f34825a4f6a748ce062689b8f19a97b54a1924e2c17f9a8",
+      "local_path": "sources/AT_RESIDENCE_BMI_2026-06-16.html"
+    }
+  ],
+  "requirements": [
+    {
+      "key": "insurance.mandatory",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "AT_RESIDENCE_BMI_2026",
+          "locator": "General granting requirements, Health insurance",
+          "excerpt": "Third-country nationals must have health insurance that covers all risks in Austria."
+        }
+      ]
+    },
+    {
+      "key": "insurance.authorized_in_country",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "AT_RESIDENCE_BMI_2026",
+          "locator": "General granting requirements, Health insurance",
+          "excerpt": "health insurance that covers all risks in Austria"
+        }
+      ]
+    },
+    {
+      "key": "insurance.comprehensive",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "AT_RESIDENCE_BMI_2026",
+          "locator": "General granting requirements, Health insurance",
+          "excerpt": "health insurance that covers all risks in Austria"
+        }
+      ]
+    },
+    {
+      "key": "insurance.travel_insurance_accepted",
+      "op": "==",
+      "value": false,
+      "evidence": [
+        {
+          "source_id": "AT_RESIDENCE_BMI_2026",
+          "locator": "General granting requirements, Health insurance",
+          "excerpt": "The presentation of a travel health insurance is not sufficient."
+        }
+      ]
+    }
+  ]
+}

--- a/sources/AT_RESIDENCE_BMI_2026-06-16.html
+++ b/sources/AT_RESIDENCE_BMI_2026-06-16.html
@@ -1,0 +1,1201 @@
+﻿
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="de">
+<meta http-equiv="content-type" content="text/html;charset=utf-8" />
+<head><meta charset="utf-8" /><meta http-equiv="X-UA-Compatible" content="IE=edge" /><meta name="viewport" content="width=device-width, initial-scale=1" /><meta name="Description" content="Bundesministerium für Inneres" /><meta name="Keywords" content="BMI, Innenministerium, Innenministerium Österreich" /><meta name="referrer" content="no-referrer" /><meta name="google-site-verification" content="3V5sv7g4mDrOEsKR1A0fmpcO_keCdhxMC6GEzGWHqVc" />
+    <title>
+	Requirements for the granting of residence permits to third-country nationals
+</title>
+	<!-- ICON -->
+	<link rel="icon" href="../../favicon.ico" type="image/x-icon" /><link rel="shortcut icon" href="../../favicon.ico" type="image/x-icon" />
+	<!-- Framework resources Last Update: 03/2024 -->		
+	<script src="../../scripts/js/jquery-3.5.1.min.js"></script>
+	<script src="../../scripts/js/jquery-migrate-3.4.1.min.js"></script>
+	<script src="../../scripts/bxslider/jquery.bxslider_de.js"></script>
+    <!-- slider -->
+    <!--<script src="../../lightbox2/src/js/lightbox.js"></script>-->
+    <!-- bootstrap -->
+	<script src="../../scripts/js/bootstrap.bundle.min.js"></script>
+	<!--<script src="../../scripts/js/balken.js"></script>-->
+    <link rel="stylesheet" href="../../css/bootstrap.min.css" />
+    <!--<link href="../../lightbox2/src/css/lightbox.css" rel="stylesheet" type="text/css" />-->
+    <link rel="stylesheet" href="../../font-awesome-4.7.0/css/font-awesome.css" media="all" /><link href="../../scripts/bxslider/jquery.bxslider.css" rel="stylesheet" /><link rel="stylesheet" href="../../css/bootstrap-icons.css" /><link href="../../css/layout.css" rel="stylesheet" /><link href="../../css/bcmsicons.css" rel="stylesheet" />
+    <!-- ASP.NET Script für IncludeFiles +  Searchprovider -->
+		<base  />
+	</head>
+<body>
+	<div class="container" id="skipLink">
+				<div class="row">
+					<div class="col-12">
+					<nav aria-label="Seitenbereiche">
+						<div id="skip"></div>
+						</nav>
+					</div>
+				</div>
+		</div>
+	<!-- WCAG-Change 26.08.2024-->
+	<form method="post" action="http://bmi.gv.at/start.aspx" id="form1" role="presentation">
+<div class="aspNetHidden">
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwULLTE5ODM0NTYxODlkZKpuiE/tUF9Dvxsz1XbIygRLZyZ0/Q48C03zI4ywTil/" />
+</div>
+<div class="aspNetHidden">
+	<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="F64697E4" />
+</div>
+        <button type="submit" style="width:0px;height:0px;visibility:hidden;">Neu laden</button> 	
+			<div class="container">
+				<div class="row d-print-none">
+					<div class="col-5 d-none d-sm-none d-md-block">
+						<ul class="soc_oben">
+  <li class="soc">
+<!--<style>
+.bi {
+color: #71869b;
+font-size: 1.5em;
+padding-right: 5px;
+}
+</style>-->
+    <a href="https://www.facebook.com/innenministerium/" title="zu Facebook des BMI" target="_blank" aria-label="zu Facebook des BMI">
+      <i class="bi bi-facebook" aria-hidden="true" title="öffnet Facebook"></i>
+    </a>
+  </li>
+  <li>
+    <a href="https://www.instagram.com/innenministerium/?hl=de" target="_blank" aria-label="zu Instagram">
+      <i class="bi bi-instagram" aria-hidden="true" title="öffnet Instagram"></i>
+    </a>
+  </li>
+  <!--<li>
+    <a href="https://www.snapchat.com/add/polizei_oe" target="_blank" aria-label="zu Snapchat">
+      <i class="bi bi-snapchat" aria-hidden="true" title="öffnet Snapchat"></i>
+    </a>
+  </li>-->
+  <li>
+    <a href="https://twitter.com/@bmi_oe" target="_blank" title="öffnet Twitter" aria-label="zu Twitter">
+      <i class="bi bi-twitter-x" aria-hidden="true"></i>
+    </a>
+  </li>
+  <li>
+    <a href="https://www.youtube.com/channel/UCiKH5XPrw9FUDW0J2DVRFuQ" target="_blank" title="öffnet YouTube"  aria-label="zu YouTube">
+      <i class="bi bi-youtube" aria-hidden="true" title="öffnet YouTube"></i>
+    </a>
+  </li>
+ <li>
+    <a href="https://www.tiktok.com/@diepolizei" target="_blank" title="öffnet TikTok"  aria-label="zu TikTok">
+      <i class="bi bi-tiktok" aria-hidden="true" title="öffnet TikTok"></i>
+    </a>
+  </li>
+ <li>
+    <a href="../../podcast/index.html" title="öffnet die Übersichtsseite des Podcasts"  aria-label="zum Podcast">
+      <i class="bi bi-mic" aria-hidden="true" title="öffnet die Übersichtsseite des Podcasts"></i>
+    </a>
+  </li>
+<li style="vertical-align: text-bottom;">
+    <a href="https://bsky.app/profile/innenministerium.bsky.social" target="_blank" title="öffnet Bluesky"  aria-label="zum Podcast">
+     <svg fill="none" viewBox="0 0 64 57" style="width: 1.5em; height: auto;" class="sky"><path fill="#71869b" d="M13.873 3.805C21.21 9.332 29.103 20.537 32 26.55v15.882c0-.338-.13.044-.41.867-1.512 4.456-7.418 21.847-20.923 7.944-7.111-7.32-3.819-14.64 9.125-16.85-7.405 1.264-15.73-.825-18.014-9.015C1.12 23.022 0 8.51 0 6.55 0-3.268 8.579-.182 13.873 3.805ZM50.127 3.805C42.79 9.332 34.897 20.537 32 26.55v15.882c0-.338.13.044.41.867 1.512 4.456 7.418 21.847 20.923 7.944 7.111-7.32 3.819-14.64-9.125-16.85 7.405 1.264 15.73-.825 18.014-9.015C62.88 23.022 64 8.51 64 6.55c0-9.818-8.578-6.732-13.873-2.745Z"></path></svg>
+    </a>
+  </li>
+</ul>
+					</div>
+					<div class="col-5 d-block d-sm-block d-md-block">
+						<ul class="soc_mitte">
+<li>
+<!--<style>
+.bcmsicon {
+color: #71869b;
+font-size: 2em;
+font-weight: bold;
+}
+</style>-->
+<a href="../../leichter-lesen/start.html" title="Informationen in Leichter Lesen" aria-label="Leichter Lesen Texte">
+    <span class="bcmsicon bcmsicon-leichter_lesen unsericon" aria-hidden="true" ></span>
+  </a>
+<a href="../../inhalte-in-gebaerdensprache/start.html" title="Informationen in Gebärdensprache" aria-label="Gebärdensprache Videos">
+    <span class="bcmsicon bcmsicon-gebaerdensprache unsericon" aria-hidden="true" ></span>
+  </a>
+  <a href="javascript:window.print()" title="Seite Drucken" aria-label="Seite drucken">
+    <span class="bcmsicon bcmsicon-drucken unsericon" aria-hidden="true" ></span>
+  </a>
+</li>
+<!--<li>
+  <a href="styles.html">
+    <i class="fa fa-low-vision fa-2x" aria-hidden="true"></i>
+  </a>
+</li>--> 
+</ul>
+					</div>
+					<div class="col-1 d-none d-sm-none d-md-block">
+						<!--<ul class="soc_mitte">
+                        <li class="aktiv">DE</li>
+                        <li>| <a href="#">EN</a></li>
+                    </ul> -->
+					</div>
+					<div class="col-4 d-none d-sm-none d-md-block soc_rechts">
+						<div class="navbar-form navbar-left navbar-expand-md">
+							<div class="navbar-form navbar-left form-inline" style="display:none;">
+   <div class="form-group">
+    <a class="btn btn-default" href="../../suche.html" title="Suche">
+      <i class="fa fa-search" aria-hidden="true"></i>
+    </a>
+  </div>
+</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="container-fluid hintergrund clearfix">
+				<div class="header container">
+					<div class="col-lg-8">
+						<a href="../../index.html" title="Home">
+							<img class="toplogo img-fluid" src="../../grafiken_all/bmi_logo_srgb.png" alt="Bundesministerium für Inneres - zur Startseite" />
+							<!--<h1 class="nicht">Bundesministerium für Inneres</h1>-->
+						</a>
+					</div>
+					<a id="skipheadermenu"></a>
+					<div class="col-lg-12 col-lg-offset-4 d-print-none">				
+<ul class="nav_oben">
+	<!--<li>
+		<a href="412/nationalratswahlen/nationalratswahl_2024/start.aspx" aria-label="Informationen zur Nationalratswahl 2024" title="Informationen zur Nationalratswahl 2024">Nationalratswahl 2024</a> |
+	</li>
+	<li>
+		<a href="podcast/" title="öffnet die Übersichtsseite des Podcasts" aria-label="Link zu unserem Podcast">Podcast</a> |
+    </li>-->
+	<li >
+		<a href="../../ukraine/index.html" title="Alles zum Thema 'Ukraine - Schutz in Österreich'" aria-label="Ukraine - Schutz in Österreich"><strong>Ukraine</strong></a> |
+	</li>
+<li >
+		<a href="https://www.returnfromaustria.at/syrien/select-language.html" "target="_blank" title="Alles zum Thema 'Rückkehr nach Syrien'" aria-label="Rückkehr nach Syrien"><strong>Syrien</strong></a> |
+	</li>
+	<li>
+		<a href="../../notrufnummern/start.html" aria-label="Link zu den Notrufnummern" title="Notrufnummern" >Notruf</a> |
+	</li>
+	<li>
+		<a href="../../kontakt/start.html" title="Kontakt zum BMI" aria-label="Kontakt zum BMI">Kontakt</a> |
+	</li>
+	<li>
+		<a href="../../presse/start.html" title="Kontakt zu den Pressesprechern und Pressestellen" aria-label="Pressesprecher und Pressestellen">Presse</a> |
+  </li>
+  <li>
+    <a href="../../downloads/start.html" title="Dokumente für den Download" aria-label="Dokumente für den Download">Downloads</a> |
+  </li>
+  <li>
+    <a href="../../links/start.html" title="Link zu anderen Behörden und Instutionen" aria-label="Link zu anderen Behörden und Instutionen">Links</a>
+  </li>
+ <!-- <li class="mob">
+    <a href="../searchres.aspx"> | Suchen</a>
+  </li> -->
+</ul>
+					</div>
+				</div>
+			</div>
+			<a id="skipnavigation"></a>
+			<div class="container">
+				<nav class="navbar navbar-light navbar-expand-lg">
+					<div class="container-fluid">
+						<div class="row nav-btn-collapsed">
+  <button title="Navigation ein-/ausblenden" type="button" class="navbar-toggler" data-bs-toggle="collapse" data-bs-target="#bs-example-navbar-collapse-1" aria-controls="bs-example-navbar-collapse-1" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon" title="Navigation ein-/ausblenden">
+    </span>
+  </button>
+</div>
+<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+  <ul class="navbar-nav nav">
+    <li class="dropdown nav-item">
+      <a data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" class="dropdown-toggle nav-link" href="#" id="dropdownMenuDivider1">
+        <p class="nav-menuoben-new">Minister und<br/>Ministerium</p>
+      </a>
+      <ul class="dropdown-menu" aria-labelledby="dropdownMenuDivider1">
+        <li>
+          <a class="dropdown-item" href="../../101/start.html" title="Bundesminister - Vita - Fotos">Bundesminister</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../102/start.html" title="Aufgaben des Bundesministeriums für Inneres">Bundesministerium</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../113/start.html" title="Aufgaben, Organigramme, Leitungsfunktionen">Geschäftseinteilung</a>
+        </li>
+        <li>
+          <hr class="dropdown-divider">
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../104/start.html" title="Die Sicherheitsakademie im BMI">Aus- und Fortbildung im BMI</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../107/start.html" title="Informationen zu den Förderungen">Förderungen</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../105/start.html" title="Links zu den Jobangeboten, Veröffentlichungen gemäß Ausschreibungsgesetz">Jobs und Karriere</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="https://bmi.vergabeportal.at/" target="_blank" title="Link zum Vergabeportal">Sachausschreibungen</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../110/start.html" title="Amtliche Verlautbarungen">Verlautbarungen</a>
+        </li>
+        <li>
+          <hr class="dropdown-divider">
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../114/start.html" title="Veröffentlichungspflichten für Studien, Gutachten und Umfragen">Veröffentlichungspflichten<br/>gem. B-VG</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../115/start.html" title="Veröffentlichungen gemäß § 2 Abs. 1b Z 1 MedKF-TG">Bekanntgabepflicht<br/>gem. MedKF-TG</a>
+        </li>
+      </ul>
+    </li>
+    <li class="dropdown nav-item">
+      <a data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" class="dropdown-toggle nav-link" href="#" id="dropdownMenuDivider2">
+        <p class="nav-menuoben-new">Polizei und<br/>Sicherheit</p>
+      </a>
+      <ul class="dropdown-menu" aria-labelledby="dropdownMenuDivider2">
+        <li>
+          <a class="dropdown-item" href="../../201/start.html" title="Sicherheitsdialog zwischen Bürgerinnen und Bürgern, Gemeinden und Polizei">Gemeinsam.Sicher</a>
+        </li>
+        <li>
+          <hr class="dropdown-divider">
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../202/start.html" title="Bundespolizei - Informationen und Bereiche">Bundespolizei</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../fahndung/start.html" title="Fahndungen des Bundeskriminalamtes">Fahndungen</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../202/fremdenpolizei_und_grenzkontrolle/start.html" title="Informationen zu Fremdenpolizei und Grenzkontrolle">Fremdenpolizei und Grenzkontrolle</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../204/start.html" title="Zivilschutz, Bevölkerungsschutz und Katastrophenschutz in Österreich">Krisen- und Katastrophenmanagement</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../211/start.html" title="Sport in der Polizei">Polizeisport</a>
+        </li>
+        <li>
+          <hr class="dropdown-divider">
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../206/start.html" title="Allgemeines über das Bundeskriminalamt">Bundeskriminalamt</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../205/start.html" title="Allgemeines über die Direktion Staatsschutz und Nachrichtendienst">Direktion Staatsschutz und Nachrichtendienst</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../207/start.html" title="Direktion Spezialeinheiten / Einsatzkommando Cobra (DSE/EKO Cobra)">Einsatzkommando Cobra/<br/>Direktion für Spezialeinheiten</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../208/start.html" title="Allgemeines zu den Landespolizeidirektionen">Landespolizeidirektionen</a>
+        </li>
+      </ul>
+    </li>
+    <li class="dropdown nav-item">
+      <a data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" class="dropdown-toggle nav-link" href="#" id="dropdownMenuDivider3">
+        <p class="nav-menuoben-new">Asyl und<br/>Migration</p>
+      </a>
+      <ul class="dropdown-menu asyl" aria-labelledby="dropdownMenuDivider3">
+        <li>
+          <a class="dropdown-item" href="../../301/start.html" title="Asyl in Österreich">Asylwesen</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../312/start.html" title="Informationen zum Aufenthalt von Fremden in Österreich">Niederlassung und Aufenthaltsrecht</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../303/start.html" title="Informationen zur Grundversorgung in Österreich">Grundversorgung</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../305/start.html" title="Gesamtstaatliche Migrationsstrategie in Österreich">Migrationsstrategie und Gesellschaft</a>
+        </li>
+        <li>
+          <hr class="dropdown-divider">
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../304/start.html" title="Allgemeines zum Bundesamt für Fremdenwesen und Asyl">Bundesamt für Fremdenwesen und Asyl</a>
+        </li>
+        <li>
+          <hr class="dropdown-divider">
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../107/eu_foerderungen/start.html" title="Förderprogramme der EU">EU-Förderungen</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../301/foerderungen/start.html" title="Projektförderungen im Themenbereich &quot;Asyl, Migration und Rückkehr“">Förderungen "Asyl, Migration und Rückkehr"</a>
+        </li>
+      </ul>
+    </li>
+    <li class="dropdown nav-item">
+      <a data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" class="dropdown-toggle nav-link" href="#" id="dropdownMenuDivider4">
+        <p class="nav-menuoben-new">Gesellschaft<br/>und Recht</p>
+      </a>
+      <ul class="dropdown-menu" aria-labelledby="dropdownMenuDivider4">
+        <li>
+          <a class="dropdown-item" href="../../401/start.html" title="Entwürfe für Gesetzte und Verordnungen zur Begutachtung">Begutachtungen</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../402/start.html" title="Datenschutz im BMI">Datenschutz</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../417/start.html" title="Informationen zur Europäischen Bürgerinitiative">Europäische Bürgerinitiative</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../403/start.html" title="Vorstellung der Abteilung 'Historische Angelegenheiten'">Historische Angelegenheiten</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../404/start.html" title="KZ-Gedenkstätte Mauthausen Memorial">Mauthausen Memorial</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../405/start.html" title="Parteienregister">Politische Parteien</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../407/start.html" title="Der Rechtsschutzbeauftragte beim Bundesminister für Inneres">Rechtsschutzbeauftragter</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../408/start.html" title="Rechtsstaatlichkeit und Menschenrechte">Rechtsstaat und Menschenrechte</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../406/start.html" title="Informationen zum Erwerb der Staatsbürgerschaft">Staatsbürgerschaft</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../409/start.html" title="Verzeichnis der Stiftungen und Fonds">Stiftungs- und Fondsregister</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../418/start.html" title="EBM-Beirat">Unabhängiger Beirat Ermittlungs- und Beschwerdestelle Misshandlungsvorwürfe</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../410/start.html" title="Volksabstimmungen in Österreich">Volksabstimmungen</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../416/start.html" title="Volksbefragungen in Österreich">Volksbefragungen</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../411/start.html" title="Volksbegehren in Österreich">Volksbegehren</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../412/start.html" title="Nationalrats-, Bundespräsidenten- und Europawahlen">Wahlen</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../413/start.html" title="Zentrale Melderegister (ZMR)">Zentrales Melderegister</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../414/start.html" title="Zentrales Personenstandsregister (ZPR)">Zentrales Personenstandsregister</a>
+        </li>
+        <li>
+          <hr class="dropdown-divider">
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../415/start.html" title="Allgemeines zum Bundesamt zur Korruptionsprävention und Korruptionsbekämpfung">Bundesamt zur Korruptionsprävention<br/>und Korruptionsbekämpfung</a>
+        </li>
+      </ul>
+    </li>
+    <li class="dropdown nav-item">
+      <a data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" class="dropdown-toggle nav-link" href="#" id="dropdownMenuDivider5">
+        <p class="nav-menuoben-new">Sicherheitspolitik<br/>und Strategie</p>
+      </a>
+      <ul class="dropdown-menu" aria-labelledby="dropdownMenuDivider5">
+        <li>
+          <a class="dropdown-item" href="../../501/start.html" title="Strategien des BMI">BMI Strategien</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../502/start.html" title="Österreichische Sicherheitsstrategie. Sicherheit in einer neuen Dekade – Sicherheit gestalten">Österreichische Sicherheitsstrategie</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../503/start.html" title="Strategien der Europäischen Union">Europäische Strategien</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../510/start.html" title="Nationale Anti-Korruptionsstrategie und Nationaler Anti-Korruptionsplan">Nationale <br/>Anti-Korruptionsstrategie</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../511/start.html" title="Jugendstrategie, Umsetzung durch das Bundesministerium für Inneres">Österreichische Jugendstrategie</a>
+        </li>
+        <li>
+          <hr class="dropdown-divider">
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../509/start.html" title="Das BMI-Engagement in der Europäischen Union">EU-Engagement des BMI</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../504/start.html" title="Cybersicherheit">Cybersicherheit</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../505/start.html" title="Österreichisches Programm zum Schutz kritischer Infrastrukturen (APCIP)">Schutz kritischer Infrastruktur</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../506/start.html" title="Zivil-militärische Zusammenarbeit (ZMZ)">Zivil - militärische Zusammenarbeit</a>
+        </li>
+        <li>
+          <hr class="dropdown-divider">
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../508/start.html" title="Bericht über die innere Sicherheit">Sicherheitsbericht</a>
+        </li>
+      </ul>
+    </li>
+    <li class="dropdown nav-item">
+      <a data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" class="dropdown-toggle service nav-link" href="#" id="dropdownMenuDivider6">
+        <p class="nav-menuoben-new">Bürger-<br/>service</p>
+      </a>
+      <ul class="dropdown-menu buerger" aria-labelledby="dropdownMenuDivider6">
+        <li>
+          <a class="dropdown-item" href="https://citizen.bmi.gv.at/at.gv.bmi.fnsbazweb-p/baz/public/BuergeranzeigeInfo" target="_blank" title="Externer Link zur Online Diebstahlsanzeige">Online Diebstahlsanzeige</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="https://citizen.bmi.gv.at/at.gv.bmi.fnsbfaweb-p/bfa/public/SISAntrag" target="_blank" title="Externer Link zum Online-Formular Schengen Informationssystem">Online-Formular Schengener Informationssystem (SIS)</a>
+        </li>
+        <li>
+          <hr class="dropdown-divider">
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../611/start.html" title="Informationen zur Barrierefreiheit">Barrierefreiheit</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../601/start.html" title="Bürgerservice inklusive Hotline">Bürgertelefon</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../602/start.html" title="Call Center im Einsatz- und Koordinationscenter des BMI">Callcenter</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../613/start.html" title="e-Learning Demenz.Aktivgemeinde">Demenz.Aktivgemeinde</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../615/start.html" title="ID Austria (elektronische Identität)">ID Austria Behörden</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../603/start.html" title="Kriminalprävention des BK">Kriminalprävention</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../604/start.html" title="Meldewesen in Österreich">Meldeangelegenheiten</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../605/start.html" title="Meldestellen des BK, BAK und DSN">Meldestellen</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../magazin/magazin.html" title="Öffentliche Sicherheit - Das Magazin des Innenministeriums">Magazin "Öffentliche Sicherheit"</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../104/wissenschaft_und_forschung/siak-journal/start.html" title="Zeitschrift für Polizeiwissenschaft und polizeiliche Praxis">SIAK-Journal</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../607/start.html" title="Informationen zu „Flugsicherheit“ und „Reisepass“">Sicherheit bei Reisen<br/>(Reisepass/Personalausweis)</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../614/start.html" title="Leben in der Krise ohne Aggression und Gewalt">Sicher zu Hause</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../termin.html" title="Terminvorschau">Termine</a>
+        </li>
+        <li>
+          <a class="dropdown-item" href="../../609/start.html" title="Vereinswesen">Vereine</a>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>
+					</div>
+				</nav>
+			</div>
+			<a id="skipinhalt"></a>
+<div class="container">
+        <div class="row">
+  <ol class="breadcrumb">
+    <li>
+      <a href="../../index.html" title="Startseite">Startseite</a>
+    </li>
+    <li>
+      <a href="../index.html" title="Zurück">Settlement in Austria</a>
+    </li>
+    <li class="active">Requirements for the granting of residence permits to third-country nationals</li>
+  </ol>
+</div>
+    </div>
+     <!--Change 08/2024 div wird main-->
+	<main class="container">
+        <article class="row article-style">
+            <div class="text col-lg-8 clearfix">
+     <h1><a id="uebersicht"></a>Requirements for the granting of residence permits to third-country nationals</h1>
+<p>The authority can only grant a residence permit if all general and special conditions are met and there are no obstacles to granting it.</p>
+<p>You can <a title="Link to 'Documents required when applying for a residence permit'" href="../05/start.html">find out here</a>, which documents you must enclose with every application for a residence permit to prove these requirements.</p>
+<ul>
+<li><a title="General granting requirements" href="start.html#pkt_01">General granting requirements</a></li>
+<li><a title="Obstacles for a residence permit" href="start.html#pkt_02">Obstacles for a residence permit</a></li>
+<li><a title="Absence of necessary requirements or existence of an obstacle" href="start.html#pkt_03">Absence of necessary requirements or existence of an obstacle</a></li>
+<li><a title="Absence of necessary requirements or existence of an obstacle" href="start.html#pkt_04">Special requirements for granting residence permits to third-country nationals</a></li>
+</ul>
+<hr role="presentation" />
+<h2><a id="pkt_01"></a>General granting requirements</h2>
+<p>The following conditions must be fulfilled for the granting of each residence permit:</p>
+<ul>
+<li><strong>Sufficient income (sustenance):</strong> <br />Third-country nationals must have stable and regular income. It must be possible to lead a life without recourse to public social welfare benefits. The level of income must be in line with the reference rates laid down in law, taking into account running costs such as rent, loans or similar.
+<ul>
+<li>Reference rates for the year <strong>2026</strong>:<br />
+<ul>
+<li>For Singles: &euro; 1,308.39</li>
+<li>For married couples/couples in a registered partnership: &euro; 2,064.12</li>
+<li>Additionally for each child: &euro; 201.88</li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<p style="padding-left: 30px;">This sum must be available per month (after taxes and running costs are deducted).</p>
+<p style="padding-left: 30px;">Sufficient income must not be shown, when applying for the following residence permits</p>
+<ul style="padding-left: 60px;">
+<li>red white red card (Rot-Wei&szlig;-Rot &ndash; Karte)</li>
+<li>blue card EU (Blaue Karte EU)</li>
+<li>cross-border worker (Grenzg&auml;nger)</li>
+</ul>
+<p style="padding-left: 30px;">More detailed information on the calculation of income can be found in the <span class="bmifile"><em class="fa fa-download">&nbsp;</em><a title="Informationsbrosch&uuml;re &uuml;ber die Unterhaltsberechnung im Niederlassungs- und Aufenthaltsgesetz" href="../../312/files/broschuere_unterhaltsberechnung_publikation_a4_2026_converted_webbf.pdf" target="_blank">Informationsbrosch&uuml;re &uuml;ber die Unterhaltsberechnung</a> (pdf, 505 KB)</span>&nbsp;(available in German only).</p>
+<ul>
+<li><strong>Health insurance</strong> <br />Third-country nationals must have health insurance that covers all risks in Austria. If compulsory insurance in the Austrian social insurance system applies (e.g. due to gainful employment in Austria) the insurance is sufficient in any case. Voluntary insurance in the Austrian social security system is also sufficient, if benefits can be obtained immediately after the start of the insurance (for example, when spouses are co-insured or when students are voluntarily insured). Also a private insurance, which corresponds to or has a higher level of care than the Austrian social insurance scheme in all instances, is sufficient. The presentation of a travel health insurance is not sufficient.</li>
+</ul>
+<ul>
+<ul>
+<li><strong>Locally customary accommodation</strong><br />Third-country nationals must prove a legal claim to accommodation (for example, by presenting a tenancy agreement or a <span class="bmifile"><em class="fa fa-download">&nbsp;</em><a title="accommodation agreement (only in German)" href="../../312/60a/files/e/029_2025_antragsformular_e_wohnrechtsvereinbarung_v20250625_bf.pdf" target="_blank">accommodation agreement</a> (pdf, 67 KB)</span>). The accommodation must be customary for a family of comparable size.</li>
+</ul>
+</ul>
+<ul>This does not apply, when applying for the following residence permits
+<ul>
+<li><a title="red white red card (Rot-Wei&szlig;-Rot &ndash; Karte)" href="../15/start.html">red white red card (Rot-Wei&szlig;-Rot &ndash; Karte)</a></li>
+<li><a title="blue card EU (Blaue Karte EU)" href="../17/start.html">blue card EU (Blaue Karte EU)</a></li>
+<li><a title="settlement permit researcher (Niederlassungsbewilligung &ndash; Forscher)" href="../20/start.html">settlement permit researcher (Niederlassungsbewilligung &ndash; Forscher)</a></li>
+<li><a title="stay permit researcher-mobility (Aufenthaltsbewilligung Forscher-Mobilit&auml;t)" href="../30/start.html">stay permit researcher-mobility (Aufenthaltsbewilligung Forscher-Mobilit&auml;t)</a></li>
+<li><a title="stay permit ICT (Aufenthaltsbewilligung Unternehmensintern transferierte Arbeitnehmer - &bdquo;ICT&ldquo;)" href="../26/start.html">stay permit ICT (Aufenthaltsbewilligung Unternehmensintern transferierte Arbeitnehmer - &bdquo;ICT&ldquo;)</a></li>
+<li><a title="stay permit mobile ICT (Aufenthaltsbewilligung Mobiler unternehmensintern transferierter Arbeitnehmer &ndash; &bdquo;mobile ICT&ldquo;)" href="../27/start.html">stay permit mobile ICT (Aufenthaltsbewilligung Mobiler unternehmensintern transferierter Arbeitnehmer &ndash; &bdquo;mobile ICT&ldquo;)</a></li>
+<li><a title="stay permit student (Aufenthaltsbewilligungen Student)" href="../33/start.html">stay permit student (Aufenthaltsbewilligungen Student)</a></li>
+<li>&bdquo;settlement permit&ldquo; for extended family members of EEA nationals or Swiss nationals</li>
+<li><a title="more informations about 'stay permit cross-border worker (Aufenthaltsbewilligung Grenzg&auml;nger)'" href="../37/start.html">stay permit cross-border worker (Aufenthaltsbewilligung Grenzg&auml;nger)</a></li>
+</ul>
+</ul>
+<p style="padding-left: 30px;">However, the costs of accommodation must be taken into account when calculating the available income (insofar sufficient income has to be shown for that specific residence permit).</p>
+<p style="padding-left: 30px;">If expressly provided for in the law, a <strong>declaration of liability</strong> (Haftungserkl&auml;rung) by a by a third party can be presented as proof of sufficient income and the entitlement to locally customary accommodation.</p>
+<p style="padding-left: 30px;">A declaration of liability is a declaration by a third person that he/she will pay for the requirements of accommodation and the corresponding means of subsistence (income). This person is liable for the reimbursement of those costs incurred by a local authority due to legal measures against the third-country national (e.g. costs arising from the enforcement of a return decision). <br />Austrian notary public or a domestic court must certify the declaration of liability and it must be valid for at least 5 years.</p>
+<ul>
+<li><strong>Knowledge of German</strong> <br />For certain residence permits, proof of basic knowledge of the German language is required, when the permit is issued for the first time (Deutsch vor Zuzug). As a rule, holders of such a residence permit must then prove that they have fulfilled the Integration Agreement within two years. Further information on required German language skills <a title="link to 'Proof of German language skills '" href="../06/start.html">can be found here</a>.</li>
+<li><strong>public interest considerations</strong><br />A residence permit may not be issued, if the stay of the applicant would endanger public order or public security. As a rule, this requires the presentation of a criminal record certificate from the country of origin or the country of last residence before moving to Austria. The authorities also make inquiries in the relevant police databases. It is also contrary to public interests if a residence permit would be granted to a third-country national who supports or advertises for terrorist organizations.</li>
+</ul>
+<ul>
+<li><strong>international law considerations</strong> <br />A residence permit may not be granted if the stay of the third-country national would significantly affect the relations of the Republic of Austria with another state or another subject of international law. This would be the case, for example, if a third-country national against whom sanctions of the United Nations or the European Union applies, requests a residence permit.</li>
+</ul>
+<ul>
+<li><strong>quota place (if applicable)</strong> <br />The existence of a quota place is a prerequisite for the granting of certain residence permits. The quota limits the maximum number of residence permits to be granted annually. In agreement with Parliament, the Federal Government decides how many residence permits may be granted for specific purposes for each calendar year. This is announced in the Settlement Ordinance (Niederlassungsverordnung). <br />A residence permit subject to quotas is, for example, the "Settlement permit except gainful employment". Information on whether a particular residence permit requires a quota can be found in the respective purpose of residence.</li>
+</ul>
+<p style="padding-left: 30px;">Information on the special requirements can be found on the pages on the individual residence titles.</p>
+<p class="zurueck"><a title="back to overview" href="start.html#uebersicht">back to overview</a>&nbsp;<em class="fa fa-arrow-up">&nbsp;</em></p>
+<hr role="presentation" />
+<h2><a id="pkt_02"></a>Obstacles for a residence permit</h2>
+<p>Residence permits <strong>may not be granted</strong> to third-country nationals, when</p>
+<ul>
+<li>an entry ban according to &sect; 53 FPG or a residence ban according to &sect; 67 FPG has been issued</li>
+<li>a return decision of another EEA state or Switzerland has been issued</li>
+<li>an enforceable return decision has been issued and eighteen months have not passed since the departure of the applicant from Austria, unless the applicant left voluntarily and is now making the initial application from abroad</li>
+<li>a sham marriage, sham partnership or adoption for the purpose of obtaining a residence permit was entered into</li>
+<li>the third-country national was entitled to submit an application for the first residence permit in Austria, but then exceeded the permitted visa-free stay or his stay on the basis of a visa</li>
+<li>the third-country national has been finally sentenced for circumventing border controls or entering Austria illegally in the last 12 months.</li>
+</ul>
+<p class="zurueck"><a title="back to overview" href="start.html#uebersicht">back to overview</a>&nbsp;<em class="fa fa-arrow-up">&nbsp;&nbsp;</em></p>
+<hr role="presentation" />
+<h2><a id="pkt_03"></a>Absence of necessary requirements or existence of an obstacle</h2>
+<p>Despite the absence of one or more of the above-mentioned requirements a residence permit must nevertheless be granted, if this is necessary to <strong>maintain private or family life</strong>.</p>
+<p>Likewise, in certain cases a residence permit can be granted despite the existence of an obstacle to granting the permit, if this is necessary for the reasons mentioned above. In the case of an upright entry ban (from Austria or another Schengen Member State) as well as a sham marriage, sham partnership or adoption, the residence permit cannot be granted under any circumstances (compelling reasons for refusal).</p>
+<p>In this way, Austria fulfils its obligations under Article 8 of the European Convention on Human Rights (ECHR).</p>
+<p class="zurueck"><a title="back to overview" href="start.html#uebersicht">back to overview</a>&nbsp;<em class="fa fa-arrow-up">&nbsp;</em></p>
+<hr role="presentation" />
+<h2><a id="pkt_04"></a>Special requirements for granting residence permits to third-country nationals</h2>
+<p>A residence permit can only be granted if all general and special requirements for granting are met and no obstacles exist.</p>
+<p>Information on the general requirements for granting a residence permit can be found above.</p>
+<p>Information on the special requirements can be found in the <a title="application forms" href="../60a/start.html">application forms</a> for the individual residence permits.</p>
+<p class="zurueck"><a title="back to overview" href="start.html#uebersicht">back to overview</a>&nbsp;<em class="fa fa-arrow-up">&nbsp;</em></p>
+<hr role="presentation" />
+<p class="zurueck" style="text-align: left;"><em>Last update: 10&nbsp;February 2026</em></p>
+            </div>
+            <div id="skip_navipart_right" class="col-lg-4">
+	<div class="sidenav hidden-print">
+  <h2 class="blockletter">Settlement and Residence</h2>
+  <ul class="menue_rechts">
+    <li>
+      <a href="../../312/start.html" title="German version">German version</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <hr style="text-align: left!important; margin: 0.3em auto 0.3em 0!important; width: 80%;">
+    </li>
+    <li>
+      <a href="../start-2.html" title="Overview">Overview</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <a href="../60a/start.html" title="Application forms">Application forms</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <a href="../50/start.html" title="Certifications">Certifications</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <hr style="text-align: left!important; margin: 0.3em auto 0.3em 0!important; width: 80%;">
+    </li>
+    <li>
+      <a href="../02/start.html" title="Requirements for third-country nationals">Requirements for third-country nationals</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <a href="../03/start.html" title="Residence purposes">Residence purposes</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <a href="start.html" title="Requirements">Requirements</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <a href="../05/start.html" title="Required documents">Required documents</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <a href="../06/start.html" title="Proof of German language skills">Proof of German language skills</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <a href="../08/start.html" title="Procedures for third-country nationals">Procedures for third-country nationals</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <a href="../13/start.html" title="Validity of residence permits for third-country nationals">Validity of residence permits for third-country nationals</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <a href="../14/start.html" title="Fees for residence permits for third-country nationals">Fees for residence permits for third-country nationals</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <hr style="text-align: left!important; margin: 0.3em auto 0.3em 0!important; width: 80%;">
+    </li>
+    <li>
+      <a href="../40/start.html" title="EEA nationals, Swiss nationals and their third-country family members">EEA nationals, Swiss nationals and their third-country family members</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <a href="../41/start.html" title="Procedure for EEA nationals, Swiss nationals and their third-country family members">Procedure for EEA nationals, Swiss nationals and their third-country family members</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <a href="../42/start.html" title="Fees for EEA nationals, Swiss nationals and their third-country family members">Fees for EEA nationals, Swiss nationals and their third-country family members</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+    <li>
+      <hr style="text-align: left!important; margin: 0.3em auto 0.3em 0!important; width: 80%;">
+    </li>
+    <li>
+      <a href="../brexit/start.html" title="Residence permit „Article 50 TEU“">Brexit</a>
+      <i class="fa fa-long-arrow-right" aria-hidden="true">
+      </i>
+    </li>
+  </ul>
+</div>
+            </div>
+        </article>
+        <div class="trenner_artikel"></div>
+    </main>
+			<div class="container-fluid hintergrund clearfix platz d-print-none">
+				<div class="container">
+					<div class="row fivecolumns logoslider">
+						<div id="logos" class="row">
+							<div class="col-md-2 col-xs-5 slide_kachel">
+  <a href="http://www.polizei.gv.at/" tabindex="0" target="_blank" title="Polizei - zu den Landespolizeidirektionen - öffnet in einem neuen Fenster">
+    <img src="../../masterimages/logoslider/sb_lpds.jpg" alt="Polizei - zu den Landespolizeidirektionen - öffnet in einem neuen Fenster">
+  </a>
+</div>
+<div class="col-md-2 col-xs-5 slide_kachel">
+  <a href="https://sicherheitsverwaltung.gv.at/" tabindex="0" target="_blank" title="Entfalte deine innere Vielsfalt - zur Sicherheitverwaltung - öffnet in einem neuen Fenster">
+    <img src="../../masterimages/logoslider/348_2023_slider_website_170x151px_v20231011.jpg" alt="Entfalte deine innere Vielsfalt - zur Sicherheitverwaltung - öffnet in einem neuen Fenster">
+  </a>
+</div>
+<div class="col-md-2 col-xs-5 slide_kachel">
+  <a href="http://www.polizeikarriere.gv.at/" tabindex="0" target="_blank" title="Ich kanns werden - zur Polizeikarriere - öffnet in einem neuen Fenster">
+    <img src="../../masterimages/logoslider/300_2025_slider-grafik_170x151px_v20251020_01.jpg" alt="Ich kanns werden - zur Polizeikarriere - öffnet in einem neuen Fenster">
+  </a>
+</div>
+<div class="col-md-2 col-xs-5 slide_kachel">
+  <a href="http://www.bundeskriminalamt.at/" tabindex="0" target="_blank" title="Bundesministerium Inneres Bundeskriminalamt  - zum Bundeskriminalamt - öffnet in einem neuen Fenster">
+    <img src="../../masterimages/logoslider/sb_bk_v20250314.jpg" alt="Bundesministerium Inneres Bundeskriminalamt  - zum Bundeskriminalamt - öffnet in einem neuen Fenster">
+  </a>
+</div>
+<div class="col-md-2 col-xs-5 slide_kachel">
+  <a href="http://www.bfa.gv.at/" tabindex="0" target="_blank" title="Bundesamt für Fremdenwesen und Asyl - zum Bundesamt - öffnet in einem neuen Fenster">
+    <img src="../../masterimages/logoslider/sb_bfa_v20250314.jpg" alt="Bundesamt für Fremdenwesen und Asyl - zum Bundesamt - öffnet in einem neuen Fenster">
+  </a>
+</div>
+<div class="col-md-2 col-xs-5 slide_kachel">
+  <a href="http://www.bak.gv.at/" tabindex="0" target="_blank" title="Bundesministerium Inneres Bundesamt zur Korruptionsprävention und Korruptionsbekämpfung - zum Bundesamt - öffnet in einem neuen Fenster">
+    <img src="../../masterimages/logoslider/sb_bak_v20250314.jpg" alt="Bundesministerium Inneres Bundesamt zur Korruptionsprävention und Korruptionsbekämpfung - zum Bundesamt - öffnet in einem neuen Fenster">
+  </a>
+</div>
+<div class="col-md-2 col-xs-5 slide_kachel">
+  <a href="http://www.dsn.gv.at/" tabindex="0" target="_blank" title="Bundesministerium Inneres Direktion Staatsschutz und Nachrichtendienst - zur Direktion - öffnet in einem neuen Fenster">
+    <img src="../../masterimages/logoslider/sb_dsn_v20250314.jpg" alt="Bundesministerium Inneres Direktion Staatsschutz und Nachrichtendienst - zur Direktion - öffnet in einem neuen Fenster">
+  </a>
+</div>
+<div class="col-md-2 col-xs-5 slide_kachel">
+  <a href="../../magazin/magazin2e37.html?id=163" tabindex="0" title="Magazin Öffentliche Sicherheit (Alle Ausgaben seit 2010)">
+    <img src="../../masterimages/logoslider/sb_oesi_v20260506.jpg" alt="Magazin Öffentliche Sicherheit (Alle Ausgaben seit 2010)">
+  </a>
+</div>
+<div class="col-md-2 col-xs-5 slide_kachel">
+  <a href="../../104/wissenschaft_und_forschung/siak-journal/siak-journal-ausgaben/jahrgang_2026/start.html" tabindex="0" title="SIAK-Journal (aktuelle Ausgabe)">
+    <img src="../../masterimages/logoslider/100_2026_siak_slider_1_26_v20260401.jpg" alt="SIAK-Journal (aktuelle Ausgabe)">
+  </a>
+</div>
+<div class="col-md-2 col-xs-5 slide_kachel">
+  <a href="https://gemeinsamsicher.at/" tabindex="0" target="_blank" title="GEMEINSAM.SICHER mit unserer Polizei - zur Homepage - öffnet in einem neuen Fenster">
+    <img src="../../masterimages/logoslider/sb_gsimup.jpg" alt="GEMEINSAM.SICHER mit unserer Polizei - zur Homepage - öffnet in einem neuen Fenster">
+  </a>
+</div>
+<div class="col-md-2 col-xs-5 slide_kachel">
+  <a href="https://kompetenzzentrum-sicheres-oesterreich.at/" tabindex="0" target="_blank" title="Kompetenzzentrum Sicheres Österreich">
+    <img src="../../masterimages/logoslider/sb_ksoe_012022.png" alt="Kompetenzzentrum Sicheres Österreich">
+  </a>
+</div>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div class="container hidden-xs" >
+				<div class="row sitemap">
+				<a id="skipmap"></a>
+					<h2>SITEMAP</h2>
+					<div class="col-md-2 col-sm-6">
+  <h3 style="text-transform: uppercase !important;">Minister und Minist&shy;erium</h3>
+  <ul class="menue_rechts">
+    <li>
+      <a href="../../101/start.html" title="Bundesminister - Vita - Fotos">Bundes&shy;minister</a>
+    </li>
+    <li>
+      <a href="../../102/start.html" title="Aufgaben des Bundesministeriums für Inneres">Bundes&shy;ministerium</a>
+    </li>
+    <li>
+      <a href="../../113/start.html" title="Aufgaben, Organigramme, Leitungsfunktionen">Geschäfts&shy;einteilung</a>
+    </li>
+    <li>
+      <a href="../../104/start.html" title="Die Sicherheitsakademie im BMI">Aus- und Fortbildung im BMI</a>
+    </li>
+    <li>
+      <a href="../../107/start.html" title="Informationen zu den Förderungen">Förderungen</a>
+    </li>
+    <li>
+      <a href="../../105/start.html" title="Links zu den Jobangeboten, Veröffentlichungen gemäß Ausschreibungsgesetz">Jobs und Karriere</a>
+    </li>
+    <li>
+      <a href="https://bmi.vergabeportal.at/" target="_blank" title="Link zum Vergabeportal">Sachaus&shy;schreibungen</a>
+    </li>
+    <li>
+      <a href="../../110/start.html" title="Amtliche Verlautbarungen">Verlautbarungen</a>
+    </li>
+    <li>
+      <a href="../../114/start.html" title="Veröffentlichungspflichten für Studien, Gutachten und Umfragen">Veröffentlichungspflichten<br/>gem. B-VG</a>
+    </li>
+    <li>
+      <a href="../../115/start.html" title="Bekanntgabepflichten zu Medienkooperationen, Werbeaufträgen und Förderungen">Bekanntgabepflicht gem. MedKF-TG</a>
+    </li>
+  </ul>
+</div>
+<div class="col-md-2 col-sm-6">
+  <h3 style="text-transform: uppercase !important;">Polizei und Sicher&shy;heit</h3>
+  <ul class="menue_rechts">
+    <li>
+      <a href="../../201/start.html" title="Sicherheitsdialog zwischen Bürgerinnen und Bürgern, Gemeinden und Polizei">Gemein&shy;sam.Sicher</a>
+    </li>
+    <li>
+      <a href="../../202/start.html" title="Bundespolizei - Informationen und Bereiche">Bundes&shy;polizei</a>
+    </li>
+    <li>
+      <a href="../../fahndung/start.html" title="Fahndungen des Bundeskriminalamtes">Fahndungen</a>
+    </li>
+    <li>
+      <a href="../../202/fremdenpolizei_und_grenzkontrolle/start.html" title="Informationen zu Fremdenpolizei und Grenzkontrollwesen">Fremdenpolizei und Grenzkontrollwesen</a>
+    </li>
+    <li>
+      <a href="../../204/start.html" title="Zivilschutz, Bevölkerungsschutz und Katastrophenschutz in Österreich">Krisen- und Katastrophen&shy;management</a>
+    </li>
+    <li>
+      <a href="../../211/start.html" title="Sport in der Polizei">Polizeisport</a>
+    </li>
+    <li>
+      <a href="../../206/start.html" title="Allgemeines über das Bundeskriminalamt">Bundes&shy;kriminal&shy;amt</a>
+    </li>
+    <li>
+      <a href="../../205/start.html" title="Allgemeines über die Direktion Staatsschutz und Nachrichtendienst">Direktion Staats&shy;schutz und Nach&shy;richten&shy;dienst</a>
+    </li>
+    <li>
+      <a href="../../207/start.html" title="Direktion Spezialeinheiten / Einsatz&amp;shy;kommando Cobra (DSE/EKO Cobra)">Einsatz&shy;kommando Cobra / Direktion für Spezialeinheiten</a>
+    </li>
+    <li>
+      <a href="../../208/start.html" title="Allgemeines zu den Landespolizeidirektionen">Landes&shy;polizei&shy;direk&shy;tionen</a>
+    </li>
+  </ul>
+</div>
+<div class="col-md-2 col-sm-6">
+  <h3 style="text-transform: uppercase !important;">Asyl und Migra&shy;tion</h3>
+  <ul class="menue_rechts">
+    <li>
+      <a href="../../301/start.html" title="Asyl in Österreich">Asyl&shy;wesen</a>
+    </li>
+    <li>
+      <a href="../../312/start.html" title="Informationen zum Aufenthalt von Fremden in Österreich">Nieder&shy;lassung und Aufent&shy;halts&shy;recht</a>
+    </li>
+    <li>
+      <a href="../../303/start.html" title="Informationen zur Grundversorgung in Österreich">Grund&shy;versorgung</a>
+    </li>
+    <li>
+      <a href="../../305/start.html" title="Gesamtstaatliche Migrationsstrategie in Österreich">Migrations&shy;strategie und Gesell&shy;schaft</a>
+    </li>
+    <li>
+      <a href="../../304/start.html" title="Allgemeines zum Bundesamt für Fremdenwesen und Asyl">Bundes&shy;amt für Fremden&shy;wesen und Asyl</a>
+    </li>
+    <li>
+      <a href="../../107/eu_foerderungen/start.html" title="Förderprogramme der EU">EU-Förde&shy;rungen</a>
+    </li>
+    <li>
+      <a href="../../301/foerderungen/start.html" title="Projektförderungen im Themenbereich &quot;Asyl, Migration und Rückkehr“">Förderungen "Asyl, Migration und Rückkehr"</a>
+    </li>
+  </ul>
+</div>
+<div class="col-md-2 col-sm-6">
+  <h3 style="text-transform: uppercase !important;">Ge&shy;sell&shy;schaft und Recht</h3>
+  <ul class="menue_rechts">
+    <li>
+      <a href="../../401/start.html" title="Entwürfe für Gesetzte und Verordnungen zur Begutachtung">Begut&shy;achtungen</a>
+    </li>
+    <li>
+      <a href="../../402/start.html" title="Datenschutz im BMI">Daten&shy;schutz</a>
+    </li>
+    <li>
+      <a href="../../417/start.html" title="Informationen zur Europäischen Bürgerinitiative">Europäische Bürger&shy;initiative</a>
+    </li>
+    <li>
+      <a href="../../403/start.html" title="Vorstellung der Abteilung 'Historische Angelegenheiten'">Historische Angelegen&shy;heiten</a>
+    </li>
+    <li>
+      <a href="../../404/start.html" title="KZ-Gedenkstätte Mauthausen Memorial">Mauthausen Memorial</a>
+    </li>
+    <li>
+      <a href="../../405/start.html" title="Parteienregister">Politische Parteien</a>
+    </li>
+    <li>
+      <a href="../../407/start.html" title="Der Rechtsschutzbeauftragte beim Bundesminister für Inneres">Rechts&shy;schutz&shy;beauftragter</a>
+    </li>
+    <li>
+      <a href="../../408/start.html" title="Rechtsstaatlichkeit und Menschenrechte">Rechts&shy;staat und Menschen&shy;rechte</a>
+    </li>
+    <li>
+      <a href="../../406/start.html" title="Informationen zum Erwerb der Staatsbürgerschaft">Staats&shy;bürger&shy;schaft</a>
+    </li>
+    <li>
+      <a href="../../409/start.html" title="Verzeichnis der Stiftungen und Fonds">Stiftungs- und Fonds&shy;register</a>
+    </li>
+    <li>
+      <a href="../../418/start.html" title="EBM-Beirat">Unab&shy;hängiger Beirat Ermittlungs- und Beschwerde&shy;stelle Misshandlungs&shy;vorwürfe</a>
+    </li>
+    <li>
+      <a href="../../410/start.html" title="Volksabstimmungen in Österreich">Volks&shy;abstimmungen</a>
+    </li>
+    <li>
+      <a href="../../416/start.html" title="Volksbefragungen in Österreich">Volks&shy;befragung</a>
+    </li>
+    <li>
+      <a href="../../411/start.html" title="Volksbegehren in Österreich">Volks&shy;begehren</a>
+    </li>
+    <li>
+      <a href="../../412/start.html" title="Nationalrats-, Bundespräsidenten- und Europawahlen">Wahlen</a>
+    </li>
+    <li>
+      <a href="../../413/start.html" title="Zentrale Melderegister (ZMR)">Zentrales Melde&shy;register</a>
+    </li>
+    <li>
+      <a href="../../414/start.html" title="Zentrales Personenstandsregister (ZPR)">Zentrales Personen&shy;stands&shy;register</a>
+    </li>
+    <li>
+      <a href="../../415/start.html" title="Allgemeines zum Bundesamt zur Korruptionsprävention und Korruptionsbekämpfung">Bundes&shy;amt zur Korrup&shy;tions&shy;prävention und Korrup&shy;tions&shy;bekämpfung</a>
+    </li>
+  </ul>
+</div>
+<div class="col-md-2 col-sm-6">
+  <h3 style="text-transform: uppercase !important;">Sicher&shy;heits&shy;politik und Strategie</h3>
+  <ul class="menue_rechts">
+    <li>
+      <a href="../../501/start.html" title="Strategien des BMI">BMI Strategien</a>
+    </li>
+    <li>
+      <a href="../../502/start.html" title="Österreichische Sicherheitsstrategie. Sicherheit in einer neuen Dekade – Sicherheit gestalten">Öster&shy;reichische Sicherheits&shy;strategie</a>
+    </li>
+    <li>
+      <a href="../../503/start.html" title="Strategien der Europäischen Union">Europäische Strategien</a>
+    </li>
+    <li>
+      <a href="../../510/start.html" title="Nationale Anti-Korruptionsstrategie und Nationaler Anti-Korruptionsplan">Nationale <br/>Anti-Korruptions&shy;strategie</a>
+    </li>
+    <li>
+      <a href="../../511/start.html" title="Jugendstrategie, Umsetzung durch das Bundesministerium für Inneres">Öster&shy;reichische Jugend&shy;strategie</a>
+    </li>
+    <li>
+      <a href="../../509/start.html" title="Das BMI-Engagement in der Europäischen Union">EU-Engagement des BMI</a>
+    </li>
+    <li>
+      <a href="../../504/start.html" title="Cybersicherheit">Cybersicherheit</a>
+    </li>
+    <li>
+      <a href="../../505/start.html" title="Österreichisches Programm zum Schutz kritischer Infrastrukturen (APCIP)">Schutz kritischer Infra&shy;struktur</a>
+    </li>
+    <li>
+      <a href="../../506/start.html" title="Zivil-militärische Zusammenarbeit (ZMZ)">Zivil - militärische Zusammen&shy;arbeit</a>
+    </li>
+    <li>
+      <a href="../../508/start.html" title="Bericht über die innere Sicherheit">Sicherheits&shy;bericht</a>
+    </li>
+  </ul>
+</div>
+<div class="col-md-2 col-sm-6">
+  <h3 style="text-transform: uppercase !important;">Bürger&shy;service</h3>
+  <ul class="menue_rechts">
+    <li>
+      <a href="https://citizen.bmi.gv.at/at.gv.bmi.fnsbazweb-p/baz/public/BuergeranzeigeInfo" target="_blank" title="externer Link zur Online Diebstahlsanzeige">Online Diebstahls&shy;anzeige</a>
+    </li>
+    <li>
+      <a href="https://citizen.bmi.gv.at/at.gv.bmi.fnsbfaweb-p/bfa/public/SISAntrag" target="_blank" title="Externer Link zum Online-Formular Schengener Informationssystem">Online-Formular Schengener Informationssystem (SIS)</a>
+    </li>
+    <li>
+      <a href="../../611/start.html" title="Informationen zur Barrierefreiheit">Barriere&shy;freiheit</a>
+    </li>
+    <li>
+      <a href="../../601/start.html" title="Bürgerservice inklusive Hotline">Bürger&shy;telefon</a>
+    </li>
+    <li>
+      <a href="../../602/start.html" title="Call Center im Einsatz- und Koordinationscenter des BMI">Call&shy;center</a>
+    </li>
+    <li>
+      <a href="../../613/start.html" title="e-Learning Demenz.Aktivgemeinde">Demenz.Aktiv&shy;gemeinde</a>
+    </li>
+    <li>
+      <a href="../../615/start.html" title="ID Austria (elektronische Identität)">ID Austria Behörden</a>
+    </li>
+    <li>
+      <a href="../../603/start.html" title="Kriminalprävention des BK">Kriminal&shy;prävention</a>
+    </li>
+    <li>
+      <a href="../../604/start.html" title="Meldewesen in Österreich">Melde&shy;an&shy;ge&shy;le&shy;gen&shy;heiten</a>
+    </li>
+    <li>
+      <a href="../../605/start.html" title="Meldestellen des BK, BAK und DSN">Meld&shy;estellen</a>
+    </li>
+    <li>
+      <a href="../../magazin/magazin.html" title="Öffentliche Sicherheit - Das Magazin des Innenministeriums">Magazin "Öffentliche Sicherheit"</a>
+    </li>
+    <li>
+      <a href="../../104/wissenschaft_und_forschung/siak-journal/start.html" title="Zeitschrift für Polizeiwissenschaft und polizeiliche Praxis">SIAK-Journal</a>
+    </li>
+    <li>
+      <a href="../../607/start.html" title="Informationen zu „Flugsicherheit“ und „Reisepass“">Sicherheit bei Reisen (Reise&shy;pass / Personal&shy;ausweis)</a>
+    </li>
+    <li>
+      <a href="../../614/start.html" title="Leben in der Krise ohne Aggression und Gewalt">Sicher zu Hause</a>
+    </li>
+    <li>
+      <a href="../../termin.html" title="Terminvorschau">Termine</a>
+    </li>
+    <li>
+      <a href="../../609/start.html" title="Vereinswesen">Vereine</a>
+    </li>
+  </ul>
+</div>
+				</div>
+			</div>
+			<div class="clearfix"></div>
+			<a id="skipfooter"></a>
+			<footer class="d-print-none" >
+				<div class="container-fluid hintergrund_rot">
+					<div class="row">
+						<div class="col-lg-1"></div>
+						<div class="container impressum row col-lg-11">
+							<div class="col-lg-5" style="padding-top:5px !important;text-align:center">
+                    <p>&copy; BUNDESMINISTERIUM FÜR INNERES</p>
+                </div>
+                <div class="col-lg-7"  style="padding-top:5px !important;text-align:center">
+                    <ul class="aussen">
+			<li><a href="../../rss_feed/start.html">RSS</a> |</li> 
+                        <li><a href="../../kontakt/start.html">Kontakt</a> |</li>
+                        <li><a href="../../impressum/start.html">IMPRESSUM</a> |</li>
+			<li><a href="../../402/start.html">Datenschutz</a> |</li>
+			<li><a href="../../611/erklaerung/start.html">Barrierefreiheitserklärung</a></li>
+                    </ul>
+                </div>
+						</div>
+					</div>
+				</div>
+			</footer>
+    </form>
+    <!-- Nach oben Button -->
+	<!-- WCAG-Change 26.08.2024, 2.9.2024, 1.10.2024-->
+    <div title="Zurück zum Seitenanfang" class="move-up hidden-xs" role="presentation">
+        <button aria-label="Zurück zum Seitenanfang" title="Nach oben" type="submit"><i title="Zurück zum Seitenanfang" class="fa fa-chevron-circle-up"></i></button>
+    </div>
+	<!-- slider -->
+    <script>
+        $(document).ready(function () {
+            $('#News').bxSlider({
+                mode: 'fade',
+                captions: true,
+                auto: true,
+                adaptiveHeight: false,
+                responsive: true
+            });
+        });
+         $(document).ready(function () {
+            $('#Standalone').bxSlider({
+                mode: 'fade',
+                captions: true,
+                auto: false,
+                adaptiveHeight: false,
+                responsive: true,
+                pager:false
+            });
+        });
+    </script>
+    <!-- logoslider -->
+    <script>
+        $(document).ready(function () {
+            $('#logos').bxSlider({
+                slideWidth: 220,
+                minSlides: 5,
+                maxSlides: 5,
+                moveSlides: 1,
+                slideMargin: 0,
+                autoControls: true,
+				controls: true,
+				stopAutoOnClick: true,
+				stopAuto: false,
+				captions: true,
+				keyboardNav: false,
+                adaptiveHeight: false,
+                fluid: true,
+                auto: true,
+                speed: 1500,
+                captions: false,
+            });
+			document.addEventListener("keydown", (e) => {  
+				if(e.key === "Tab" && !$(".bx-start").is(":focus") && !$(".bx-stop").is(":focus")){
+					var x = $('.bx-stop');
+					x.click();
+				}
+			});
+			document.addEventListener("keydown", (e) => {  
+				if(e.key === "Enter" && $(".bx-start").is(":focus")){
+					var x = $('.bx-start');
+					x.click(); 
+				}
+				if(e.key === "Enter" && $(".bx-stop").is(":focus")){
+					var x = $('.bx-stop');
+					x.click(); 
+				}
+			});
+			$('#logos').on('click', function(){
+				if($('.bx-start').hasClass('active')){
+					$('.bx-start.active').removeClass('active');
+					$('.bx-stop').addClass('active');
+					slider.stopAuto();
+					console.log( "Stop" );
+				}
+				else {
+					slider.startAuto();
+					console.log( "Start" );
+				}
+			});
+		});
+    </script>
+    <!-- Nach oben Button -->
+    <script>
+        jQuery(document).ready(function ($) {
+            $(function () {
+                $(window).scroll(function () {
+                    if ($(this).scrollTop() > 100) {
+                        $('.move-up').fadeIn();
+                    } else {
+                        $('.move-up').fadeOut();
+                    }
+                });
+                $('.move-up button').click(function () {
+                    $('body,html').animate({
+                        scrollTop: 0
+                    }, 800);
+                    return false;
+                });
+            });
+        });
+    </script>
+    <!-- Lightbox -->
+    <script>
+         $(document).ready(function () {
+             var img;
+             img = $("#lightbox img.lb-image");
+             if (img) {
+                 img.attr('alt', '');
+             }
+         });
+    </script>
+	<script>
+			let tabFocus;
+			let KEYCODE_TAB  = 9;
+			let KEYCODE_ENTER  = 13;
+			/* Eventlistener für lightbox */
+			document.addEventListener('keydown', (event) => {
+				let tag = event.target;
+				if(event.keyCode === KEYCODE_ENTER) {				
+					if(tag.matches("a") && tag.matches('[data-toggle="lightbox"]')){
+						tabFocus = tag;
+					}
+				}
+				if(event.keyCode === KEYCODE_TAB) {
+					if(!event.shiftKey && tag.matches(".btn-close") && tag.matches(".lbox") && document.querySelectorAll(".carousel-control-next").length > 0) {
+						document.getElementsByClassName("carousel-inner")[0].focus();
+					}
+					if(!event.shiftKey && tag.matches(".carousel-control-next")) {
+						document.getElementsByClassName("modal lightbox")[0].focus();
+					}
+					if(!event.shiftKey && tag.matches(".btn-close") && tag.matches(".lbox") && document.querySelectorAll(".carousel-control-next").length <= 0){ 
+							document.getElementsByClassName("modal lightbox")[0].focus();
+					}
+					if(event.shiftKey && tag.matches(".modal") && tag.matches(".lightbox")){
+							document.getElementsByClassName("btn-close")[0].focus();
+					}
+				}
+			});
+			document.addEventListener('click', (event) => {
+				let tag = event.target;						
+				if(tag.parentElement.matches("a") && tag.parentElement.matches('[data-toggle="lightbox"]')){
+					tabFocus = tag.parentElement;
+				}
+				if(tag.classList.contains("btn-close")){
+					tabFocus.focus();
+				}
+			});
+			document.addEventListener('keyup', (event) => {
+				let tag = event.target;
+				if(tag.classList.contains("btn-close") && event.keyCode === KEYCODE_ENTER){
+					tabFocus.focus();
+				}					
+			});	
+	</script>
+	<!-- skiplinks-->
+	<script src="../../scripts/js/gen-skiplinks.js"></script>
+	<!--<script src="../../scripts/js/skiplinks.js"></script>-->
+	<script src="../../scripts/js/bs5-lightbox.js"></script>
+	<script src="../../scripts/js/counter.js"></script>
+	<script src="../../scripts/js/visasummary.js"></script>
+</body>
+</html>

--- a/sources/AT_RESIDENCE_BMI_2026-06-16.html.meta.json
+++ b/sources/AT_RESIDENCE_BMI_2026-06-16.html.meta.json
@@ -1,0 +1,7 @@
+{
+  "source_id": "AT_RESIDENCE_BMI_2026",
+  "url": "https://www.bmi.gv.at/312_en/04/start.html",
+  "retrieved_at": "2026-06-16T00:00:00Z",
+  "sha256": "bf81b905be6263443f34825a4f6a748ce062689b8f19a97b54a1924e2c17f9a8",
+  "local_path": "sources/AT_RESIDENCE_BMI_2026-06-16.html"
+}

--- a/tools/build_content_hubs.py
+++ b/tools/build_content_hubs.py
@@ -629,6 +629,20 @@ VISA_FAQS = {
             "answer": "The published criteria state no coverage amount, so the engine encodes none and models that insurance is mandatory, must be valid in Georgia, and must cover the visa validity period.",
         },
     ],
+    "AT_RESIDENCE_BMI_2026": [
+        {
+            "question": "What insurance does an Austrian residence permit require?",
+            "answer": "The Federal Ministry of the Interior states third-country nationals must have health insurance that covers all risks in Austria, and that a travel health insurance is not sufficient.",
+        },
+        {
+            "question": "Why do SafetyWing and World Nomads show RED?",
+            "answer": "The source states that a travel health insurance is not sufficient. Travel-medical products are therefore RED, while a comprehensive health policy that documents coverage in Austria (such as Genki Native) is GREEN.",
+        },
+        {
+            "question": "Does this apply to every residence permit?",
+            "answer": "The health-insurance condition is a general granting requirement, but the source notes several permit types are exempt from demonstrating it (such as the Red-White-Red card, EU Blue Card, researchers, students and ICT workers). Confirm your specific permit type.",
+        },
+    ],
 }
 
 RELATED_POSTS = {
@@ -844,6 +858,11 @@ RELATED_POSTS = {
     "GE_LONGVISA_GEOCONSUL_2026": [
         ("/posts/georgia-long-term-visa-insurance/", "Georgia long-term visa insurance requirements"),
         ("/posts/digital-nomad-insurance-asia/", "Digital nomad insurance in Asia"),
+        ("/guides/how-to-read-results/", "How to read compliance results"),
+    ],
+    "AT_RESIDENCE_BMI_2026": [
+        ("/posts/austria-residence-insurance/", "Austria residence permit insurance requirements"),
+        ("/posts/digital-nomad-insurance-europe/", "Digital nomad insurance in Europe"),
         ("/guides/how-to-read-results/", "How to read compliance results"),
     ],
 }

--- a/tools/editorial_targets.json
+++ b/tools/editorial_targets.json
@@ -402,5 +402,13 @@
   "content/posts/georgia-long-term-visa-insurance.md": [
     450,
     1200
+  ],
+  "content/visas/austria/residence-permit-third-country-nationals/residence-permit-granting-requirements-federal-ministry-of-the-interior/index.md": [
+    900,
+    1400
+  ],
+  "content/posts/austria-residence-insurance.md": [
+    450,
+    1250
   ]
 }


### PR DESCRIPTION
## Summary
- New route **AT_RESIDENCE_BMI_2026** — Austria Residence Permit (third-country nationals)
- Primary source (byte-exact, sha256-validated): Federal Ministry of the Interior granting-requirements page (bmi.gv.at)
- Rules encoded verbatim only: `insurance.mandatory`, `insurance.authorized_in_country`, `insurance.comprehensive` ("health insurance that covers all risks in Austria"), `insurance.travel_insurance_accepted=false` ("The presentation of a travel health insurance is not sufficient")
- Disclosed but NOT modeled: several permit types are exempt (Red-White-Red card, EU Blue Card, researchers, students, ICT, cross-border)
- Reuses the generic `AuthorizedInCountryRule`; Genki Native gains `jurisdiction_facts.AT`

## Mapping outcomes
Genki Native **GREEN**; SafetyWing / World Nomads **RED** (travel insurance not accepted); Genki Traveler / Spanish products **UNKNOWN**. A differentiated route demonstrating the travel-not-accepted rule. No existing mapping changed.

## Content
- Hub: /visas/austria/residence-permit-third-country-nationals/residence-permit-granting-requirements-federal-ministry-of-the-interior/
- Post: /posts/austria-residence-insurance/ (dated 2026-06-14, past in UTC)
- Affiliate: Genki Native paid link, after results only

## Gates
All gates + ui_compliance_tests.ps1 + mapping_engine_tests.ps1 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)