### PR TITLE
feat(route): add Slovakia national (long-stay) visa route (evidence-based)

### DIFF
--- a/content/posts/slovakia-national-visa-insurance.md
+++ b/content/posts/slovakia-national-visa-insurance.md
@@ -1,0 +1,102 @@
+---
+title: "Slovakia national visa insurance requirements (evidence-based)"
+date: 2026-06-14
+description: "Evidence-based summary of the health insurance requirement for a Slovak national (long-stay) visa: insurance covering medical expenses in Slovakia throughout the stay, per the Ministry of Foreign and European Affairs."
+tags: ["slovakia", "national-visa", "long-stay", "insurance", "compliance"]
+faq:
+  - question: "What insurance does a Slovak national (long-stay) visa require?"
+    answer: "The Ministry of Foreign and European Affairs requires proof of health insurance upon entry and throughout the stay in Slovakia; commercial insurance taken out abroad that covers medical expenses in the Slovak Republic is accepted."
+  - question: "Why is only Genki Native GREEN for this route?"
+    answer: "The insurance must cover medical expenses in the Slovak Republic. Genki Native documents global coverage that includes Slovakia; the other products do not document Slovakia coverage, so the engine records UNKNOWN rather than assuming a foreign policy qualifies."
+  - question: "Is there a minimum coverage amount?"
+    answer: "The documents page states no coverage amount, so the engine encodes none and models that insurance is mandatory, must cover Slovakia, and must cover the whole stay."
+---
+
+## Short answer
+
+A Slovak national (long-stay) visa requires proof that the applicant will have health insurance upon entry and throughout their stay in the Slovak Republic; commercial health insurance taken out abroad that covers medical expenses in the Slovak Republic is among the accepted options (Source: `SK_NATIONALVISA_MZV_2026`, Ministry of Foreign and European Affairs; verified 2026-06-16). The documents page states no coverage amount, so the engine models three rules: insurance is mandatory, it must cover Slovakia, and it must cover the whole stay.
+
+## Key findings at a glance
+
+| Item | Value |
+|---|---|
+| Route | Slovakia National (Long-Stay) Visa |
+| Authority | Ministry of Foreign and European Affairs of the Slovak Republic (MZV) |
+| Evidence verified | 2026-06-16 |
+| Snapshot | 2026-06-13 |
+| Modeled rules | Insurance mandatory; covers medical expenses in Slovakia; covers the whole stay |
+
+## What the authority requires
+
+- Proof of health insurance upon entry and throughout the stay in Slovakia is a basic document. (Source: `SK_NATIONALVISA_MZV_2026`; verified 2026-06-16)
+- Commercial health insurance taken out abroad that covers medical expenses in the Slovak Republic is accepted. (Source: `SK_NATIONALVISA_MZV_2026`; verified 2026-06-16)
+- The documents page states no coverage amount, so that stays UNKNOWN.
+
+Normalized requirements table:
+
+| Requirement | Source URL | Locator | Verified date |
+|---|---|---|---|
+| Insurance is mandatory | https://www.mzv.sk/en/web/en/visa-and-services/national-visa | Basic documents, health insurance | 2026-06-16 |
+| Covers medical expenses in Slovakia | https://www.mzv.sk/en/web/en/visa-and-services/national-visa | Basic documents, health insurance | 2026-06-16 |
+| Covers the whole stay | https://www.mzv.sk/en/web/en/visa-and-services/national-visa | Basic documents, health insurance | 2026-06-16 |
+
+## Verified requirements (PASS/FAIL/UNKNOWN)
+
+| Requirement | Status | Evidence |
+|---|---|---|
+| Insurance is mandatory | PASS | MZV basic documents |
+| Covers medical expenses in Slovakia | PASS only for products documenting Slovakia coverage; UNKNOWN otherwise | "covers medical expenses in the Slovak Republic" |
+| Covers the whole stay | PASS for full-period policies; YELLOW for monthly subscriptions | "upon entry and throughout their stay in the Slovak Republic" |
+
+## How we evaluate
+
+The checker compares each modeled requirement against product evidence. Three rules are encoded from the MZV documents page: insurance is mandatory, it must cover medical expenses in Slovakia, and it must cover the whole stay. Commercial insurance taken out abroad is explicitly accepted as long as it covers Slovak medical expenses, so a product is credited only when its own documentation states Slovakia coverage; products silent about Slovakia stay UNKNOWN rather than GREEN. No coverage amount is encoded because the page states none, following the UNKNOWN > Wrong principle. See /methodology/ for the full logic.
+
+## Proof package checklist
+
+- Health insurance documented to cover medical expenses in the Slovak Republic, for entry and the whole stay.
+- A certificate showing the policy holder, policy number and coverage dates.
+- The remaining national-visa basic documents (application form, travel document, purpose of residence).
+
+## FAQ
+
+**Q: What is required?**
+**A:** Health insurance covering Slovak medical expenses throughout the stay; foreign commercial insurance is accepted if it covers Slovakia (Source: `SK_NATIONALVISA_MZV_2026`; verified 2026-06-16).
+
+**Q: Why is only Genki Native GREEN?**
+**A:** It documents global coverage including Slovakia; the others do not state Slovakia coverage, so they are UNKNOWN.
+
+**Q: Is there a minimum amount?**
+**A:** The page states none, so the engine encodes no figure.
+
+## Check in the engine
+
+Use [the compliance checker](/ui/) with the current snapshot for this route:
+
+{{< checker_cta visa="SK_NATIONALVISA_MZV_2026" product="GENKI_NATIVE_2026" snapshot="2026-06-13" >}}
+
+## Related reading
+
+- [Slovakia national visa requirements (route page)](/visas/slovakia/national-long-stay-visa/national-visa-documents-ministry-of-foreign-and-european-affairs/)
+- [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## Where to find compliant insurance for a Slovak national visa
+
+The requirement is health insurance covering Slovak medical expenses for the whole stay, and foreign commercial insurance is accepted when it covers Slovakia. In the current snapshot, Genki Native shows GREEN: it documents global coverage that includes Slovakia. The travel-medical and Spanish products show UNKNOWN because their documents do not state coverage in the Slovak Republic.
+
+- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+
+> Use the compliance checker to confirm the current GREEN products for this route before you buy.
+
+## Disclaimer + Affiliate disclosure
+
+Not legal advice. Compliance results are evidence-based snapshots.
+
+If an affiliate link is present, it appears only after results and does not change the compliance outcome. The Genki link above is a paid affiliate link.
+
+Last updated: 2026-06-14
+
+## Evidence log
+
+- Source: SK_NATIONALVISA_MZV_2026

--- a/content/visas/slovakia/national-long-stay-visa/_index.md
+++ b/content/visas/slovakia/national-long-stay-visa/_index.md
@@ -1,0 +1,42 @@
+---
+title: "Slovakia National (Long-Stay) Visa"
+visa_group: "slovakia-national-long-stay-visa"
+description: "Insurance requirements for Slovakia National (Long-Stay) Visa - evidence-based compliance checker"
+---
+
+## Slovakia National (Long-Stay) Visa Requirements
+
+All requirements below are derived from official sources. Missing evidence means UNKNOWN.
+
+## Routes
+
+| Authority | Route | Last Verified | Details |
+| --- | --- | --- | --- |
+| Ministry of Foreign and European Affairs of the Slovak Republic (MZV) | National visa documents (Ministry of Foreign and European Affairs) | 2026-06-16 | [View requirements](/visas/slovakia/national-long-stay-visa/national-visa-documents-ministry-of-foreign-and-european-affairs/) |
+
+## What the authority requires
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+## How we evaluate
+
+We compare these official requirements against insurance product specifications using our automated rule engine. Each requirement is matched to a product fact with evidence.
+
+## Check in the engine
+
+Try the compliance checker: [Open Checker](/ui/?visa=SK_NATIONALVISA_MZV_2026&snapshot=2026-06-13)
+
+## Disclaimer
+
+This is not legal advice. VisaFact provides evidence-based compliance checking only. Final visa decisions are made by government authorities. A GREEN result does not ensure visa approval.
+
+## Affiliate disclosure
+
+If affiliate links appear, they are shown only after compliance results and do not influence the compliance evaluation in any way.
+
+## Evidence log
+
+See the requirements table above. All requirements are extracted directly from official sources with evidence excerpts.
+
+
+{{< checker_cta visa="SK_NATIONALVISA_MZV_2026" snapshot="2026-06-13" >}}

--- a/content/visas/slovakia/national-long-stay-visa/national-visa-documents-ministry-of-foreign-and-european-affairs/index.md
+++ b/content/visas/slovakia/national-long-stay-visa/national-visa-documents-ministry-of-foreign-and-european-affairs/index.md
@@ -1,0 +1,105 @@
+---
+title: "Slovakia National (Long-Stay) Visa - National visa documents (Ministry of Foreign and European Affairs)"
+visa_id: "SK_NATIONALVISA_MZV_2026"
+last_verified: "2026-06-16"
+source_ids: ["SK_NATIONALVISA_MZV_2026"]
+description: "Official insurance requirements for Slovakia National (Long-Stay) Visa via National visa documents (Ministry of Foreign and European Affairs)"
+faq:
+  - question: "What insurance does a Slovak national (long-stay) visa require?"
+    answer: "The Ministry of Foreign and European Affairs requires proof of health insurance upon entry and throughout the stay in Slovakia; commercial insurance taken out abroad that covers medical expenses in the Slovak Republic is accepted."
+  - question: "Why is only Genki Native GREEN for this route?"
+    answer: "The insurance must cover medical expenses in the Slovak Republic. Genki Native documents global coverage that includes Slovakia; the other products do not document Slovakia coverage, so the engine records UNKNOWN rather than assuming a foreign policy qualifies."
+  - question: "Is there a minimum coverage amount?"
+    answer: "The documents page states no coverage amount, so the engine encodes none and models that insurance is mandatory, must cover Slovakia, and must cover the whole stay."
+---
+
+## Slovakia National (Long-Stay) Visa
+
+**Route:** National visa documents (Ministry of Foreign and European Affairs)  
+**Authority:** Ministry of Foreign and European Affairs of the Slovak Republic (MZV)  
+**Last Verified:** 2026-06-16
+
+## Requirements
+
+| Requirement | Operator | Value | Evidence |
+| --- | --- | --- | --- |
+| `insurance.mandatory` | `==` | Yes | *Which documents should be submitted, basic documents*: "proof that the applicant will have health insurance upon entry and throughout th..." ([source](/sources/SK_NATIONALVISA_MZV_2026-06-16.html)) |
+| `insurance.authorized_in_country` | `==` | Yes | *Which documents should be submitted, basic documents*: "commercial health insurance taken out abroad that covers medical expenses in the..." ([source](/sources/SK_NATIONALVISA_MZV_2026-06-16.html)) |
+| `insurance.must_cover_full_period` | `==` | Yes | *Which documents should be submitted, basic documents*: "health insurance upon entry and throughout their stay in the Slovak Republic..." ([source](/sources/SK_NATIONALVISA_MZV_2026-06-16.html)) |
+
+## Source Documents
+
+- **SK_NATIONALVISA_MZV_2026**: [Local copy](/sources/SK_NATIONALVISA_MZV_2026-06-16.html) | [Original](https://www.mzv.sk/en/web/en/visa-and-services/national-visa) | Retrieved: 2026-06-16
+
+## Related reading
+
+- [Slovakia national visa insurance requirements](/posts/slovakia-national-visa-insurance/)
+- [Digital nomad insurance in Europe](/posts/digital-nomad-insurance-europe/)
+- [How to read compliance results](/guides/how-to-read-results/)
+
+## What the authority requires
+
+The points below are taken directly from the official source for the Slovakia National (Long-Stay) Visa (National visa documents (Ministry of Foreign and European Affairs)) route. Each one is recorded with a source identifier and a locator so it can be traced back to the original document. Where the source is silent on a point, the engine records UNKNOWN instead of inferring an answer.
+
+- The authority requires that insurance is mandatory.
+- The authority requires that authorized in country.
+- The authority requires that the policy covers the full authorized stay.
+
+## How we evaluate
+
+Every requirement is compared against the documented specification of each insurance product using an automated rule engine. A product is marked GREEN for a requirement only when product evidence explicitly satisfies it; a conflict produces RED; and absent evidence produces UNKNOWN rather than a guess. The route status is the combination of its per-requirement outcomes.
+
+- Rule `insurance.mandatory == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+- Rule `insurance.authorized_in_country == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+- Rule `insurance.must_cover_full_period == Yes` GREEN on a match, RED on a conflict, UNKNOWN if unproven.
+
+## How each compliance status is decided for this route
+
+GREEN means every recorded requirement is satisfied by product evidence. RED means at least one requirement is contradicted by the product evidence. YELLOW means the evidence is partial: some requirements are met while others lack full proof. UNKNOWN means a requirement exists but the product evidence does not address it, so no claim is made. NOT_REQUIRED means the authority does not impose an insurance requirement for the route, which is itself an evidence-based finding drawn from the official document. A GREEN result reflects the evidence on the snapshot date and is not an assurance of a visa outcome, which always rests with the issuing authority.
+
+## Reading the evidence and snapshots
+
+Each requirement above links to a primary source through a source identifier and a locator (for example a page number, article, or section). The underlying documents are listed under Source Documents and are stored alongside this dataset so the wording can be checked directly. Results are tied to a dated snapshot (`2026-06-13`): a deep link to a past snapshot returns the same verdict even if the authority later changes its rules, which keeps every decision reproducible and auditable.
+
+## Proof package checklist
+
+Before applying for this route, prepare the following so the policy can be checked against each requirement:
+
+- A policy certificate that states the coverage limits, any deductible or co-payment, and the covered period.
+- Written confirmation of the insurer's status where the route requires authorization in a specific country.
+- Documentation that the coverage spans the full authorized stay rather than a partial term.
+- The official source wording for the route, so each clause can be matched to the requirements above.
+
+## Common questions
+
+**What insurance does a Slovak national (long-stay) visa require?**  
+The Ministry of Foreign and European Affairs requires proof of health insurance upon entry and throughout the stay in Slovakia; commercial insurance taken out abroad that covers medical expenses in the Slovak Republic is accepted.
+
+**Why is only Genki Native GREEN for this route?**  
+The insurance must cover medical expenses in the Slovak Republic. Genki Native documents global coverage that includes Slovakia; the other products do not document Slovakia coverage, so the engine records UNKNOWN rather than assuming a foreign policy qualifies.
+
+**Is there a minimum coverage amount?**  
+The documents page states no coverage amount, so the engine encodes none and models that insurance is mandatory, must cover Slovakia, and must cover the whole stay.
+
+## Check in the engine
+
+Run a specific product against this route in the compliance checker: [Open Checker](/ui/?visa=SK_NATIONALVISA_MZV_2026&snapshot=2026-06-13). The checker shows the per-requirement outcome and the evidence behind each one.
+
+## Disclaimer
+
+This page is not legal advice. VisaFact provides evidence-based compliance checking only, and final visa decisions are made by government authorities. A GREEN result reflects documented evidence on the snapshot date; it does not ensure that a visa application will succeed. Always confirm the current requirements with the issuing authority before submitting an application.
+
+## Affiliate disclosure
+
+If affiliate links appear on related pages, they are shown only after the compliance result and never change the evaluation, which is generated independently from the official evidence.
+
+## Evidence log
+
+Each entry pairs a requirement with the source identifier and locator it was drawn from:
+
+- `insurance.mandatory` <- SK_NATIONALVISA_MZV_2026 (Which documents should be submitted, basic documents): "proof that the applicant will have health insurance upon entry and throughout their stay in the Slov"
+- `insurance.authorized_in_country` <- SK_NATIONALVISA_MZV_2026 (Which documents should be submitted, basic documents): "commercial health insurance taken out abroad that covers medical expenses in the Slovak Republic"
+- `insurance.must_cover_full_period` <- SK_NATIONALVISA_MZV_2026 (Which documents should be submitted, basic documents): "health insurance upon entry and throughout their stay in the Slovak Republic"
+
+
+{{< checker_cta visa="SK_NATIONALVISA_MZV_2026" snapshot="2026-06-13" >}}

--- a/data/mappings/SK_NATIONALVISA_MZV_2026__ASISA_HEALTH_RESIDENTS_2026.json
+++ b/data/mappings/SK_NATIONALVISA_MZV_2026__ASISA_HEALTH_RESIDENTS_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "SK_NATIONALVISA_MZV_2026",
+  "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.SK.authorized"
+  ]
+}

--- a/data/mappings/SK_NATIONALVISA_MZV_2026__DKV_VISADO_2026.json
+++ b/data/mappings/SK_NATIONALVISA_MZV_2026__DKV_VISADO_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "SK_NATIONALVISA_MZV_2026",
+  "product_id": "DKV_VISADO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.SK.authorized"
+  ]
+}

--- a/data/mappings/SK_NATIONALVISA_MZV_2026__GENERIC_EXPAT_COMPLETE_2026.json
+++ b/data/mappings/SK_NATIONALVISA_MZV_2026__GENERIC_EXPAT_COMPLETE_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "SK_NATIONALVISA_MZV_2026",
+  "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.SK.authorized"
+  ]
+}

--- a/data/mappings/SK_NATIONALVISA_MZV_2026__GENKI_NATIVE_2026.json
+++ b/data/mappings/SK_NATIONALVISA_MZV_2026__GENKI_NATIVE_2026.json
@@ -1,0 +1,7 @@
+{
+  "visa_id": "SK_NATIONALVISA_MZV_2026",
+  "product_id": "GENKI_NATIVE_2026",
+  "status": "GREEN",
+  "reasons": [],
+  "missing": []
+}

--- a/data/mappings/SK_NATIONALVISA_MZV_2026__GENKI_TRAVELER_2026.json
+++ b/data/mappings/SK_NATIONALVISA_MZV_2026__GENKI_TRAVELER_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "SK_NATIONALVISA_MZV_2026",
+  "product_id": "GENKI_TRAVELER_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.SK.authorized"
+  ]
+}

--- a/data/mappings/SK_NATIONALVISA_MZV_2026__SAFETYWING_NOMAD_2026.json
+++ b/data/mappings/SK_NATIONALVISA_MZV_2026__SAFETYWING_NOMAD_2026.json
@@ -1,0 +1,20 @@
+{
+  "visa_id": "SK_NATIONALVISA_MZV_2026",
+  "product_id": "SAFETYWING_NOMAD_2026",
+  "status": "UNKNOWN",
+  "reasons": [
+    {
+      "text": "Visa requires coverage for full legal stay, monthly subscriptions can be cancelled",
+      "evidence": [
+        {
+          "source_id": "SK_NATIONALVISA_MZV_2026",
+          "locator": "Which documents should be submitted, basic documents",
+          "excerpt": "health insurance upon entry and throughout their stay in the Slovak Republic"
+        }
+      ]
+    }
+  ],
+  "missing": [
+    "specs.jurisdiction_facts.SK.authorized"
+  ]
+}

--- a/data/mappings/SK_NATIONALVISA_MZV_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
+++ b/data/mappings/SK_NATIONALVISA_MZV_2026__SANITAS_MAS_SALUD_SIN_COPAGO_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "SK_NATIONALVISA_MZV_2026",
+  "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.SK.authorized"
+  ]
+}

--- a/data/mappings/SK_NATIONALVISA_MZV_2026__WORLDNOMADS_EXPLORER_2026.json
+++ b/data/mappings/SK_NATIONALVISA_MZV_2026__WORLDNOMADS_EXPLORER_2026.json
@@ -1,0 +1,9 @@
+{
+  "visa_id": "SK_NATIONALVISA_MZV_2026",
+  "product_id": "WORLDNOMADS_EXPLORER_2026",
+  "status": "UNKNOWN",
+  "reasons": [],
+  "missing": [
+    "specs.jurisdiction_facts.SK.authorized"
+  ]
+}

--- a/data/products/Genki/Native/2026-06-08/product_facts.json
+++ b/data/products/Genki/Native/2026-06-08/product_facts.json
@@ -146,6 +146,16 @@
             "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
           }
         ]
+      },
+      "SK": {
+        "authorized": true,
+        "evidence": [
+          {
+            "source_id": "GENKI_NATIVE_COVERAGE_2026",
+            "locator": "Global Coverage",
+            "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
+          }
+        ]
       }
     }
   },

--- a/data/ui_index.json
+++ b/data/ui_index.json
@@ -1,6 +1,6 @@
 {
-  "built_at": "2026-06-15T23:58:19.374431+00:00",
-  "snapshot_id": "2026-06-15",
+  "built_at": "2026-06-16T00:04:59.988419+00:00",
+  "snapshot_id": "2026-06-16",
   "visas": [
     {
       "id": "AE_VIRTUALWORK_GDRFA_2026",
@@ -2142,6 +2142,61 @@
       ]
     },
     {
+      "id": "SK_NATIONALVISA_MZV_2026",
+      "country": "Slovakia",
+      "visa_name": "National (Long-Stay) Visa",
+      "route": "National visa documents (Ministry of Foreign and European Affairs)",
+      "authority": "Ministry of Foreign and European Affairs of the Slovak Republic (MZV)",
+      "last_verified": "2026-06-16",
+      "sources": [
+        {
+          "source_id": "SK_NATIONALVISA_MZV_2026",
+          "url": "https://www.mzv.sk/en/web/en/visa-and-services/national-visa",
+          "retrieved_at": "2026-06-16T00:00:00Z",
+          "sha256": "03571b2f20d5d17803d2f1ea79adcd3fafe31af936e0987a0a60a818ddda07e6",
+          "local_path": "sources/SK_NATIONALVISA_MZV_2026-06-16.html"
+        }
+      ],
+      "requirements": [
+        {
+          "key": "insurance.mandatory",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "SK_NATIONALVISA_MZV_2026",
+              "locator": "Which documents should be submitted, basic documents",
+              "excerpt": "proof that the applicant will have health insurance upon entry and throughout their stay in the Slovak Republic (e.g. commercial health insurance taken out abroad that covers medical expenses in the Slovak Republic, commercial health insurance taken out in Slovakia, proof of public health insurance in Slovakia, or proof that the applicant will be covered by public health insurance, etc.);"
+            }
+          ]
+        },
+        {
+          "key": "insurance.authorized_in_country",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "SK_NATIONALVISA_MZV_2026",
+              "locator": "Which documents should be submitted, basic documents",
+              "excerpt": "commercial health insurance taken out abroad that covers medical expenses in the Slovak Republic"
+            }
+          ]
+        },
+        {
+          "key": "insurance.must_cover_full_period",
+          "op": "==",
+          "value": true,
+          "evidence": [
+            {
+              "source_id": "SK_NATIONALVISA_MZV_2026",
+              "locator": "Which documents should be submitted, basic documents",
+              "excerpt": "health insurance upon entry and throughout their stay in the Slovak Republic"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "SM_ELECTIVE_ESTERI_2026",
       "country": "San Marino",
       "visa_name": "Elective Residence Permit",
@@ -2603,6 +2658,16 @@
                 "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
               }
             ]
+          },
+          "SK": {
+            "authorized": true,
+            "evidence": [
+              {
+                "source_id": "GENKI_NATIVE_COVERAGE_2026",
+                "locator": "Global Coverage",
+                "excerpt": "Global Coverage: All countries are covered, including those with travel warnings."
+              }
+            ]
           }
         }
       },
@@ -2921,7 +2986,7 @@
       "missing": [
         "specs.jurisdiction_facts.AT.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "AT_RESIDENCE_BMI_2026",
@@ -2931,7 +2996,7 @@
       "missing": [
         "specs.jurisdiction_facts.AT.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "AT_RESIDENCE_BMI_2026",
@@ -2942,7 +3007,7 @@
         "specs.jurisdiction_facts.AT.authorized",
         "specs.comprehensive"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "AT_RESIDENCE_BMI_2026",
@@ -2950,7 +3015,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "AT_RESIDENCE_BMI_2026",
@@ -2962,7 +3027,7 @@
         "specs.jurisdiction_facts.AT.authorized",
         "specs.comprehensive"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "AT_RESIDENCE_BMI_2026",
@@ -2984,7 +3049,7 @@
         "specs.jurisdiction_facts.AT.authorized",
         "specs.comprehensive"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "AT_RESIDENCE_BMI_2026",
@@ -2994,7 +3059,7 @@
       "missing": [
         "specs.jurisdiction_facts.AT.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "AT_RESIDENCE_BMI_2026",
@@ -3016,7 +3081,7 @@
         "specs.jurisdiction_facts.AT.authorized",
         "specs.comprehensive"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-16"
     },
     {
       "visa_id": "BB_WELCOMESTAMP_OAG_2026",
@@ -6322,6 +6387,95 @@
       "last_verified": "2026-06-15"
     },
     {
+      "visa_id": "SK_NATIONALVISA_MZV_2026",
+      "product_id": "ASISA_HEALTH_RESIDENTS_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.SK.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "SK_NATIONALVISA_MZV_2026",
+      "product_id": "DKV_VISADO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.SK.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "SK_NATIONALVISA_MZV_2026",
+      "product_id": "GENERIC_EXPAT_COMPLETE_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.SK.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "SK_NATIONALVISA_MZV_2026",
+      "product_id": "GENKI_NATIVE_2026",
+      "status": "GREEN",
+      "reasons": [],
+      "missing": [],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "SK_NATIONALVISA_MZV_2026",
+      "product_id": "GENKI_TRAVELER_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.SK.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "SK_NATIONALVISA_MZV_2026",
+      "product_id": "SAFETYWING_NOMAD_2026",
+      "status": "UNKNOWN",
+      "reasons": [
+        {
+          "text": "Visa requires coverage for full legal stay, monthly subscriptions can be cancelled",
+          "evidence": [
+            {
+              "source_id": "SK_NATIONALVISA_MZV_2026",
+              "locator": "Which documents should be submitted, basic documents",
+              "excerpt": "health insurance upon entry and throughout their stay in the Slovak Republic"
+            }
+          ]
+        }
+      ],
+      "missing": [
+        "specs.jurisdiction_facts.SK.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "SK_NATIONALVISA_MZV_2026",
+      "product_id": "SANITAS_MAS_SALUD_SIN_COPAGO_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.SK.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
+      "visa_id": "SK_NATIONALVISA_MZV_2026",
+      "product_id": "WORLDNOMADS_EXPLORER_2026",
+      "status": "UNKNOWN",
+      "reasons": [],
+      "missing": [
+        "specs.jurisdiction_facts.SK.authorized"
+      ],
+      "last_verified": ""
+    },
+    {
       "visa_id": "SM_ELECTIVE_ESTERI_2026",
       "product_id": "ASISA_HEALTH_RESIDENTS_2026",
       "status": "GREEN",
@@ -7188,6 +7342,13 @@
       "retrieved_at": "2026-06-15T00:00:00Z",
       "sha256": "4f712357fc4c45a3be6271a5b64b9db14fde5da609a8485bc472560c44fb52ba",
       "local_path": "sources/SI_D_GOVSI_2026-06-15.pdf"
+    },
+    "SK_NATIONALVISA_MZV_2026": {
+      "source_id": "SK_NATIONALVISA_MZV_2026",
+      "url": "https://www.mzv.sk/en/web/en/visa-and-services/national-visa",
+      "retrieved_at": "2026-06-16T00:00:00Z",
+      "sha256": "03571b2f20d5d17803d2f1ea79adcd3fafe31af936e0987a0a60a818ddda07e6",
+      "local_path": "sources/SK_NATIONALVISA_MZV_2026-06-16.html"
     },
     "SM_ELECTIVE_ESTERI_2026": {
       "source_id": "SM_ELECTIVE_ESTERI_2026",

--- a/data/visas/SK/NATIONALVISA/mzv/2026-06-16/visa_facts.json
+++ b/data/visas/SK/NATIONALVISA/mzv/2026-06-16/visa_facts.json
@@ -1,0 +1,55 @@
+{
+  "id": "SK_NATIONALVISA_MZV_2026",
+  "country": "Slovakia",
+  "visa_name": "National (Long-Stay) Visa",
+  "route": "National visa documents (Ministry of Foreign and European Affairs)",
+  "authority": "Ministry of Foreign and European Affairs of the Slovak Republic (MZV)",
+  "last_verified": "2026-06-16",
+  "sources": [
+    {
+      "source_id": "SK_NATIONALVISA_MZV_2026",
+      "url": "https://www.mzv.sk/en/web/en/visa-and-services/national-visa",
+      "retrieved_at": "2026-06-16T00:00:00Z",
+      "sha256": "03571b2f20d5d17803d2f1ea79adcd3fafe31af936e0987a0a60a818ddda07e6",
+      "local_path": "sources/SK_NATIONALVISA_MZV_2026-06-16.html"
+    }
+  ],
+  "requirements": [
+    {
+      "key": "insurance.mandatory",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "SK_NATIONALVISA_MZV_2026",
+          "locator": "Which documents should be submitted, basic documents",
+          "excerpt": "proof that the applicant will have health insurance upon entry and throughout their stay in the Slovak Republic (e.g. commercial health insurance taken out abroad that covers medical expenses in the Slovak Republic, commercial health insurance taken out in Slovakia, proof of public health insurance in Slovakia, or proof that the applicant will be covered by public health insurance, etc.);"
+        }
+      ]
+    },
+    {
+      "key": "insurance.authorized_in_country",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "SK_NATIONALVISA_MZV_2026",
+          "locator": "Which documents should be submitted, basic documents",
+          "excerpt": "commercial health insurance taken out abroad that covers medical expenses in the Slovak Republic"
+        }
+      ]
+    },
+    {
+      "key": "insurance.must_cover_full_period",
+      "op": "==",
+      "value": true,
+      "evidence": [
+        {
+          "source_id": "SK_NATIONALVISA_MZV_2026",
+          "locator": "Which documents should be submitted, basic documents",
+          "excerpt": "health insurance upon entry and throughout their stay in the Slovak Republic"
+        }
+      ]
+    }
+  ]
+}

--- a/sources/SK_NATIONALVISA_MZV_2026-06-16.html
+++ b/sources/SK_NATIONALVISA_MZV_2026-06-16.html
@@ -1,0 +1,7320 @@
+<html class="ltr yui3-js-enabled" dir="ltr" lang="en-US"><head>
+    <script src="/o/mzvTheme/js/mzv_modal.js"></script>
+	<script src="/o/mzvTheme/js/jquery-3.6.0.min.js"></script>
+	<script src="/o/mzvTheme/js/datatables.min.js"></script>
+	<script src="/o/mzvTheme/js/selectize.min.js"></script>
+	<script src="/o/mzvTheme/js/select2.min.js"></script>
+	<script src="/o/mzvTheme/js/flatpickr.min.js"> </script>
+	<script src="/o/mzvTheme/js/flatpickr_sk.js"> </script>
+    <script src="/o/mzvTheme/js/moment.min.js"></script>
+	<script src="/o/mzvTheme/leaflet/leaflet.js"></script>
+	<script src="/o/mzvTheme/leaflet/markercluster/leaflet.markercluster.js"></script>
+	<script src="/o/mzvTheme/leaflet/gesture-handling/leaflet-gesture-handling.js"></script>
+	<script src="/o/mzvTheme/js/cookies.js" defer=""></script>
+	<title>National visa | Ministry of Foreign and European Affairs of the Slovak Republic</title>
+    <link rel="stylesheet" href="/o/mzvTheme/css/mzv_modal.css">
+	<link rel="stylesheet" href="/o/mzvTheme/css/calc.css">
+	<link rel="stylesheet" href="/o/mzvTheme/css/selectize.css">
+	<link rel="stylesheet" href="/o/mzvTheme/css/select2.min.css">
+	<link rel="stylesheet" href="/o/mzvTheme/css/flatpickr.min.css">
+    <link rel="stylesheet" href="/o/mzvTheme/css/datatables.min.css">	
+	<link rel="stylesheet" href="/o/mzvTheme/leaflet/leaflet.css">
+	<link rel="stylesheet" href="/o/mzvTheme/leaflet/markercluster/markercluster.css">
+	<link rel="stylesheet" href="/o/mzvTheme/leaflet/gesture-handling/leaflet-gesture-handling.min.css">
+
+    <style>
+        table.dataTable thead .sorting,
+        table.dataTable thead .sorting_asc,
+        table.dataTable thead .sorting_desc,
+        table.dataTable thead .sorting_asc_disabled,
+        table.dataTable thead .sorting_desc_disabled {
+            background-image: none !important;
+        }
+    </style>
+
+	<meta content="initial-scale=1.0, width=device-width, viewport-fit=cover" name="viewport">
+
+	<!--THIS IS ONLY FOR TEST. COMMENT FOR PRODUCTION-->
+	<!--<meta name="robots" content="noindex, nofollow">-->
+	<!--********************************************-->
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<meta content="text/html; charset=UTF-8" http-equiv="content-type">
+
+
+
+
+
+
+
+
+
+
+
+
+<link data-senna-track="temporary" href="https://mzv.sk/web/en/visa-and-services/national-visa" rel="canonical">
+<link data-senna-track="temporary" href="https://mzv.sk/zh/web/en/visa-and-services/national-visa" hreflang="zh-CN" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/es/web/en/visa-and-services/national-visa" hreflang="es-ES" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/ko/web/en/visa-and-services/national-visa" hreflang="ko-KR" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/ru/web/en/visa-and-services/national-visa" hreflang="ru-RU" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/sl/web/en/visa-and-services/national-visa" hreflang="sl-SL" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/hu/web/en/visa-and-services/national-visa" hreflang="hu-HU" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/sr/web/en/visa-and-services/national-visa" hreflang="sr-RS" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/ar/web/en/visa-and-services/national-visa" hreflang="ar-SA" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/pt/web/en/visa-and-services/national-visa" hreflang="pt-BR" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/de/web/en/visa-and-services/national-visa" hreflang="de-DE" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/tr/web/en/visa-and-services/national-visa" hreflang="tr-TR" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/pl/web/en/visa-and-services/national-visa" hreflang="pl-PL" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/be/web/en/visa-and-services/national-visa" hreflang="be-BY" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/web/en/visa-and-services/national-visa" hreflang="sk-SK" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/it/web/en/visa-and-services/national-visa" hreflang="it-IT" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/fr/web/en/visa-and-services/national-visa" hreflang="fr-FR" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/vi/web/en/visa-and-services/national-visa" hreflang="vi-VN" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/en/web/en/visa-and-services/national-visa" hreflang="en-US" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/uk/web/en/visa-and-services/national-visa" hreflang="uk-UA" rel="alternate">
+<link data-senna-track="temporary" href="https://mzv.sk/web/en/visa-and-services/national-visa" hreflang="x-default" rel="alternate">
+
+<meta property="og:locale" content="en_US">
+<meta property="og:locale:alternate" content="en_US">
+<meta property="og:locale:alternate" content="be_BY">
+<meta property="og:locale:alternate" content="zh_CN">
+<meta property="og:locale:alternate" content="fr_FR">
+<meta property="og:locale:alternate" content="de_DE">
+<meta property="og:locale:alternate" content="hu_HU">
+<meta property="og:locale:alternate" content="it_IT">
+<meta property="og:locale:alternate" content="ko_KR">
+<meta property="og:locale:alternate" content="pl_PL">
+<meta property="og:locale:alternate" content="pt_BR">
+<meta property="og:locale:alternate" content="ru_RU">
+<meta property="og:locale:alternate" content="sr_RS">
+<meta property="og:locale:alternate" content="sl_SL">
+<meta property="og:locale:alternate" content="sk_SK">
+<meta property="og:locale:alternate" content="es_ES">
+<meta property="og:locale:alternate" content="tr_TR">
+<meta property="og:locale:alternate" content="uk_UA">
+<meta property="og:locale:alternate" content="vi_VN">
+<meta property="og:locale:alternate" content="ar_SA">
+<meta property="og:site_name" content="MZV EN">
+<meta property="og:title" content="National visa - MZV EN - MZV">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://mzv.sk/web/en/visa-and-services/national-visa">
+
+
+<link href="https://www.mzv.sk/o/mzvTheme/images/favicon.ico" rel="icon">
+
+
+
+<link class="lfr-css-file" data-senna-track="temporary" href="https://www.mzv.sk/o/mzvTheme/css/clay.css?browserId=chrome&amp;themeId=mzvtheme_WAR_mzvTheme&amp;minifierType=css&amp;languageId=en_US&amp;b=7307&amp;t=1771511136000" id="liferayAUICSS" rel="stylesheet" type="text/css">
+
+
+
+<script charset="utf-8" id="yui_patched_v3_18_1_1_1781568080100_35" src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/frontend-js-aui-web/aui/event-base/event-base-min.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_1_1_1781568080100_51" src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/frontend-js-aui-web/aui/event-base/event-base-min.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_1_1_1781568080100_59" src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/frontend-js-aui-web/aui/yui-throttle/yui-throttle-min.js&amp;/o/frontend-js-aui-web/aui/classnamemanager/classnamemanager-min.js&amp;/o/frontend-js-aui-web/aui/aui-classnamemanager/aui-classnamemanager-min.js&amp;/o/frontend-js-aui-web/aui/aui-debounce/aui-debounce-min.js&amp;/o/frontend-js-aui-web/aui/array-extras/array-extras-min.js&amp;/o/frontend-js-aui-web/aui/dom-core/dom-core-min.js&amp;/o/frontend-js-aui-web/aui/dom-base/dom-base-min.js&amp;/o/frontend-js-aui-web/aui/selector-native/selector-native-min.js&amp;/o/frontend-js-aui-web/aui/selector/selector-min.js&amp;/o/frontend-js-aui-web/aui/node-core/node-core-min.js&amp;/o/frontend-js-aui-web/aui/dom-style/dom-style-min.js&amp;/o/frontend-js-aui-web/aui/node-base/node-base-min.js&amp;/o/frontend-js-aui-web/aui/event-delegate/event-delegate-min.js&amp;/o/frontend-js-aui-web/aui/node-event-delegate/node-event-delegate-min.js&amp;/o/frontend-js-aui-web/aui/pluginhost-base/pluginhost-base-min.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_1_1_1781568080100_60" src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/frontend-js-aui-web/aui/pluginhost-config/pluginhost-config-min.js&amp;/o/frontend-js-aui-web/aui/node-pluginhost/node-pluginhost-min.js&amp;/o/frontend-js-aui-web/aui/dom-screen/dom-screen-min.js&amp;/o/frontend-js-aui-web/aui/node-screen/node-screen-min.js&amp;/o/frontend-js-aui-web/aui/node-style/node-style-min.js&amp;/o/frontend-js-aui-web/aui/aui-node-base/aui-node-base-min.js&amp;/o/frontend-js-aui-web/aui/aui-timer/aui-timer-min.js&amp;/o/frontend-js-aui-web/aui/event-touch/event-touch-min.js&amp;/o/frontend-js-aui-web/aui/event-synthetic/event-synthetic-min.js&amp;/o/frontend-js-aui-web/aui/event-move/event-move-min.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_1_1_1781568080100_61" src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/frontend-js-aui-web/liferay/menu.js" async=""></script><script charset="utf-8" id="yui_patched_v3_18_1_1_1781568080100_67" src="https://www.mzv.sk/o/frontend-js-web/liferay/available_languages.jsp?browserId=chrome&amp;themeId=mzvtheme_WAR_mzvTheme&amp;colorSchemeId=01&amp;minifierType=js&amp;languageId=en_US&amp;b=7307&amp;t=1776769050800" async=""></script><script charset="utf-8" id="yui_patched_v3_18_1_1_1781568080100_68" src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/frontend-js-aui-web/aui/array-invoke/array-invoke-min.js&amp;/o/frontend-js-aui-web/liferay/language.js" async=""></script><link rel="stylesheet" id="yui_patched_v3_18_1_1_1781568080100_73" href="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/frontend-js-aui-web/aui/widget-base/assets/skins/sam/widget-base.css"><script charset="utf-8" id="yui_patched_v3_18_1_1_1781568080100_74" src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/frontend-js-aui-web/aui/base-core/base-core-min.js&amp;/o/frontend-js-aui-web/aui/base-observable/base-observable-min.js&amp;/o/frontend-js-aui-web/aui/base-base/base-base-min.js&amp;/o/frontend-js-aui-web/aui/base-pluginhost/base-pluginhost-min.js&amp;/o/frontend-js-aui-web/aui/event-focus/event-focus-min.js&amp;/o/frontend-js-aui-web/aui/widget-base/widget-base-min.js&amp;/o/frontend-js-aui-web/aui/aui-widget-cssclass/aui-widget-cssclass-min.js&amp;/o/frontend-js-aui-web/aui/aui-widget-toggle/aui-widget-toggle-min.js&amp;/o/frontend-js-aui-web/aui/base-build/base-build-min.js&amp;/o/frontend-js-aui-web/aui/aui-component/aui-component-min.js&amp;/o/frontend-js-aui-web/aui/cookie/cookie-min.js&amp;/o/frontend-js-aui-web/aui/plugin/plugin-min.js&amp;/o/frontend-js-aui-web/liferay/session.js" async=""></script><link data-senna-track="temporary" href="/o/frontend-css-web/main.css?browserId=chrome&amp;themeId=mzvtheme_WAR_mzvTheme&amp;minifierType=css&amp;languageId=en_US&amp;b=7307&amp;t=1623377010573" id="liferayPortalCSS" rel="stylesheet" type="text/css">
+
+
+
+
+
+
+
+
+
+	
+
+	
+
+
+
+
+
+	
+
+
+
+	
+
+		<link data-senna-track="temporary" href="/combo?browserId=chrome&amp;minifierType=&amp;themeId=mzvtheme_WAR_mzvTheme&amp;languageId=en_US&amp;b=7307&amp;com_liferay_portal_search_web_search_bar_portlet_SearchBarPortlet_INSTANCE_templateSearch:%2Fcss%2Fmain.css&amp;com_liferay_product_navigation_product_menu_web_portlet_ProductMenuPortlet:%2Fcss%2Fmain.css&amp;com_liferay_product_navigation_user_personal_bar_web_portlet_ProductNavigationUserPersonalBarPortlet:%2Fcss%2Fmain.css&amp;com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet:%2Fcss%2Fmain.css&amp;sk_mzv_portal_feedback_portlet_FeedbackPortlet:%2Fcss%2Fmain.css&amp;sk_mzv_portal_pdf_viewer_embedded_PDFViewerPortlet:%2Fcss%2Fmain.css&amp;sk_mzv_portal_search_global_GlobalSearchInputPortlet_INSTANCE_xzy8:%2Fcss%2Finput.css&amp;t=1771511136000" id="6b62b65a" rel="stylesheet" type="text/css">
+
+	
+
+
+
+
+
+
+
+<script data-senna-track="temporary" type="text/javascript">
+	// <![CDATA[
+		var Liferay = Liferay || {};
+
+		Liferay.Browser = {
+			acceptsGzip: function() {
+				return true;
+			},
+
+			
+
+			getMajorVersion: function() {
+				return 149.0;
+			},
+
+			getRevision: function() {
+				return '537.36';
+			},
+			getVersion: function() {
+				return '149.0';
+			},
+
+			
+
+			isAir: function() {
+				return false;
+			},
+			isChrome: function() {
+				return true;
+			},
+			isEdge: function() {
+				return false;
+			},
+			isFirefox: function() {
+				return false;
+			},
+			isGecko: function() {
+				return true;
+			},
+			isIe: function() {
+				return false;
+			},
+			isIphone: function() {
+				return false;
+			},
+			isLinux: function() {
+				return false;
+			},
+			isMac: function() {
+				return true;
+			},
+			isMobile: function() {
+				return false;
+			},
+			isMozilla: function() {
+				return false;
+			},
+			isOpera: function() {
+				return false;
+			},
+			isRtf: function() {
+				return true;
+			},
+			isSafari: function() {
+				return true;
+			},
+			isSun: function() {
+				return false;
+			},
+			isWebKit: function() {
+				return true;
+			},
+			isWindows: function() {
+				return false;
+			}
+		};
+
+		Liferay.Data = Liferay.Data || {};
+
+		Liferay.Data.ICONS_INLINE_SVG = true;
+
+		Liferay.Data.NAV_SELECTOR = '#navigation';
+
+		Liferay.Data.NAV_SELECTOR_MOBILE = '#navigationCollapse';
+
+		Liferay.Data.isCustomizationView = function() {
+			return false;
+		};
+
+		Liferay.Data.notices = [
+			
+
+			
+		];
+
+		Liferay.PortletKeys = {
+			DOCUMENT_LIBRARY: 'com_liferay_document_library_web_portlet_DLPortlet',
+			DYNAMIC_DATA_MAPPING: 'com_liferay_dynamic_data_mapping_web_portlet_DDMPortlet',
+			ITEM_SELECTOR: 'com_liferay_item_selector_web_portlet_ItemSelectorPortlet'
+		};
+
+		Liferay.PropsValues = {
+			JAVASCRIPT_SINGLE_PAGE_APPLICATION_TIMEOUT: 0,
+			NTLM_AUTH_ENABLED: false,
+			UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE: 5000000000
+		};
+
+		Liferay.ThemeDisplay = {
+
+			
+
+			
+				getLayoutId: function() {
+					return '402';
+				},
+
+				
+
+				getLayoutRelativeControlPanelURL: function() {
+					return '/en/group/en/~/control_panel/manage';
+				},
+
+				getLayoutRelativeURL: function() {
+					return '/en/web/en/visa-and-services/national-visa';
+				},
+				getLayoutURL: function() {
+					return 'https://www.mzv.sk/en/web/en/visa-and-services/national-visa';
+				},
+				getParentLayoutId: function() {
+					return '176';
+				},
+				isControlPanel: function() {
+					return false;
+				},
+				isPrivateLayout: function() {
+					return 'false';
+				},
+				isVirtualLayout: function() {
+					return false;
+				},
+			
+
+			getBCP47LanguageId: function() {
+				return 'en-US';
+			},
+			getCanonicalURL: function() {
+
+				
+
+				return 'https\x3a\x2f\x2fmzv\x2esk\x2fweb\x2fen\x2fvisa-and-services\x2fnational-visa';
+			},
+			getCDNBaseURL: function() {
+				return 'https://www.mzv.sk';
+			},
+			getCDNDynamicResourcesHost: function() {
+				return '';
+			},
+			getCDNHost: function() {
+				return '';
+			},
+			getCompanyGroupId: function() {
+				return '10195';
+			},
+			getCompanyId: function() {
+				return '10155';
+			},
+			getDefaultLanguageId: function() {
+				return 'sk_SK';
+			},
+			getDoAsUserIdEncoded: function() {
+				return '';
+			},
+			getLanguageId: function() {
+				return 'en_US';
+			},
+			getParentGroupId: function() {
+				return '30297';
+			},
+			getPathContext: function() {
+				return '';
+			},
+			getPathImage: function() {
+				return '/image';
+			},
+			getPathJavaScript: function() {
+				return '/o/frontend-js-web';
+			},
+			getPathMain: function() {
+				return '/en/c';
+			},
+			getPathThemeImages: function() {
+				return 'https://www.mzv.sk/o/mzvTheme/images';
+			},
+			getPathThemeRoot: function() {
+				return '/o/mzvTheme';
+			},
+			getPlid: function() {
+				return '4898762';
+			},
+			getPortalURL: function() {
+				return 'https://www.mzv.sk';
+			},
+			getScopeGroupId: function() {
+				return '30297';
+			},
+			getScopeGroupIdOrLiveGroupId: function() {
+				return '30297';
+			},
+			getSessionId: function() {
+				return '';
+			},
+			getSiteAdminURL: function() {
+				return 'https://www.mzv.sk/group/en/~/control_panel/manage?p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view';
+			},
+			getSiteGroupId: function() {
+				return '30297';
+			},
+			getURLControlPanel: function() {
+				return '/en/group/control_panel?refererPlid=4898762';
+			},
+			getURLHome: function() {
+				return 'https\x3a\x2f\x2fwww\x2emzv\x2esk\x2fweb\x2fsk';
+			},
+			getUserEmailAddress: function() {
+				return '';
+			},
+			getUserId: function() {
+				return '10159';
+			},
+			getUserName: function() {
+				return '';
+			},
+			isAddSessionIdToURL: function() {
+				return false;
+			},
+			isImpersonated: function() {
+				return false;
+			},
+			isSignedIn: function() {
+				return false;
+			},
+			isStateExclusive: function() {
+				return false;
+			},
+			isStateMaximized: function() {
+				return false;
+			},
+			isStatePopUp: function() {
+				return false;
+			}
+		};
+
+		var themeDisplay = Liferay.ThemeDisplay;
+
+		Liferay.AUI = {
+
+			
+
+			getAvailableLangPath: function() {
+				return 'available_languages.jsp?browserId=chrome&themeId=mzvtheme_WAR_mzvTheme&colorSchemeId=01&minifierType=js&languageId=en_US&b=7307&t=1776769050800';
+			},
+			getCombine: function() {
+				return true;
+			},
+			getComboPath: function() {
+				return '/combo/?browserId=chrome&minifierType=&languageId=en_US&b=7307&t=1623376995526&';
+			},
+			getDateFormat: function() {
+				return '%m/%d/%Y';
+			},
+			getEditorCKEditorPath: function() {
+				return '/o/frontend-editor-ckeditor-web';
+			},
+			getFilter: function() {
+				var filter = 'raw';
+
+				
+					
+						filter = 'min';
+					
+					
+				
+
+				return filter;
+			},
+			getFilterConfig: function() {
+				var instance = this;
+
+				var filterConfig = null;
+
+				if (!instance.getCombine()) {
+					filterConfig = {
+						replaceStr: '.js' + instance.getStaticResourceURLParams(),
+						searchExp: '\\.js$'
+					};
+				}
+
+				return filterConfig;
+			},
+			getJavaScriptRootPath: function() {
+				return '/o/frontend-js-web';
+			},
+			getLangPath: function() {
+				return 'aui_lang.jsp?browserId=chrome&themeId=mzvtheme_WAR_mzvTheme&colorSchemeId=01&minifierType=js&languageId=en_US&b=7307&t=1623376995526';
+			},
+			getPortletRootPath: function() {
+				return '/html/portlet';
+			},
+			getStaticResourceURLParams: function() {
+				return '?browserId=chrome&minifierType=&languageId=en_US&b=7307&t=1623376995526';
+			}
+		};
+
+		Liferay.authToken = 'WekKFFKF';
+
+		
+
+		Liferay.currentURL = '\x2fen\x2fweb\x2fen\x2fvisa-and-services\x2fnational-visa';
+		Liferay.currentURLEncoded = '\x252Fen\x252Fweb\x252Fen\x252Fvisa-and-services\x252Fnational-visa';
+	// ]]>
+</script>
+
+<script src="/o/js_loader_config?t=1776765980380" type="text/javascript"></script>
+<script data-senna-track="permanent" src="/combo?browserId=chrome&amp;minifierType=js&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/frontend-js-aui-web/aui/aui/aui.js&amp;/o/frontend-js-aui-web/liferay/modules.js&amp;/o/frontend-js-aui-web/liferay/aui_sandbox.js&amp;/o/frontend-js-aui-web/aui/attribute-base/attribute-base.js&amp;/o/frontend-js-aui-web/aui/attribute-complex/attribute-complex.js&amp;/o/frontend-js-aui-web/aui/attribute-core/attribute-core.js&amp;/o/frontend-js-aui-web/aui/attribute-observable/attribute-observable.js&amp;/o/frontend-js-aui-web/aui/attribute-extras/attribute-extras.js&amp;/o/frontend-js-aui-web/aui/event-custom-base/event-custom-base.js&amp;/o/frontend-js-aui-web/aui/event-custom-complex/event-custom-complex.js&amp;/o/frontend-js-aui-web/aui/oop/oop.js&amp;/o/frontend-js-aui-web/aui/aui-base-lang/aui-base-lang.js&amp;/o/frontend-js-aui-web/liferay/dependency.js&amp;/o/frontend-js-aui-web/liferay/util.js&amp;/o/frontend-js-web/loader/config.js&amp;/o/frontend-js-web/loader/loader.js&amp;/o/frontend-js-web/liferay/dom_task_runner.js&amp;/o/frontend-js-web/liferay/events.js&amp;/o/frontend-js-web/liferay/lazy_load.js&amp;/o/frontend-js-web/liferay/liferay.js&amp;/o/frontend-js-web/liferay/global.bundle.js&amp;/o/frontend-js-web/liferay/portlet.js&amp;/o/frontend-js-web/liferay/workflow.js" type="text/javascript"></script>
+
+
+
+
+	
+
+	<script data-senna-track="temporary" src="/o/js_bundle_config?t=1776765996683" type="text/javascript"></script>
+
+
+<script data-senna-track="temporary" type="text/javascript">
+	// <![CDATA[
+		
+			
+				
+				
+			
+		
+
+		
+
+		
+	// ]]>
+</script>
+
+
+
+
+
+	
+		
+
+			
+
+			
+		
+		
+	
+
+
+
+	
+		
+		
+
+			
+
+			
+		
+	
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	
+
+
+
+
+
+	
+
+
+
+	
+
+		<script data-senna-track="temporary" src="/combo?browserId=chrome&amp;minifierType=&amp;themeId=mzvtheme_WAR_mzvTheme&amp;languageId=en_US&amp;b=7307&amp;sk_mzv_portal_pdf_viewer_embedded_PDFViewerPortlet:%2Fjs%2Finit.js&amp;t=1771511136000" type="text/javascript"></script>
+
+	
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+	
+
+
+
+
+
+
+
+
+
+
+<link class="lfr-css-file" data-senna-track="temporary" href="https://www.mzv.sk/o/mzvTheme/css/main.css?browserId=chrome&amp;themeId=mzvtheme_WAR_mzvTheme&amp;minifierType=css&amp;languageId=en_US&amp;b=7307&amp;t=1771511136000" id="liferayThemeCSS" rel="stylesheet" type="text/css">
+
+
+
+
+
+
+
+
+	<style data-senna-track="temporary" type="text/css">
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+			
+
+		
+
+	</style>
+
+
+<link href="/o/commerce-frontend-js/styles/main.css" rel="stylesheet" type="text/css"><style data-senna-track="temporary" type="text/css">
+	:root {
+		--container-max-sm: 576px;
+		--h4-font-size: 1rem;
+		--font-weight-bold: 700;
+		--rounded-pill: 50rem;
+		--display4-weight: 300;
+		--danger: #da1414;
+		--display2-size: 5.5rem;
+		--body-bg: #fff;
+		--display2-weight: 300;
+		--display1-weight: 300;
+		--display3-weight: 300;
+		--box-shadow-sm: 0 .125rem .25rem rgba(0, 0, 0, .075);
+		--font-weight-lighter: lighter;
+		--h3-font-size: 1.1875rem;
+		--btn-outline-primary-hover-border-color: #0b5fff;
+		--transition-collapse: height .35s ease;
+		--blockquote-small-color: #6b6c7e;
+		--gray-200: #f1f2f5;
+		--btn-secondary-hover-background-color: #f7f8f9;
+		--gray-600: #6b6c7e;
+		--secondary: #6b6c7e;
+		--btn-outline-primary-color: #0b5fff;
+		--btn-link-hover-color: #004ad7;
+		--hr-border-color: rgba(0, 0, 0, .1);
+		--hr-border-margin-y: 1rem;
+		--light: #f1f2f5;
+		--btn-outline-primary-hover-color: #0b5fff;
+		--btn-secondary-background-color: #fff;
+		--btn-outline-secondary-hover-border-color: transparent;
+		--display3-size: 4.5rem;
+		--primary: #0b5fff;
+		--container-max-md: 768px;
+		--border-radius-sm: 0.1875rem;
+		--display-line-height: 1.2;
+		--h6-font-size: 0.8125rem;
+		--h2-font-size: 1.375rem;
+		--aspect-ratio-4-to-3: 75%;
+		--spacer-10: 10rem;
+		--font-weight-normal: 400;
+		--dark: #272833;
+		--blockquote-small-font-size: 80%;
+		--h5-font-size: 0.875rem;
+		--blockquote-font-size: 1.25rem;
+		--transition-fade: opacity .15s linear;
+		--display4-size: 3.5rem;
+		--border-radius-lg: 0.375rem;
+		--btn-primary-hover-color: #fff;
+		--display1-size: 6rem;
+		--black: #000;
+		--gray-300: #e7e7ed;
+		--gray-700: #495057;
+		--btn-secondary-border-color: #cdced9;
+		--btn-outline-secondary-hover-color: #272833;
+		--body-color: #272833;
+		--btn-outline-secondary-hover-background-color: rgba(39, 40, 51, 0.03);
+		--btn-primary-color: #fff;
+		--btn-secondary-color: #6b6c7e;
+		--btn-secondary-hover-border-color: #cdced9;
+		--box-shadow-lg: 0 1rem 3rem rgba(0, 0, 0, .175);
+		--container-max-lg: 992px;
+		--btn-outline-primary-border-color: #0b5fff;
+		--aspect-ratio: 100%;
+		--aspect-ratio-16-to-9: 56.25%;
+		--box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .15);
+		--white: #fff;
+		--warning: #b95000;
+		--info: #2e5aac;
+		--hr-border-width: 1px;
+		--btn-link-color: #0b5fff;
+		--gray-400: #cdced9;
+		--gray-800: #393a4a;
+		--btn-outline-primary-hover-background-color: #f0f5ff;
+		--btn-primary-hover-background-color: #0053f0;
+		--btn-primary-background-color: #0b5fff;
+		--success: #287d3c;
+		--font-size-sm: 0.875rem;
+		--btn-primary-border-color: #0b5fff;
+		--font-family-base: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+		--spacer-0: 0;
+		--font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+		--lead-font-size: 1.25rem;
+		--border-radius: 0.25rem;
+		--spacer-9: 9rem;
+		--font-weight-light: 300;
+		--btn-secondary-hover-color: #272833;
+		--spacer-2: 0.5rem;
+		--spacer-1: 0.25rem;
+		--spacer-4: 1.5rem;
+		--spacer-3: 1rem;
+		--spacer-6: 4.5rem;
+		--spacer-5: 3rem;
+		--spacer-8: 7.5rem;
+		--border-radius-circle: 50%;
+		--spacer-7: 6rem;
+		--font-size-lg: 1.125rem;
+		--aspect-ratio-8-to-3: 37.5%;
+		--font-family-sans-serif: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+		--gray-100: #f7f8f9;
+		--font-weight-bolder: 900;
+		--container-max-xl: 1280px;
+		--btn-outline-secondary-color: #6b6c7e;
+		--gray-500: #a7a9bc;
+		--h1-font-size: 1.625rem;
+		--gray-900: #272833;
+		--text-muted: #a7a9bc;
+		--btn-primary-hover-border-color: transparent;
+		--btn-outline-secondary-border-color: #cdced9;
+		--lead-font-weight: 300;
+		--font-size-base: 0.875rem;
+	}
+</style>
+<link href="https://www.mzv.sk/o/favicon-override/images/favicon.ico" rel="icon">
+
+
+
+
+
+
+<script type="text/javascript">
+// <![CDATA[
+Liferay.on(
+	'ddmFieldBlur', function(event) {
+		if (window.Analytics) {
+			Analytics.send(
+				'fieldBlurred',
+				'Form',
+				{
+					fieldName: event.fieldName,
+					focusDuration: event.focusDuration,
+					formId: event.formId,
+					page: event.page
+				}
+			);
+		}
+	}
+);
+
+Liferay.on(
+	'ddmFieldFocus', function(event) {
+		if (window.Analytics) {
+			Analytics.send(
+				'fieldFocused',
+				'Form',
+				{
+					fieldName: event.fieldName,
+					formId: event.formId,
+					page: event.page
+				}
+			);
+		}
+	}
+);
+
+Liferay.on(
+	'ddmFormPageShow', function(event) {
+		if (window.Analytics) {
+			Analytics.send(
+				'pageViewed',
+				'Form',
+				{
+					formId: event.formId,
+					page: event.page,
+					title: event.title
+				}
+			);
+		}
+	}
+);
+
+Liferay.on(
+	'ddmFormSubmit', function(event) {
+		if (window.Analytics) {
+			Analytics.send(
+				'formSubmitted',
+				'Form',
+				{
+					formId: event.formId
+				}
+			);
+		}
+	}
+);
+
+Liferay.on(
+	'ddmFormView', function(event) {
+		if (window.Analytics) {
+			Analytics.send(
+				'formViewed',
+				'Form',
+				{
+					formId: event.formId,
+					title: event.title
+				}
+			);
+		}
+	}
+);
+// ]]>
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<script data-senna-track="temporary" type="text/javascript">
+	if (window.Analytics) {
+		window._com_liferay_document_library_analytics_isViewFileEntry = false;
+	}
+</script>
+
+
+
+
+
+
+
+
+
+<script src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/coreNamed.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/core.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/array/array.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/async/async.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/disposable/Disposable.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/object/object.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/string/string.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal@2.16.8/lib/metal.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/domData.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-events@2.16.8/lib/EventHandle.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-events@2.16.8/lib/EventEmitter.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-events@2.16.8/lib/EventEmitterProxy.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-events@2.16.8/lib/EventHandler.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-events@2.16.8/lib/events.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/DomDelegatedEventHandle.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/DomEventHandle.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/domNamed.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/dom.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/DomEventEmitterProxy.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/features.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/globalEval.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/globalEvalStyles.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/events.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-dom@2.16.8/lib/all/dom.js"></script><script src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/js/resolved-module/frontend-js-metal-web@4.0.8/bridge/metal-dom/src/all/dom.js&amp;/o/js/resolved-module/frontend-taglib-clay$classnames@2.2.6/index.js&amp;/o/js/resolved-module/frontend-js-react-web$object-assign@4.1.1/index.js&amp;/o/js/resolved-module/frontend-js-react-web$react@16.12.0/cjs/react.production.min.js&amp;/o/js/resolved-module/frontend-js-react-web$react@16.12.0/index.js&amp;/o/js/resolved-module/frontend-taglib-clay$warning@4.0.3/warning.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/icon@3.1.0/lib/index.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/layout@3.3.0/lib/Col.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/layout@3.3.0/lib/Container.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/layout@3.3.0/lib/ContainerFluid.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/layout@3.3.0/lib/Content.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/layout@3.3.0/lib/Row.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/layout@3.3.0/lib/Sheet.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/layout@3.3.0/lib/index.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/alert@3.5.0/lib/Footer.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/alert@3.5.0/lib/ToastContainer.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/alert@3.5.0/lib/index.js&amp;/o/js/resolved-module/frontend-js-node-shims$process@0.11.10/browser.js&amp;/o/js/resolved-module/frontend-js-node-shims$process@0.11.10/index.js&amp;/o/js/resolved-module/frontend-js-react-web$scheduler@0.18.0/cjs/scheduler.production.min.js&amp;/o/js/resolved-module/frontend-js-react-web$scheduler@0.18.0/index.js&amp;/o/js/resolved-module/frontend-js-react-web$react-dom@16.12.0/cjs/react-dom.production.min.js&amp;/o/js/resolved-module/frontend-js-react-web$react-dom@16.12.0/index.js&amp;/o/js/resolved-module/frontend-js-react-web@4.0.18/js/render.es.js"></script><script src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/js/resolved-module/frontend-js-react-web@4.0.18/js/hooks/useEventListener.es.js&amp;/o/js/resolved-module/frontend-js-react-web@4.0.18/js/hooks/useIsMounted.es.js&amp;/o/js/resolved-module/frontend-js-react-web@4.0.18/js/hooks/useInterval.es.js&amp;/o/js/resolved-module/frontend-js-react-web@4.0.18/js/hooks/usePrevious.es.js&amp;/o/js/resolved-module/frontend-js-react-web@4.0.18/js/hooks/useStateSafe.es.js&amp;/o/js/resolved-module/frontend-js-react-web@4.0.18/js/hooks/useThunk.es.js&amp;/o/js/resolved-module/frontend-js-react-web@4.0.18/js/hooks/useTimeout.es.js&amp;/o/js/resolved-module/frontend-js-react-web@4.0.18/js/index.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/toast/commands/OpenToast.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/bridge/frontend-js-web/liferay/toast/commands/OpenToast.es.js"></script><script src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/js/resolved-module/frontend-js-tabs-support-web@1.0.8/TabsProvider.js&amp;/o/js/resolved-module/frontend-js-tabs-support-web@1.0.8/index.js"></script><script src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/js/resolved-module/frontend-js-dropdown-support-web$dom-align@1.10.4/dist-node/index.js&amp;/o/js/resolved-module/frontend-js-dropdown-support-web@1.0.8/DropdownProvider.js&amp;/o/js/resolved-module/frontend-js-dropdown-support-web@1.0.8/index.js"></script><script src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/js/resolved-module/frontend-js-collapse-support-web@1.0.10/CollapseProvider.js&amp;/o/js/resolved-module/frontend-js-collapse-support-web@1.0.10/index.js"></script><script src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/js/resolved-module/frontend-js-alert-support-web@1.0.7/index.js"></script><script src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/tooltip@3.4.0/lib/Tooltip.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.28.0/lib/Portal.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.28.0/lib/delegate.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.28.0/lib/Keys.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.28.0/lib/useFocusManagement.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.28.0/lib/FocusScope.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.28.0/lib/getEllipsisItems.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/button@3.6.0/lib/Group.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/button@3.6.0/lib/Button.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/button@3.6.0/lib/ButtonWithIcon.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/button@3.6.0/lib/index.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/link@3.2.0/lib/Context.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/link@3.2.0/lib/index.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.28.0/lib/LinkOrButton.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.28.0/lib/sub.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.28.0/lib/observeRect.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.28.0/lib/useDebounce.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.28.0/lib/setElementFullHeight.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.28.0/lib/useInternalState.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/shared@3.28.0/lib/index.js&amp;/o/js/resolved-module/frontend-taglib-clay$dom-align@1.10.4/dist-node/index.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/tooltip@3.4.0/lib/TooltipProvider.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/tooltip@3.4.0/lib/index.js"></script><script src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/js/resolved-module/frontend-js-metal-web$metal-position@2.1.2/lib/Geometry.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-position@2.1.2/lib/Position.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-position@2.1.2/lib/Align.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-position@2.1.2/lib/all/position.js&amp;/o/js/resolved-module/frontend-js-tooltip-support-web@3.0.4/reducer.js&amp;/o/js/resolved-module/frontend-js-tooltip-support-web@3.0.4/index.js"></script><script src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/aop/AOP.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/autosize/autosize.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/debounce/debounce.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/form/object_to_form_data.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/breakpoints.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-state@2.16.8/lib/validators.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-state@2.16.8/lib/Config.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-state@2.16.8/lib/State.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-state@2.16.8/lib/all/state.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/CompatibilityEventProxy.es.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-component@2.16.8/lib/events/events.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-component@2.16.8/lib/sync/sync.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-component@2.16.8/lib/ComponentDataManager.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-component@2.16.8/lib/ComponentRenderer.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-component@2.16.8/lib/Component.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-component@2.16.8/lib/ComponentRegistry.js&amp;/o/js/resolved-module/frontend-js-metal-web$metal-component@2.16.8/lib/all/component.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/PortletBase.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/DefaultEventHandler.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/toggle_disabled.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/ItemSelectorDialog.es.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/loading-indicator@3.2.0/lib/index.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.8.0/lib/Body.js"></script><script src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.8.0/lib/Context.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.8.0/lib/Footer.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.8.0/lib/Header.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.8.0/lib/Hook.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.8.0/lib/types.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.8.0/lib/Modal.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.8.0/lib/useModal.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.8.0/lib/Provider.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/modal@3.8.0/lib/index.js&amp;/o/js/resolved-module/frontend-js-react-web$classnames@2.2.6/index.js&amp;/o/js/resolved-module/frontend-js-react-web$prop-types@15.7.2/lib/ReactPropTypesSecret.js&amp;/o/js/resolved-module/frontend-js-react-web$prop-types@15.7.2/factoryWithThrowingShims.js&amp;/o/js/resolved-module/frontend-js-react-web$prop-types@15.7.2/index.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/modal/Modal.scss.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/navigate.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/modal/Modal.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.28.0/lib/Checkbox.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.28.0/lib/SelectBox.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.28.0/lib/DualListBox.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.28.0/lib/Form.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.28.0/lib/Input.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.28.0/lib/Radio.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.28.0/lib/RadioGroup.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.28.0/lib/Select.js"></script><script src="/combo/?browserId=chrome&amp;minifierType=&amp;languageId=en_US&amp;b=7307&amp;t=1623376995526&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.28.0/lib/SelectWithOption.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.28.0/lib/Toggle.js&amp;/o/js/resolved-module/@frontend-taglib-clay$clayui/form@3.28.0/lib/index.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/modal/components/SimpleInputModal.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/modal/commands/OpenSimpleInputModal.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/get_portlet_namespace.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/portlet_url/create_portlet_url.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/portlet_url/create_action_url.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/portlet_url/create_render_url.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/portlet_url/create_resource_url.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/fetch.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/session.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/throttle.es.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/add_params.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/get_dom.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/get_element.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/in_browser_view.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/focus_form_field.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/get_portlet_id.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/is_phone.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/is_tablet.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/liferay/util/normalize_friendly_url.js&amp;/o/js/resolved-module/frontend-js-web@4.0.42/index.es.js&amp;/o/js/resolved-module/remote-app-support-web@1.0.5/index.js"></script><link rel="stylesheet" type="text/css" href="/o/frontend-js-web/liferay/modal/Modal.css"></head>
+
+<body class="chrome controls-visible  yui3-skin-sam signed-out public-page site"><div class="idsk-cookie-banner" aria-label="Cookies na stránke www.mzv.sk">
+                                    <div class="govuk-width-container">
+                                        <div class="govuk-grid-row">
+                                            <div class="govuk-grid-column-two-thirds">
+                                                <h2 class="govuk-heading-m">Cookies on website www.mzv.sk</h2>
+                                                <p>We use basic cookies to ensure page functionality.</p>
+                                                <p>We alse use analytical cookies and 3rd party cookies, you can agree by accepting all cookies.</p>
+                                            </div>
+                                            
+                                        </div>
+
+                                        <div class="idsk-button-group">
+                                            <button type="button" class="idsk-button" data-module="idsk-button" onclick="localStorage.setItem('cookieBannerAccepted', 'all');location.reload();">
+                                                Accept all
+                                            </button>
+                                            <button type="button" class="idsk-button" data-module="idsk-button" onclick="localStorage.setItem('cookieBannerAccepted', 'basic');location.reload();">
+                                                Basic only
+                                            </button>
+                                            <a class="govuk-link" href="/en/web/en/cookies" title="More info">More info</a>
+                                        </div>
+                                    </div>
+                                </div>
+<div id="fb-root"></div>
+
+<div id="socialMediaAndAnalyticsScripts"><!-- Placeholder pre skripty --></div>
+
+<dialog id="mzv-info-msg-dialog" tabindex="-1">
+    <div class="mzv-info-msg-dialog-text-content"></div>
+    <button type="button" class="idsk-button mzv-info-msg-dialog-confirm-btn"></button>
+</dialog>
+
+<script>
+	var cookiesSettings = localStorage.getItem('cookieBannerAccepted');
+	if (cookiesSettings === 'all') {
+		const fbScriptExists = document.getElementById('facebookInitScript');
+		const twInitScript = document.getElementById('twitterInitScript');
+		const gaInitScript = document.getElementById('gaInitScript');
+
+		const socialMediaScripts = document.getElementById('socialMediaAndAnalyticsScripts');
+
+		if (!fbScriptExists) {
+			const fbScript = document.createElement('script');
+			fbScript.src = 'https://connect.facebook.net/sk_SK/sdk.js#xfbml=1&version=v12.0';
+			fbScript.crossorigin='anonymous';
+			fbScript.id='facebookInitScript';
+			socialMediaScripts.appendChild(fbScript);
+		}
+
+		if (!twInitScript) {
+			const twScript = document.createElement('script');
+			twScript.src='https://platform.twitter.com/widgets.js';
+			twScript.type='text/javascript';
+			twScript.id='twitterInitScript';
+			socialMediaScripts.appendChild(twScript);
+		}
+
+		const googleAnalyticsId = "UA-11731567-1".trim();
+
+		if (!gaInitScript && googleAnalyticsId) {
+			const gaScript = document.createElement('script');
+			gaScript.src='https://www.google-analytics.com/analytics.js';
+			gaScript.async=true;
+			gaScript.id='gaInitScript';
+			socialMediaScripts.appendChild(gaScript);
+
+			const gaInitScript = document.createElement('script');
+			gaInitScript.innerHTML = `
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', 'UA-11731567-1', 'auto');
+ga('send', 'pageview');
+`;
+			socialMediaScripts.appendChild(gaInitScript);
+		}
+	}
+</script>
+
+<!--
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<nav aria-label="Quick Links" class="quick-access-nav" id="bxob_quickAccessNav">
+		<h1 class="hide-accessible">Navigation</h1>
+
+		<ul>
+			
+				<li><a href="#main-content">Skip to Content</a></li>
+			
+
+			
+		</ul>
+	</nav>
+-->
+	<a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="d-flex flex-column min-vh-100">
+
+	<div class="d-flex flex-column flex-fill" id="wrapper">
+			<div class="tricolorLine"></div>
+			<header id="banner">
+				<div class="navbar navbar-classic navbar-expand-md navbar-light pb-3 top_navigation">
+					<div class="container-fluid container-fluid-max-xl">
+						<div class="top-nav-bar">
+							Official website of the
+							<a href="https://www.slovensko.sk/"> Slovak public administration</a>
+						</div>
+							<div class="language-bar">
+								<label class="label-hidden" for="languageSelect">
+									Vyberte jazyk
+								</label>
+								<select class="language-select" id="languageSelect" name="languageSelect" onchange="location = this.value;">
+									<option value="https://www.mzv.sk/sk/web/sk">Slovenčina</option>
+									<option value="https://www.mzv.sk/en/web/en" selected="">English</option>
+								</select>
+							</div>
+					</div>
+				</div>
+				<div class="navbar navbar-classic navbar-top py-3">
+					<div class="container-fluid container-fluid-max-xl user-personal-bar">
+						<div class="align-items-center autofit-row">
+								<a class="logo custom-logo enClass align-items-center d-md-inline-flex d-sm-none d-none logo-md" href="https://www.mzv.sk/en/web/en" title="Go to ">
+								<img alt="Anglicka verzia sidla MZV" class="mr-2" height="56" src="/image/layout_set_logo?img_id=16400757&amp;t=1781394782499">
+
+							</a>
+
+
+							<div class="autofit-col autofit-col-expand">
+							</div>
+							<script>
+								var search_input = document.querySelector("input.form-control.input-group-inset.input-group-inset-after.search-bar-keywords-input");
+								if (search_input) {
+									search_input.placeholder = "Zadajte hľadaný výraz";
+								}								
+							</script>
+						</div>
+					</div>
+				</div>
+
+				<div class="idsk-header-web__nav--divider"></div>
+				
+				<div class="navbar navbar-classic navbar-expand-md navbar-light pb-3 main-navigation">
+					<div class="container-fluid container-fluid-max-xl">
+						
+						<a class="logo custom-logo align-items-center d-inline-flex d-md-none logo-xs" href="https://www.mzv.sk/en/web/en" rel="nofollow">
+							<img alt="Anglicka verzia sidla MZV" class="mr-2" height="56" src="/image/layout_set_logo?img_id=16400757&amp;t=1781394782499">
+
+						</a>
+
+
+	<button aria-controls="navigationCollapse" aria-expanded="false" aria-label="Button for opening and closing menu" class="navbar-toggler navbar-toggler-right collapsed" data-target="#navigationCollapse" data-toggle="liferay-collapse" type="button">
+		<!--span class="navbar-toggler-icon"></span-->
+		<span></span>
+		<span></span>
+		<span></span>
+	</button>
+
+	<div class="collapse navbar-collapse" id="navigationCollapse">
+	
+	
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	<div class="portlet-boundary portlet-boundary_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_  portlet-static portlet-static-end portlet-barebone portlet-navigation " id="p_p_id_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_">
+		<span id="p_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet"></span>
+
+
+
+
+	
+
+	
+		
+			
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+	
+	
+		
+<section class="portlet" id="portlet_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet">
+
+
+	<div class="portlet-content">
+
+
+		
+			<div class=" portlet-content-container">
+				
+
+
+	<div class="portlet-body">
+
+
+
+	
+		
+			
+			
+				
+					
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+				
+
+				
+					
+					
+						
+
+
+	
+
+		
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+		
+
+		
+			
+				
+
+<script>
+	var subLevelCheck = 0;
+
+    function _isSmallScreen() {
+        return $(window).width() < 769;
+    }
+
+    function _isFocusedInside(parentElement) {
+        return parentElement.contains(document.activeElement);
+    }
+
+    function _displayElement(element) {
+        element.classList.remove("is-hidden");
+    }
+
+    function _hideElement(element) {
+        element.classList.add("is-hidden");
+    }
+
+    function _activateElement(element) {
+        element.classList.remove("is-inactive");
+    }
+
+    function _inactivateElement(element) {
+        if (_couldBeInactivated(element)) {
+            element.classList.add("is-inactive");
+        }
+    }
+
+    function _selectElement(element) {
+        element.classList.add("selected");
+    }
+    
+    function _unselectElement(element) {
+        element.classList.remove("selected");
+    }
+
+    function _isSelected(element) {
+        return element.classList.contains("selected");
+    }
+
+    function _hasChildren(element) {
+        return element.classList.contains("has-children");
+    }
+
+    function _couldBeInactivated(element) {
+        return !element.classList.contains("cannot-be-inactivated");
+    }
+
+    function _getIdForCss(element) {
+        return element.id.replaceAll("_", "-");
+    }
+
+    function _showOwerlay() {
+        var cookieBanner = document.querySelector("." + "idsk-cookie-banner");
+        if (cookieBanner) {
+            cookieBanner.classList.add("is-hidden");
+        }
+        document.querySelector("body").classList.add("main-nav-overflow-hidden");
+    }
+
+    function _hideOwerlay() {
+        var cookieBanner = document.querySelector("." + "idsk-cookie-banner");
+        if (cookieBanner) {
+            cookieBanner.classList.remove("is-hidden");
+        }
+        document.querySelector("body").classList.remove("main-nav-overflow-hidden");
+    }
+
+    function _getNavItemChildren(element) {
+        return document.querySelectorAll("." + _getIdForCss(element) + "-nav-child");
+    }
+
+    function _deselectElementAndHideItsChildren(navItems, inactivateChildren = false) {
+        // deselect previously selected and hide its children
+        for (const navItem of navItems) {
+            if (!inactivateChildren) {
+                _inactivateElement(navItem);
+            }
+            if (_isSelected(navItem)) {
+                _unselectElement(navItem);
+                if (_hasChildren(navItem)) {
+                    let _unselectedNavChildItems = _getNavItemChildren(navItem);
+                    for (const childNavItem of _unselectedNavChildItems) {
+                        _hideElement(childNavItem);
+                        if (inactivateChildren) {
+                            _inactivateElement(childNavItem);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    function _getSmallScreenToggleBtn () {
+        return document.querySelector(".navbar button.navbar-toggler[aria-controls='navigationCollapse']");
+    }
+
+    function _getLastNavMenuFocusableElements () {
+        return document.querySelectorAll(".nav-item-main-level:last-of-type > button, .nav-item-main-level:last-of-type > a, .nav-item-main-level:last-of-type .main-nav-sec-container:not(.is-hidden) a, .nav-item-main-level:last-of-type .main-nav-sec-container:not(.is-hidden) button:not(.main-nav-back-btn)");
+    }
+
+    function _getFirstNavMenuFocusableElement () {
+        return document.querySelector(".nav-item-main-level > button");
+    }
+
+    function _getFirstNavMenuFocusableElementMobileView () {
+        return document.querySelector("button.navbar-toggler.navbar-toggler-right[aria-controls='navigationCollapse']");
+    }
+
+    function _getLastNavMenuFocusableElementMobileView () {
+        var allMainLvlFocusable = document.querySelectorAll(".nav-item-main-level > button, .nav-item-main-level > a");
+        return allMainLvlFocusable[allMainLvlFocusable.length -1];
+    }
+
+    function _trapFocusInsideMainMenuMobileView (event) {
+        if (event.key === "Escape") {
+			// close menu on escape
+			onCloseNav();
+  		} else if (_isSmallScreen() && event.key === "Tab") {
+            var smallScreenToggleBtn = _getSmallScreenToggleBtn();
+            if (event.target == smallScreenToggleBtn || _isFocusedInside(document.getElementById("portlet_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet"))) {
+                var navCollapse = document.getElementById("navigationCollapse");
+                if (navCollapse.classList.contains("show")) {
+                    var subsection = navCollapse.querySelector(".main-nav-sec-container:not(.is-hidden)");
+
+                    if (subsection) {
+                        // sublevel opened - focus trap active
+                        event.preventDefault(); // Prevent default tab behavior
+                        
+                        var secondLevelActive = subsection.querySelectorAll("li:not(.nav-item-sub-level.is-hidden) > button[aria-expanded='true']").length > 0;
+
+                        if (secondLevelActive) {
+                            var expandedParentButton = document.querySelector("nav li.nav-item-main-level.selected div.main-nav-children-content ul.idsk-header-extended__navigation button[aria-expanded='true']");
+                            var focusableSubsecBtns = expandedParentButton.parentElement.parentElement.parentElement.parentElement.querySelectorAll('.main-nav-back-btn, .main-nav-close-btn');
+                            var focusableSubsecAnchors = expandedParentButton.parentElement.querySelectorAll("ul a");
+                            var subsecFocusableElements = Array.from(focusableSubsecBtns).concat(Array.from(focusableSubsecAnchors));
+                        } else {
+                            var subsectionFocusableElements = subsection.querySelectorAll('.main-nav-back-btn, .main-nav-close-btn, li.nav-item-second-level:not(.is-hidden) > a, li.nav-item-sub-level:not(.is-hidden) > button');
+                            var subsecFocusableElements = Array.from(subsectionFocusableElements); // Convert NodeList to Array
+                        }
+
+                        var currentIndex = subsecFocusableElements.indexOf(event.target);
+
+                        if (event.shiftKey) {
+                            // Shift + Tab: Move focus to the previous element or wrap to the last element
+                            const prevIndex = (currentIndex === 0) ? subsecFocusableElements.length - 1 : currentIndex - 1;
+                            if (subsecFocusableElements[prevIndex]) {
+                                subsecFocusableElements[prevIndex].focus();
+                            }                            
+                        } else {
+                            // Tab: Move focus to the next element or wrap to the first element
+                            const nextIndex = (currentIndex === subsecFocusableElements.length - 1) ? 0 : currentIndex + 1;
+                            if (subsecFocusableElements[nextIndex]) {
+                                subsecFocusableElements[nextIndex].focus();
+                            } 
+                        }
+
+                    } else {
+                        // only main level opened
+                        var firstFocusableEl = _getFirstNavMenuFocusableElementMobileView();
+                        var lastFocusableEl = _getLastNavMenuFocusableElementMobileView();
+
+                        if (event.shiftKey && event.target == firstFocusableEl) {
+                            event.preventDefault(); // Prevent default tab behavior             
+                            lastFocusableEl.focus();
+                        } else if (!event.shiftKey && event.target == lastFocusableEl) {
+                            event.preventDefault(); // Prevent default tab behavior
+                            firstFocusableEl.focus();
+                        }
+                    }
+                } else {
+                    // menu is not open anymore, cancel event listener
+                    document.removeEventListener("keydown", _trapFocusInsideMainMenuMobileView);
+                }
+            } else {
+                onCloseNav();
+            }
+        }
+    }
+
+    function _trapFocusInsideMainMenuDesktopView (event) {
+        if (event.key === "Escape") {
+			// close menu on escape
+			onCloseNav();
+  		} else if (!_isSmallScreen() && event.key === "Tab") {
+            if (document.querySelector(".main-nav-overflow-hidden") !== null) {
+                // desktop view
+                if (_isFocusedInside(document.getElementById("portlet_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet"))) {
+                    var focusableElements = _getLastNavMenuFocusableElements();
+                    var firstFocusableEl = _getFirstNavMenuFocusableElement();
+                    var lastFocusableEl = focusableElements[focusableElements.length -1];
+
+                    if (event.shiftKey && event.target == firstFocusableEl || !event.shiftKey && event.target == lastFocusableEl) {
+                        onCloseNav();
+                    }
+                } else {
+                    // focus out of menu
+                    onCloseNav();
+                }
+            } else {
+                // menu is not open anymore, cancel event listener
+                document.removeEventListener("keydown", _trapFocusInsideMainMenuDesktopView);
+            }
+        }
+    }
+
+    function _selectElementAndShowItsChildren(element, activate = false) {
+        // mark element as selected and show its children
+        _selectElement(element);
+        let elBtn = element.querySelector("button.idsk-header-extended__link");
+        if (elBtn) {
+            elBtn.setAttribute('aria-expanded', true);
+        }
+        if (activate) {
+            _activateElement(element);
+        }        
+        let _selectedNavChildItems = _getNavItemChildren(element);
+        for (const childNavItem of _selectedNavChildItems) {
+            _displayElement(childNavItem);
+        }
+    }
+
+    function onClickFirstLevel(navItemId) {
+        // remove previous instance of _trapFocusInsideMainMenuDesktopView event listener to only one at the time exist
+        document.removeEventListener("keydown", _trapFocusInsideMainMenuDesktopView);
+
+        // add new instance of _trapFocusInsideMainMenuDesktopView event listener
+        document.addEventListener("keydown", _trapFocusInsideMainMenuDesktopView);
+
+        let element = document.getElementById(navItemId);
+        
+        if (_isSelected(element)) {
+            onCloseNav();
+        } else {
+            _showOwerlay();
+            let navItems = document.querySelectorAll(".idsk-header-extended__navigation-item");
+            _deselectElementAndHideItsChildren(navItems, true);
+            _selectElementAndShowItsChildren(element);
+        }
+		
+        var smScr_extendedNav = document.querySelector("nav ul.idsk-header-extended__navigation");
+		if (_isSmallScreen()){
+			//document.querySelector(".main-navigation nav").style.background="#003078";
+            if (smScr_extendedNav) {
+                smScr_extendedNav.style.transform="translateX(-100%)";
+            }
+		} else if (smScr_extendedNav) {
+            smScr_extendedNav.removeAttribute("style");
+        }
+		subLevelCheck = 1;
+
+        event.stopPropagation();
+    }
+
+    function unexpandAll() {
+        document.querySelectorAll("nav li.nav-item-main-level button[aria-expanded='true']").forEach(
+            function(el) {
+                el.setAttribute('aria-expanded', false);
+            }
+        );
+    }
+
+    function unexpandFirstLevel() {
+        var el = document.querySelector("nav li.nav-item-main-level.selected button[aria-expanded='true']");
+        if (el) {
+            el.setAttribute('aria-expanded', false);
+            if (el.parentElement && _isSelected(el.parentElement)) {
+                _unselectElement(el.parentElement);
+            }
+        }
+    }
+
+    function unexpandSecondLevel() {
+        document.querySelectorAll("nav li.nav-item-main-level.selected div.main-nav-children-content button[aria-expanded='true']").forEach(
+            function(el) {
+                el.setAttribute('aria-expanded', false);
+            }
+        );
+    }
+
+    function onClickSecondLevel(navItemId) {
+        let element = document.getElementById(navItemId);
+        
+        // if it is selected, close subsection
+        if (_isSelected(element)) {
+            unexpandSecondLevel();
+            let elementsToUnselect = document.querySelectorAll(".nav-item-sub-level");
+            _deselectElementAndHideItsChildren(elementsToUnselect);
+        } else if (!_isSelected(element)) {
+            unexpandSecondLevel();
+            let elementsToUnselect = document.querySelectorAll(".nav-item-sub-level");
+            _deselectElementAndHideItsChildren(elementsToUnselect);
+            _selectElementAndShowItsChildren(element, true);
+        } else if (_isSmallScreen()) {
+            let elBtn = element.querySelector("button.idsk-header-extended__link");
+            if (elBtn) {
+                elBtn.setAttribute('aria-expanded', true);
+            }
+        }
+		
+        var smScr_extendedChildNav = document.querySelector("nav li.nav-item-main-level.selected div.main-nav-children-content ul.idsk-header-extended__navigation");
+		if (_isSmallScreen()){
+           
+            if (smScr_extendedChildNav) {
+                smScr_extendedChildNav.style.visibility="hidden";
+                smScr_extendedChildNav.style.transform="translateX(-100%)";
+                var backBtnToFocus = smScr_extendedChildNav.parentElement.parentElement.querySelector(".main-nav-back-btn");
+                if (backBtnToFocus) {
+                    backBtnToFocus.focus();
+                }
+            }
+		}
+		subLevelCheck = 2;
+
+        var smScr_extendedChildNav_firstEl = smScr_extendedChildNav.querySelector("li");
+        if (smScr_extendedChildNav_firstEl) {
+            smScr_extendedChildNav_firstEl.scrollIntoView();
+        }
+
+        event.stopPropagation();
+    }
+	
+	function onBackNav() {
+		if(subLevelCheck == 1){
+            var firstLevelActiveElement = document.querySelector("nav ul.idsk-header-extended__navigation .nav-item-main-level.selected button");
+            unexpandFirstLevel();
+
+            var smScr_extendedNav = document.querySelector("nav ul.idsk-header-extended__navigation");
+            if (smScr_extendedNav) {
+                smScr_extendedNav.style.transform="translateX(0%)";
+            }
+
+            _hideOwerlay();
+
+			subLevelCheck = 0;
+            var subsection = document.querySelector("#navigationCollapse .main-nav-sec-container:not(.is-hidden)");
+            if (subsection) {
+                _hideElement(subsection);
+            }
+
+            setTimeout(() => {
+                if (firstLevelActiveElement) {
+                    firstLevelActiveElement.focus();
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                }                
+            }, 0);
+            
+		}
+		if(subLevelCheck == 2){
+            unexpandSecondLevel();
+
+            var smScr_extendedChildNav = document.querySelector("nav li.nav-item-main-level.selected div.main-nav-children-content ul.idsk-header-extended__navigation");
+            if (smScr_extendedChildNav) {
+                smScr_extendedChildNav.style.transform="translateX(0%)";
+                smScr_extendedChildNav.style.visibility="visible";
+            }
+
+            var prevSelectedElement = document.querySelector(".nav-item-second-level.selected");
+            if (prevSelectedElement) {
+                setTimeout(() => {
+                    _unselectElement(prevSelectedElement);
+                    var prevSelectedElementBtn = prevSelectedElement.querySelector("button");
+                    if (prevSelectedElementBtn) {
+                        prevSelectedElementBtn.setAttribute('aria-expanded', false);
+                        prevSelectedElementBtn.focus();
+                        prevSelectedElementBtn.scrollIntoView();
+                    }
+                }, 0);
+            }
+
+			subLevelCheck = 1;
+		}
+	}
+
+    function prepareToCloseNav() {
+        unexpandAll();
+
+        // for small screen
+        var smScr_extendedChildNav = document.querySelector("nav li.nav-item-main-level.selected div.main-nav-children-content ul.idsk-header-extended__navigation");
+        if (smScr_extendedChildNav) {
+            smScr_extendedChildNav.style.transform="translateX(0%)";
+            smScr_extendedChildNav.style.visibility="visible";
+        }
+		
+		subLevelCheck = 0;
+        let elementsToUnselect = document.querySelectorAll(".idsk-header-extended__navigation-item");
+        let elementsToHide = document.querySelectorAll(".nav-item-sub-level");
+
+        for (const element of elementsToUnselect) {
+            _unselectElement(element);
+        }
+
+        for (const element of elementsToHide) {
+            _hideElement(element);
+            _inactivateElement(element);
+        }
+
+        _hideOwerlay();
+
+        // for small screen
+        var smScr_selectedNav = document.querySelector("div.main-nav-children-content li.selected ul.idsk-header-extended__navigation");
+        if (smScr_selectedNav) {
+            smScr_selectedNav.style.transform="translateX(0%)";
+        }
+        var smScr_nav = document.querySelector("div.main-nav-children-content ul.idsk-header-extended__navigation");
+        if (smScr_nav) {
+            smScr_nav.style.visibility="visible";
+        }
+
+		var smScr_extendedNav = document.querySelector("nav ul.idsk-header-extended__navigation");
+        if (smScr_extendedNav) {
+            smScr_extendedNav.style.transform="translateX(0%)";
+        }
+    }
+
+    function onCloseNav() {
+        prepareToCloseNav();
+
+        var smallScreenToggleBtn = _getSmallScreenToggleBtn();
+        if(smallScreenToggleBtn && smallScreenToggleBtn.getAttribute('aria-expanded') === 'true') {
+            smallScreenToggleBtn.click();
+        }
+			
+        document.removeEventListener("keydown", _trapFocusInsideMainMenuMobileView);
+        document.removeEventListener("keydown", _trapFocusInsideMainMenuDesktopView);
+
+        event.stopPropagation();
+    }
+
+    function _handleSmallScreenToggleBtnCallback (button) {
+        if (button.getAttribute('aria-expanded') === 'true') {
+            prepareToCloseNav();
+            document.removeEventListener("keydown", _trapFocusInsideMainMenuMobileView);
+        } else {
+            document.addEventListener("keydown", _trapFocusInsideMainMenuMobileView);
+        }
+    }
+
+    function _onSmallToggleClick(event) {
+        _handleSmallScreenToggleBtnCallback(event.currentTarget);
+    }
+
+    AUI().ready(() => {
+        function attachHandler() {
+            var smallScreenToggleBtn = _getSmallScreenToggleBtn();
+            if (!smallScreenToggleBtn) return;
+            smallScreenToggleBtn.removeEventListener("click", _onSmallToggleClick);
+            smallScreenToggleBtn.addEventListener("click", _onSmallToggleClick);
+        }
+
+        attachHandler(); // load
+
+        window.addEventListener('resize', function() {
+            onCloseNav();
+            attachHandler();
+        });
+    });    
+
+</script>
+
+
+    <nav>
+		<ul class="idsk-header-extended__navigation">
+
+
+
+
+
+
+				<li id="tree_nav_item_1_0" class="idsk-header-extended__navigation-item  has-children nav-item-main-level">
+
+                        <button class="idsk-header-extended__link" type="button" aria-expanded="false" onclick="onClickFirstLevel(&quot;tree_nav_item_1_0&quot;)">
+                            Ministry
+                        </button>
+
+                            <ul class="main-nav-sec-container idsk-header-extended__navigation-item tree-nav-item-1-0-nav-child cannot-be-inactivated nav-item-sub-level is-hidden">
+                                <li class="main-nav-children-container">
+                                    <p class="main-nav-panel-header">
+                                        <span>
+                                            Ministry
+                                        </span>
+                                    </p>
+									<button class="main-nav-back-btn" onclick="onBackNav()">Back</button>
+                                    <button class="main-nav-close-btn navbar-toggler navbar-toggler-right collapsed" onclick="onCloseNav()" aria-controls="navigationCollapse" aria-label="Close menu" data-target="#navigationCollapse" data-toggle="liferay-collapse"></button>
+                                    <div class="main-nav-children-content" tabindex="-1">
+
+		<ul class="idsk-header-extended__navigation">
+
+
+
+
+
+
+				<li id="tree_0_nav_item_2_0" class="idsk-header-extended__navigation-item tree-nav-item-1-0-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/what-we-do">
+                                What we do
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_nav_item_2_1" class="idsk-header-extended__navigation-item tree-nav-item-1-0-nav-child has-children nav-item-sub-level is-hidden is-inactive nav-item-second-level">
+
+                        <button class="idsk-header-extended__link" type="button" aria-expanded="false" onclick="onClickSecondLevel(&quot;tree_0_nav_item_2_1&quot;)">
+                            Who we are
+                        </button>
+
+
+		<ul class="idsk-header-extended__navigation">
+
+
+
+
+
+
+				<li id="tree_0_1_nav_item_3_0" class="idsk-header-extended__navigation-item tree-0-nav-item-2-1-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/who-we-are/minister">
+                                Minister
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_1_nav_item_3_1" class="idsk-header-extended__navigation-item tree-0-nav-item-2-1-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/who-we-are/state-secretary-1">
+                                State Secretary 1
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_1_nav_item_3_2" class="idsk-header-extended__navigation-item tree-0-nav-item-2-1-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/who-we-are/state-secretary-2">
+                                State Secretary 2
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_1_nav_item_3_3" class="idsk-header-extended__navigation-item tree-0-nav-item-2-1-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/who-we-are/secretary-general">
+                                Secretary General
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_1_nav_item_3_4" class="idsk-header-extended__navigation-item tree-0-nav-item-2-1-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/who-we-are/organization-chart">
+                                Organization Chart
+                            </a>
+
+
+				</li>
+
+		</ul>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_nav_item_2_2" class="idsk-header-extended__navigation-item tree-nav-item-1-0-nav-child has-children nav-item-sub-level is-hidden is-inactive nav-item-second-level">
+
+                        <button class="idsk-header-extended__link" type="button" aria-expanded="false" onclick="onClickSecondLevel(&quot;tree_0_nav_item_2_2&quot;)">
+                            Slovak Diplomatic Missions
+                        </button>
+
+
+		<ul class="idsk-header-extended__navigation">
+
+
+
+
+
+
+				<li id="tree_0_2_nav_item_3_0" class="idsk-header-extended__navigation-item tree-0-nav-item-2-2-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/slovak-diplomatic-missions/diplomatic-missions-of-the-slovak-republic">
+                                Diplomatic Missions of the Slovak Republic
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_2_nav_item_3_1" class="idsk-header-extended__navigation-item tree-0-nav-item-2-2-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/slovak-diplomatic-missions/slovak-envoys">
+                                Slovak Envoys
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_2_nav_item_3_2" class="idsk-header-extended__navigation-item tree-0-nav-item-2-2-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/slovak-diplomatic-missions/diplomatic-ranks">
+                                Diplomatic Ranks
+                            </a>
+
+
+				</li>
+
+		</ul>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_nav_item_2_3" class="idsk-header-extended__navigation-item tree-nav-item-1-0-nav-child has-children nav-item-sub-level is-hidden is-inactive nav-item-second-level">
+
+                        <button class="idsk-header-extended__link" type="button" aria-expanded="false" onclick="onClickSecondLevel(&quot;tree_0_nav_item_2_3&quot;)">
+                            Diplomatic Guide
+                        </button>
+
+
+		<ul class="idsk-header-extended__navigation">
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_0" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/system-of-protocol-in-the-slovak-republic">
+                                System of Protocol in the Slovak Republic
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_1" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/the-inaugural-audience-ceremony-of-ambassador">
+                                The Inaugural Audience Ceremony of Ambassador
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_2" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/the-diplomatic-corps-list">
+                                The Diplomatic Corps List
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_3" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/long-term-visa">
+                                Long-term Visa
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_4" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/registration-of-persons-accredited-in-the-slovak-republic-and-issuance-of-identification-cards">
+                                Registration of Persons Accredited in the Slovak Republic and Issuance of Identification Cards
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_5" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/requesting-for-a-slovak-birth-identification-number-rodne-cislo">
+                                Requesting for a&nbsp;Slovak Birth Identification Number (rodné číslo)
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_6" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/entitlement-to-the-exemption-from-import-duty">
+                                Entitlement to the Exemption from Import Duty
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_7" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/entitlement-to-exemption-from-tax">
+                                Entitlement to Exemption from Tax
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_8" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/entitlement-to-value-added-tax-refund">
+                                Entitlement to Value Added Tax Refund
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_9" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/entitlement-to-the-refund-of-excise-duty-on-electricity-coal-and-natural-gas">
+                                Entitlement to the refund of excise duty on electricity, coal, and natural gas
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_10" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/registration-of-motor-vehicles-of-diplomatic-missions">
+                                Registration of Motor Vehicles of Diplomatic Missions
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_11" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/driving-licence">
+                                Driving licence
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_12" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/employment-of-relatives-of-the-staff-of-diplomatic-missions">
+                                Employment of Relatives of the Staff of Diplomatic Missions
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_13" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/protection-and-security">
+                                Protection and Security
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_14" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/diplomatic-clearance-for-overflights-and-landings">
+                                Diplomatic clearance for Overflights and Landings
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_15" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/permits-to-enter-the-landing-area-of-the-bratislava-airport">
+                                Permits to Enter the Landing Area of the Bratislava Airport
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_16" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/property-management-and-services-for-diplomatic-corps">
+                                Property Management and Services for Diplomatic Corps
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_3_nav_item_3_17" class="idsk-header-extended__navigation-item tree-0-nav-item-2-3-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/diplomatic-guide/international-schools-in-bratislava">
+                                International Schools in Bratislava
+                            </a>
+
+
+				</li>
+
+		</ul>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_nav_item_2_4" class="idsk-header-extended__navigation-item tree-nav-item-1-0-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/cultural-diplomacy">
+                                Cultural Diplomacy
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_nav_item_2_5" class="idsk-header-extended__navigation-item tree-nav-item-1-0-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/publications">
+                                Publications
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_nav_item_2_6" class="idsk-header-extended__navigation-item tree-nav-item-1-0-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/annual-report">
+                                Annual Report
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_0_nav_item_2_7" class="idsk-header-extended__navigation-item tree-nav-item-1-0-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/ministry/privacy-protection-policy">
+                                Privacy protection policy
+                            </a>
+
+
+				</li>
+
+		</ul>
+
+                                    </div>
+                                </li>
+                            </ul>
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_nav_item_1_1" class="idsk-header-extended__navigation-item  has-children nav-item-main-level nav-item-main-level-selected-descendant">
+
+                        <button class="idsk-header-extended__link" type="button" aria-expanded="false" onclick="onClickFirstLevel(&quot;tree_nav_item_1_1&quot;)">
+                            Visa and Services
+                        </button>
+
+                            <ul class="main-nav-sec-container idsk-header-extended__navigation-item tree-nav-item-1-1-nav-child cannot-be-inactivated nav-item-sub-level is-hidden">
+                                <li class="main-nav-children-container">
+                                    <p class="main-nav-panel-header">
+                                        <span>
+                                            Visa and Services
+                                        </span>
+                                    </p>
+									<button class="main-nav-back-btn" onclick="onBackNav()">Back</button>
+                                    <button class="main-nav-close-btn navbar-toggler navbar-toggler-right collapsed" onclick="onCloseNav()" aria-controls="navigationCollapse" aria-label="Close menu" data-target="#navigationCollapse" data-toggle="liferay-collapse"></button>
+                                    <div class="main-nav-children-content" tabindex="-1">
+
+		<ul class="idsk-header-extended__navigation">
+
+
+
+
+
+
+				<li id="tree_1_nav_item_2_0" class="idsk-header-extended__navigation-item tree-nav-item-1-1-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/visa-and-services/schengen-visa">
+                                Schengen visa
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_1_nav_item_2_1" class="idsk-header-extended__navigation-item tree-nav-item-1-1-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/visa-and-services/national-visa">
+                                National visa
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_1_nav_item_2_2" class="idsk-header-extended__navigation-item tree-nav-item-1-1-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/visa-and-services/foreign-students-in-slovakia">
+                                Foreign students in Slovakia
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_1_nav_item_2_3" class="idsk-header-extended__navigation-item tree-nav-item-1-1-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/visa-and-services/visa-application-forms">
+                                Visa application forms
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_1_nav_item_2_4" class="idsk-header-extended__navigation-item tree-nav-item-1-1-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/visa-and-services/residence-of-foreigners-in-territory-of-slovakia">
+                                Residence of Foreigners in Territory of Slovakia
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_1_nav_item_2_5" class="idsk-header-extended__navigation-item tree-nav-item-1-1-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/visa-and-services/slovak-honorary-consulates-abroad">
+                                Slovak Honorary Consulates Abroad
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_1_nav_item_2_6" class="idsk-header-extended__navigation-item tree-nav-item-1-1-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/visa-and-services/petitions-and-complaints">
+                                Petitions and complaints
+                            </a>
+
+
+				</li>
+
+		</ul>
+
+                                    </div>
+                                </li>
+                            </ul>
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_nav_item_1_2" class="idsk-header-extended__navigation-item  has-children nav-item-main-level">
+
+                        <button class="idsk-header-extended__link" type="button" aria-expanded="false" onclick="onClickFirstLevel(&quot;tree_nav_item_1_2&quot;)">
+                            Diplomacy
+                        </button>
+
+                            <ul class="main-nav-sec-container idsk-header-extended__navigation-item tree-nav-item-1-2-nav-child cannot-be-inactivated nav-item-sub-level is-hidden">
+                                <li class="main-nav-children-container">
+                                    <p class="main-nav-panel-header">
+                                        <span>
+                                            Diplomacy
+                                        </span>
+                                    </p>
+									<button class="main-nav-back-btn" onclick="onBackNav()">Back</button>
+                                    <button class="main-nav-close-btn navbar-toggler navbar-toggler-right collapsed" onclick="onCloseNav()" aria-controls="navigationCollapse" aria-label="Close menu" data-target="#navigationCollapse" data-toggle="liferay-collapse"></button>
+                                    <div class="main-nav-children-content" tabindex="-1">
+
+		<ul class="idsk-header-extended__navigation">
+
+
+
+
+
+
+				<li id="tree_2_nav_item_2_0" class="idsk-header-extended__navigation-item tree-nav-item-1-2-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/documents">
+                                Documents
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_nav_item_2_1" class="idsk-header-extended__navigation-item tree-nav-item-1-2-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/european-affairs">
+                                European Affairs
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_nav_item_2_2" class="idsk-header-extended__navigation-item tree-nav-item-1-2-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/security-policy">
+                                Security Policy
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_nav_item_2_3" class="idsk-header-extended__navigation-item tree-nav-item-1-2-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/economic-diplomacy">
+                                Economic diplomacy
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_nav_item_2_4" class="idsk-header-extended__navigation-item tree-nav-item-1-2-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomac/slovakia-and-the-un">
+                                Slovakia and the UN
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_nav_item_2_5" class="idsk-header-extended__navigation-item tree-nav-item-1-2-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/international-sanctions">
+                                International sanctions
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_nav_item_2_6" class="idsk-header-extended__navigation-item tree-nav-item-1-2-nav-child has-children nav-item-sub-level is-hidden is-inactive nav-item-second-level">
+
+                        <button class="idsk-header-extended__link" type="button" aria-expanded="false" onclick="onClickSecondLevel(&quot;tree_2_nav_item_2_6&quot;)">
+                            Human Rights
+                        </button>
+
+
+		<ul class="idsk-header-extended__navigation">
+
+
+
+
+
+
+				<li id="tree_2_6_nav_item_3_0" class="idsk-header-extended__navigation-item tree-2-nav-item-2-6-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/human-rights/news">
+                                News
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_6_nav_item_3_1" class="idsk-header-extended__navigation-item tree-2-nav-item-2-6-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/human-rights/un-human-rights-council">
+                                UN Human Rights Council
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_6_nav_item_3_2" class="idsk-header-extended__navigation-item tree-2-nav-item-2-6-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/human-rights/committee-for-human-rights">
+                                Committee for Human Rights
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_6_nav_item_3_3" class="idsk-header-extended__navigation-item tree-2-nav-item-2-6-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/human-rights/current-human-rights-topics">
+                                Current human rights topics
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_6_nav_item_3_4" class="idsk-header-extended__navigation-item tree-2-nav-item-2-6-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/human-rights/where-to-complain-about-human-rights-violation">
+                                Where to complain about human rights violation
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_6_nav_item_3_5" class="idsk-header-extended__navigation-item tree-2-nav-item-2-6-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/human-rights/important-documents-and-human-rights-institutions">
+                                Important documents and Human Rights institutions
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_6_nav_item_3_6" class="idsk-header-extended__navigation-item tree-2-nav-item-2-6-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/human-rights/reports-on-implementation-of-human-rights-treaties">
+                                Reports on implementation of human rights treaties
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_6_nav_item_3_7" class="idsk-header-extended__navigation-item tree-2-nav-item-2-6-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/human-rights/national-minorities-and-protection-of-national-minorities">
+                                National Minorities and Protection of National Minorities
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_6_nav_item_3_8" class="idsk-header-extended__navigation-item tree-2-nav-item-2-6-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/human-rights/slovakia-and-the-task-force-for-international-cooperation-on-holocaust-education-remebrance-and-research">
+                                Slovakia and the Task Force for International Cooperation on Holocaust Education, Remebrance and Research
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_6_nav_item_3_9" class="idsk-header-extended__navigation-item tree-2-nav-item-2-6-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/human-rights/council-of-europe">
+                                Council of Europe
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_6_nav_item_3_10" class="idsk-header-extended__navigation-item tree-2-nav-item-2-6-nav-child nav-item-sub-level is-hidden">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/human-rights/osce">
+                                OSCE
+                            </a>
+
+
+				</li>
+
+		</ul>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_2_nav_item_2_7" class="idsk-header-extended__navigation-item tree-nav-item-1-2-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/diplomacy/slavkov-format">
+                                Slavkov format (S3)
+                            </a>
+
+
+				</li>
+
+		</ul>
+
+                                    </div>
+                                </li>
+                            </ul>
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_nav_item_1_3" class="idsk-header-extended__navigation-item  has-children nav-item-main-level">
+
+                        <button class="idsk-header-extended__link" type="button" aria-expanded="false" onclick="onClickFirstLevel(&quot;tree_nav_item_1_3&quot;)">
+                            Slovakia
+                        </button>
+
+                            <ul class="main-nav-sec-container idsk-header-extended__navigation-item tree-nav-item-1-3-nav-child cannot-be-inactivated nav-item-sub-level is-hidden">
+                                <li class="main-nav-children-container">
+                                    <p class="main-nav-panel-header">
+                                        <span>
+                                            Slovakia
+                                        </span>
+                                    </p>
+									<button class="main-nav-back-btn" onclick="onBackNav()">Back</button>
+                                    <button class="main-nav-close-btn navbar-toggler navbar-toggler-right collapsed" onclick="onCloseNav()" aria-controls="navigationCollapse" aria-label="Close menu" data-target="#navigationCollapse" data-toggle="liferay-collapse"></button>
+                                    <div class="main-nav-children-content" tabindex="-1">
+
+		<ul class="idsk-header-extended__navigation">
+
+
+
+
+
+
+				<li id="tree_3_nav_item_2_0" class="idsk-header-extended__navigation-item tree-nav-item-1-3-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/slovakia/brand-of-the-slovak-republic">
+                                Brand of the Slovak Republic
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_3_nav_item_2_1" class="idsk-header-extended__navigation-item tree-nav-item-1-3-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/slovakia/study-in-slovakia">
+                                Study in Slovakia
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_3_nav_item_2_2" class="idsk-header-extended__navigation-item tree-nav-item-1-3-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/slovakia/public-holidays">
+                                Public holidays
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_3_nav_item_2_3" class="idsk-header-extended__navigation-item tree-nav-item-1-3-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/history">
+                                History
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_3_nav_item_2_4" class="idsk-header-extended__navigation-item tree-nav-item-1-3-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/blog">
+                                Blog
+                            </a>
+
+
+				</li>
+
+		</ul>
+
+                                    </div>
+                                </li>
+                            </ul>
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_nav_item_1_4" class="idsk-header-extended__navigation-item  has-children nav-item-main-level">
+
+                        <button class="idsk-header-extended__link" type="button" aria-expanded="false" onclick="onClickFirstLevel(&quot;tree_nav_item_1_4&quot;)">
+                            News
+                        </button>
+
+                            <ul class="main-nav-sec-container idsk-header-extended__navigation-item tree-nav-item-1-4-nav-child cannot-be-inactivated nav-item-sub-level is-hidden">
+                                <li class="main-nav-children-container">
+                                    <p class="main-nav-panel-header">
+                                        <span>
+                                            News
+                                        </span>
+                                    </p>
+									<button class="main-nav-back-btn" onclick="onBackNav()">Back</button>
+                                    <button class="main-nav-close-btn navbar-toggler navbar-toggler-right collapsed" onclick="onCloseNav()" aria-controls="navigationCollapse" aria-label="Close menu" data-target="#navigationCollapse" data-toggle="liferay-collapse"></button>
+                                    <div class="main-nav-children-content" tabindex="-1">
+
+		<ul class="idsk-header-extended__navigation">
+
+
+
+
+
+
+				<li id="tree_4_nav_item_2_0" class="idsk-header-extended__navigation-item tree-nav-item-1-4-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/what-is-new/all-news">
+                                All news
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_4_nav_item_2_1" class="idsk-header-extended__navigation-item tree-nav-item-1-4-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/what-is-new/european-affairs">
+                                European Affairs
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_4_nav_item_2_2" class="idsk-header-extended__navigation-item tree-nav-item-1-4-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/news/ukraine-in-focus">
+                                Ukraine in Focus
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_4_nav_item_2_3" class="idsk-header-extended__navigation-item tree-nav-item-1-4-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/news/myths-and-facts">
+                                Myths and Facts
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_4_nav_item_2_4" class="idsk-header-extended__navigation-item tree-nav-item-1-4-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/what-is-new/slovak-aid">
+                                Slovak Aid
+                            </a>
+
+
+				</li>
+
+		</ul>
+
+                                    </div>
+                                </li>
+                            </ul>
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_nav_item_1_5" class="idsk-header-extended__navigation-item  has-children nav-item-main-level">
+
+                        <button class="idsk-header-extended__link" type="button" aria-expanded="false" onclick="onClickFirstLevel(&quot;tree_nav_item_1_5&quot;)">
+                            Contact us
+                        </button>
+
+                            <ul class="main-nav-sec-container idsk-header-extended__navigation-item tree-nav-item-1-5-nav-child cannot-be-inactivated nav-item-sub-level is-hidden">
+                                <li class="main-nav-children-container">
+                                    <p class="main-nav-panel-header">
+                                        <span>
+                                            Contact us
+                                        </span>
+                                    </p>
+									<button class="main-nav-back-btn" onclick="onBackNav()">Back</button>
+                                    <button class="main-nav-close-btn navbar-toggler navbar-toggler-right collapsed" onclick="onCloseNav()" aria-controls="navigationCollapse" aria-label="Close menu" data-target="#navigationCollapse" data-toggle="liferay-collapse"></button>
+                                    <div class="main-nav-children-content" tabindex="-1">
+
+		<ul class="idsk-header-extended__navigation">
+
+
+
+
+
+
+				<li id="tree_5_nav_item_2_0" class="idsk-header-extended__navigation-item tree-nav-item-1-5-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/contact/contacts-and-opening-hours-to-public">
+                                Contacts and opening hours to public
+                            </a>
+
+
+				</li>
+
+
+
+
+
+
+
+				<li id="tree_5_nav_item_2_1" class="idsk-header-extended__navigation-item tree-nav-item-1-5-nav-child nav-item-sub-level is-hidden nav-item-second-level">
+
+                            <a class="idsk-header-extended__link" href="https://www.mzv.sk/en/web/en/contact/press-centre">
+                                Press Centre
+                            </a>
+
+
+				</li>
+
+		</ul>
+
+                                    </div>
+                                </li>
+                            </ul>
+
+				</li>
+
+		</ul>
+    </nav>
+
+			
+			
+		
+	
+	
+	
+	
+
+
+	
+	
+
+					
+				
+			
+		
+	
+	
+
+
+
+	</div>
+
+			</div>
+		
+	</div>
+</section>
+	
+
+		
+		
+	
+
+
+
+
+
+
+
+	</div>
+
+
+
+
+
+
+	</div>
+					</div>
+				</div>
+			</header>
+
+		<section class=" flex-fill" id="content">
+			<h2 class="sr-only" role="heading" aria-level="1">National visa - MZV EN</h2>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+	
+
+		
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+	
+		<div class="layout-content portlet-layout" id="main-content" role="main">
+			
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	<div class="">
+
+				
+
+				
+
+					
+
+					
+
+						
+
+						<div class=" mb-lg-0 ml-lg-0 mr-lg-0 mt-lg-0 pb-lg-0 pl-lg-0 pr-lg-0 pt-lg-0" style="box-sizing: border-box;border-style: solid; border-width: 0px;opacity: 1.0;">
+							<div id="fragment-4462-idfh"> <div class="content-container">
+	<div class="content-container-column content-container-content-area">
+		<div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	<div class="">
+
+				
+
+				
+
+					
+
+					
+
+						
+
+						<div class=" mb-lg-0 ml-lg-0 mr-lg-0 mt-lg-0 pb-lg-0 pl-lg-0 pr-lg-0 pt-lg-0" style="box-sizing: border-box;border-style: solid; border-width: 0px;opacity: 1.0;">
+							<div id="fragment-0-dbzm">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	<div class="portlet-boundary portlet-boundary_sk_mzv_portal_breadcrumb_portlet_BreadcrumbPortlet_  portlet-static portlet-static-end portlet-borderless  " id="p_p_id_sk_mzv_portal_breadcrumb_portlet_BreadcrumbPortlet_INSTANCE_dbzm_">
+		<span id="p_sk_mzv_portal_breadcrumb_portlet_BreadcrumbPortlet_INSTANCE_dbzm"></span>
+
+
+
+
+	
+
+	
+		
+			
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+	
+	
+		
+<section class="portlet" id="portlet_sk_mzv_portal_breadcrumb_portlet_BreadcrumbPortlet_INSTANCE_dbzm">
+
+
+	<div class="portlet-content">
+
+
+		
+			<div class=" portlet-content-container">
+				
+
+
+	<div class="portlet-body">
+
+
+
+	
+		
+			
+			
+				
+					
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+				
+
+				
+					
+					
+						
+
+
+	
+
+		
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+    section[id^="portlet_sk_mzv_portal_breadcrumb_portlet_BreadcrumbPortlet_"] {
+        max-width: 960px;
+        margin: 0 auto;
+    }
+
+    section[id^="portlet_sk_mzv_portal_breadcrumb_portlet_BreadcrumbPortlet_"]
+    .portlet-content {
+        padding: 0 !important;
+    }
+
+    .govuk-breadcrumbs {
+        margin-top: 0px;
+    }
+
+    span.breadcrumb-home-logo {
+        display: inline-block;
+        position: absolute;
+        left: 0;
+        vertical-align: text-top;
+        background-color: #0b0c0c;
+        width: 16px;
+        height: 20px;
+        -webkit-mask: url(/o/mzvTheme/images/icons/home_icon.svg) no-repeat center;
+        mask: url(/o/mzvTheme/images/icons/home_icon.svg) no-repeat center;
+        transform: scale(0.75);
+    }
+
+    .govuk-breadcrumbs__list-item:before {
+        border-color: #0b0c0c;
+        top: 3px;
+    }
+
+    .mzv-breadcrumb-list-home-item:before {
+        display: none;
+    }
+
+    .govuk-breadcrumbs__list-item.clickable-breadcrumb-list-item {
+        border: none;
+    }
+
+    .govuk-breadcrumbs__list-item.clickable-breadcrumb-list-item a {
+        border-bottom: solid 1px;
+    }
+
+    .govuk-breadcrumbs__list-item.clickable-breadcrumb-list-item a:hover {
+        outline: 3px solid rgba(0, 0, 0, 0);
+        color: #0b0c0c;
+        box-shadow: 0 3px #0b0c0c;
+        text-decoration: none;
+    }
+
+    .breadcrumb-text-truncate {
+        font-size: 1.1875rem;
+    }
+
+    /*
+    *******************************************
+        For darker backgrounds use this css
+    *******************************************
+        span.breadcrumb-home-logo {
+            background-color: #FFFFFF;
+            display: inline-block;
+            vertical-align: text-top;
+            width: 17px;
+            height: 17px;
+            margin-top: 2px;
+            margin-right: 6px;
+            -webkit-mask: url(/o/mzvTheme/images/icons/home_icon.svg) no-repeat center;
+            mask: url(/o/mzvTheme/images/icons/home_icon.svg) no-repeat center;
+        }
+
+        .govuk-breadcrumbs__list-item .breadcrumb-text-truncate,
+        .govuk-breadcrumbs__list-item a.breadcrumb-text-truncate {
+            color: #FFFFFF;
+        }
+
+        .govuk-breadcrumbs__list-item:before {
+            border-color: #FFFFFF;
+        }
+
+        .govuk-breadcrumbs__link:focus span.breadcrumb-text-truncate {
+            color: #0b0c0c;
+        }
+
+        .govuk-breadcrumbs__list-item.clickable-breadcrumb-list-item {
+            border: none;
+        }
+
+       .govuk-breadcrumbs__list-item.clickable-breadcrumb-list-item a {
+            color: #FFFFFF;
+            border-bottom: solid 1px;
+        }
+
+        .govuk-breadcrumbs__list-item.clickable-breadcrumb-list-item a:hover {
+            outline: 3px solid rgba(255,255,255, 0);
+            color: #FFFFFF;
+            box-shadow: 0 3px #FFFFFF;
+            text-decoration: none;
+        }
+
+        .govuk-breadcrumbs__list-item.clickable-breadcrumb-list-item a:focus {
+            color: #0b0c0c;
+            box-shadow: 0 3px #0b0c0c;
+        }
+    */
+</style>
+
+
+
+
+
+
+
+
+
+
+
+<div class="mzv-breadcrumbs">
+    
+            <div class="govuk-breadcrumbs">
+                <ol class="govuk-breadcrumbs__list">
+                    
+                                    <span class="breadcrumb-home-logo"></span>
+                                    <li class="govuk-breadcrumbs__list-item clickable-breadcrumb-list-item mzv-breadcrumb-list-home-item">
+                                        <a class="govuk-breadcrumbs__link" href="https://www.mzv.sk/en/web/en" title="Home">
+                                            <span class="breadcrumb-text-truncate">Home</span>
+                                        </a>
+                                    </li>
+                        
+                                        <li class="govuk-breadcrumbs__list-item clickable-breadcrumb-list-item">
+                                            <a class="govuk-breadcrumbs__link" href="https://www.mzv.sk/en/web/en/visa-and-services" title="Visa and Services">
+                                                <span class="breadcrumb-text-truncate">Visa and Services</span>
+                                            </a>
+                                        </li>
+                        
+                                    <li class="govuk-breadcrumbs__list-item" aria-current="page">
+                                        <span class="active breadcrumb-text-truncate">National visa</span>
+                                    </li>
+                        
+                </ol>
+            </div>
+    
+</div>
+
+	
+	
+
+					
+				
+			
+		
+	
+	
+
+
+
+	</div>
+
+			</div>
+		
+	</div>
+</section>
+	
+
+		
+		
+	
+
+
+
+
+
+
+
+	</div>
+
+
+
+
+
+
+</div>
+						</div>
+					
+				
+			</div>
+		
+		
+		
+	
+
+
+
+	
+		
+		
+		
+		
+		
+			<div class="">
+
+				
+
+				
+
+					
+
+					
+
+						
+
+						<div class=" mb-lg-0 ml-lg-0 mr-lg-0 mt-lg-0 pb-lg-0 pl-lg-0 pr-lg-0 pt-lg-0" style="box-sizing: border-box;border-style: solid; border-width: 0px;opacity: 1.0;">
+							<div id="fragment-0-blmb"> <h2 class="component-heading mb-0 text-break" data-lfr-editable-id="element-text" data-lfr-editable-type="text">National visa</h2></div><style>.fragment-heading-text-colored a {
+	color: inherit;
+}</style>
+						</div>
+					
+				
+			</div>
+
+</div>
+	</div>
+</div></div>
+						</div>
+					
+				
+			</div>
+		
+		
+		
+	
+
+
+
+	
+		
+		
+		
+		
+		
+			<div class="">
+
+				
+
+				
+
+					
+
+					
+
+						
+
+						<div class=" mb-lg-0 ml-lg-0 mr-lg-0 mt-lg-0 pb-lg-0 pl-lg-0 pr-lg-0 pt-lg-0" style="box-sizing: border-box;border-style: solid; border-width: 0px;opacity: 1.0;">
+							<div id="fragment-4462-prgj"> <div class="content-container">
+	<div class="content-container-column content-container-content-area">
+		<div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	<div class="">
+
+				
+
+				
+
+					
+
+					
+
+						
+
+						<div class=" mb-lg-0 ml-lg-0 mr-lg-0 mt-lg-0 pb-lg-0 pl-lg-0 pr-lg-0 pt-lg-0" style="box-sizing: border-box;border-style: solid; border-width: 0px;opacity: 1.0;">
+							<div id="fragment-4398-xmsp"> <div class="inpage_navigation_menu_and_content_container">
+	<div class="idsk-in-page-navigation govuk-grid-column-one-quarter">
+		<div class="idsk-in-page-navigation-wrapper">
+			<div class="idsk-in-page-navigation__title " data-lfr-editable-id="inpage_navigation_menu_title" data-lfr-editable-type="text">On this page</div>
+			<div class="idsk-in-page-navigation__link-panel">
+      <button class="idsk-in-page-navigation__link-panel-button">National Visa</button>
+    </div>
+			<ul class="idsk-in-page-navigation__list inpage_nav_items_container"><li class="idsk-in-page-navigation__list-item idsk-in-page-navigation__list-item--active"><a class="idsk-in-page-navigation__link in-page-navigation-anchor" href="#4398_xmsp_inpage_nav_0" data-navitemid="4398_xmsp_inpage_nav_0"><span class="idsk-in-page-navigation__link-title">National Visa</span></a></li><li class="idsk-in-page-navigation__list-item"><a class="idsk-in-page-navigation__link in-page-navigation-anchor" href="#4398_xmsp_inpage_nav_1" data-navitemid="4398_xmsp_inpage_nav_1"><span class="idsk-in-page-navigation__link-title">Who may apply for a national visa</span></a></li><li class="idsk-in-page-navigation__list-item"><a class="idsk-in-page-navigation__link in-page-navigation-anchor" href="#4398_xmsp_inpage_nav_2" data-navitemid="4398_xmsp_inpage_nav_2"><span class="idsk-in-page-navigation__link-title">Where you can lodge a national visa application</span></a></li><li class="idsk-in-page-navigation__list-item"><a class="idsk-in-page-navigation__link in-page-navigation-anchor" href="#4398_xmsp_inpage_nav_3" data-navitemid="4398_xmsp_inpage_nav_3"><span class="idsk-in-page-navigation__link-title">Which documents should be submitted with the national visa application</span></a></li><li class="idsk-in-page-navigation__list-item"><a class="idsk-in-page-navigation__link in-page-navigation-anchor" href="#4398_xmsp_inpage_nav_4" data-navitemid="4398_xmsp_inpage_nav_4"><span class="idsk-in-page-navigation__link-title">Higher verification and translation of documents</span></a></li><li class="idsk-in-page-navigation__list-item"><a class="idsk-in-page-navigation__link in-page-navigation-anchor" href="#4398_xmsp_inpage_nav_5" data-navitemid="4398_xmsp_inpage_nav_5"><span class="idsk-in-page-navigation__link-title">Collecting of biometric data</span></a></li><li class="idsk-in-page-navigation__list-item"><a class="idsk-in-page-navigation__link in-page-navigation-anchor" href="#4398_xmsp_inpage_nav_6" data-navitemid="4398_xmsp_inpage_nav_6"><span class="idsk-in-page-navigation__link-title">Appointment for submission of the visa application</span></a></li><li class="idsk-in-page-navigation__list-item"><a class="idsk-in-page-navigation__link in-page-navigation-anchor" href="#4398_xmsp_inpage_nav_7" data-navitemid="4398_xmsp_inpage_nav_7"><span class="idsk-in-page-navigation__link-title">Visa Fee</span></a></li><li class="idsk-in-page-navigation__list-item"><a class="idsk-in-page-navigation__link in-page-navigation-anchor" href="#4398_xmsp_inpage_nav_8" data-navitemid="4398_xmsp_inpage_nav_8"><span class="idsk-in-page-navigation__link-title">Decision Making Deadlines</span></a></li><li class="idsk-in-page-navigation__list-item"><a class="idsk-in-page-navigation__link in-page-navigation-anchor" href="#4398_xmsp_inpage_nav_9" data-navitemid="4398_xmsp_inpage_nav_9"><span class="idsk-in-page-navigation__link-title">Validity of the national visa</span></a></li></ul>
+		</div>
+	</div>
+	<div class="govuk-grid-column-three-quarters inpage_navigation_menu_content_container">
+		<div class="inpage_content_container">
+			<div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	<div class="">
+
+				
+
+				
+
+					
+
+					
+
+						
+
+						<div class=" mb-lg-0 ml-lg-0 mr-lg-0 mt-lg-0 pb-lg-0 pl-lg-0 pr-lg-0 pt-lg-0" style="box-sizing: border-box;border-style: solid; border-width: 0px;opacity: 1.0;">
+							<div id="fragment-0-ngmj">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	<div class="portlet-boundary portlet-boundary_com_liferay_journal_content_web_portlet_JournalContentPortlet_  portlet-static portlet-static-end portlet-borderless portlet-journal-content " id="p_p_id_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_ngmj_">
+		<span id="p_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_ngmj"></span>
+
+
+
+
+	
+
+	
+		
+			
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+	
+	
+		
+<section class="portlet" id="portlet_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_ngmj">
+
+
+	<div class="portlet-content">
+
+			<div class="autofit-float autofit-row portlet-header">
+
+
+					<div class="autofit-col autofit-col-end">
+						<div class="autofit-section">
+							<div class="visible-interaction">
+	
+		
+
+		
+
+		
+
+		
+	
+</div>
+						</div>
+					</div>
+			</div>
+
+		
+			<div class=" portlet-content-container">
+				
+
+
+	<div class="portlet-body">
+
+
+
+	
+		
+			
+			
+				
+					
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+				
+
+				
+					
+					
+						
+
+
+	
+
+		
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+	
+		
+			
+			
+				
+					
+					
+					
+
+						
+
+						<div class="" data-fragments-editor-item-id="10109-6337538" data-fragments-editor-item-type="fragments-editor-mapped-item">
+							
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="journal-content-article " data-analytics-asset-id="266340" data-analytics-asset-title="Národné vízum" data-analytics-asset-type="web-content">
+	
+
+	
+
+
+    <script>
+        function Wct_prswdapv($module) {
+            this.$module = $module;
+
+            this.innerRowNotVisibleClass = 'inner-row-not-visible';
+            this.inactiveBtnClass = 'not-active';
+            this.prevVersionsToggleBtnClass = 'wct-prswdapv-previous-versions-toggle-btn';
+            this.prevVersionsRowClass = 'wct-prswdapv-previous-versions-content-inner-row';
+        }
+
+        Wct_prswdapv.prototype.togglePrevVersions = function() {
+            if (!this.$module) {
+                return;
+            }
+            
+            var togglePreviousVersionsBtn = this.$module.querySelector('button.' + this.prevVersionsToggleBtnClass);
+            var toggleBtnText = this.$module.querySelector('button.' + this.prevVersionsToggleBtnClass + ' span');
+            var toggleArea = this.$module.querySelector('.' + this.prevVersionsRowClass);
+
+            if(toggleBtnText && toggleArea) {
+                if (toggleArea.classList.contains(this.innerRowNotVisibleClass)) {
+                    togglePreviousVersionsBtn.setAttribute('aria-expanded', true);
+                    toggleBtnText.innerHTML = 'hide updates';
+                    toggleArea.classList.remove(this.innerRowNotVisibleClass);
+                } else {
+                    togglePreviousVersionsBtn.setAttribute('aria-expanded', false);
+                    toggleBtnText.innerHTML = 'show updates';
+                    toggleArea.classList.add(this.innerRowNotVisibleClass);
+                }
+            }        
+        }
+
+        Wct_prswdapv.prototype.setupButtonEvents = function (){
+            var $self = this;
+            if (!$self.$module) {
+                return;
+            }
+            var togglePreviousVersionsBtn = $self.$module.querySelector('.' + $self.prevVersionsToggleBtnClass);
+
+            // Handle events for the controls
+            if (togglePreviousVersionsBtn) {
+                togglePreviousVersionsBtn.addEventListener('click', $self.togglePrevVersions.bind($self));
+                // allow button click now
+                togglePreviousVersionsBtn.classList.remove($self.inactiveBtnClass);
+            }
+        }
+
+        // Initialize component
+        Wct_prswdapv.prototype.init = function () {
+            // Check for module
+            if (!this.$module) {
+                return;
+            }
+            this.setupButtonEvents();
+        };
+
+        AUI().ready('aui-module', function() {
+            var wct_prswdapv_component = document.querySelector("#wct-prswdapv-ngmj");
+            new Wct_prswdapv(wct_prswdapv_component).init();
+        });
+    </script>
+
+
+    <div class="wct-prswdapv" id="wct-prswdapv-ngmj">
+
+                <div class="wct-prswdapv-previous-versions-content-area">
+                    <div class="wct-prswdapv-previous-versions-content-top-row">
+                        <span>Updated 22.09.2025</span>
+                        <button class="wct-prswdapv-previous-versions-toggle-btn" aria-controls="ngmj-previous-versions-content" aria-expanded="false">
+                            <span>show updates</span>
+                        </button>
+                    </div>
+                    <div class="wct-prswdapv-previous-versions-content-inner-row inner-row-not-visible" id="ngmj-previous-versions-content">
+                        <div class="wct-prswdapv-previous-versions-content-inner-row-section">
+                            <strong>Published 31.05.2022</strong>
+                        </div>
+                    </div>
+                </div>
+
+            <div class="wct-prswdapv-text-content-area">
+                <h3 id="4398_xmsp_inpage_nav_0">National Visa</h3>
+
+<p>A national visa is the permission granted by the Slovak Republic authorising its holder for the stay in the territory of the Slovak Republic for the duration of the validity of the visa and in other Member States for a period not exceeding 90 days in any 180-day period under the conditions stipulated in the Schengen Borders Code. The national visa may be issued with maximum validity of 1 year.</p>
+
+<p>The conditions of granting of the national visa are regulated by the <a href="https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/2011/404/" target="_blank" title="Act No. 404/2011 Coll. on Residence of Foreigners and on the Amendment and Supplementation to Certain Acts on the Slov-Lex website">Act No. 404/2011 Coll. on Residence of Foreigners and on the Amendment and Supplementation to Certain Acts</a>.</p>
+
+<p>&nbsp;</p>
+
+<h3 id="4398_xmsp_inpage_nav_1">Who may apply for a national visa</h3>
+
+<p>National (long-stay) visas are issued for stays of duration of more than 90 days. A third country national may be granted a national visa:</p>
+
+<ol>
+	<li>on the basis of the granted residence permit;</li>
+	<li>for the purpose of submission of the residence permit application in the Slovak Republic;</li>
+	<li>if the applicant is older than 15 years and is accepted for language education at a <a href="https://www.cvtisr.sk/buxus/docs/JH/stat_zus.pdf" target="_blank" title="List of state language schools in Slovakia in PDF format, 1.15 MB">language school (pdf, 1.15 MB)</a> in the extent of not less than 25 lessons per week;</li>
+	<li>if it is in the interest of the Slovak Republic, namely:
+	<ul>
+		<li>on the basis of a certificate or confirmation from the statutory representative of the competent ministry;</li>
+		<li>based on the Resolution of the Government of the Slovak Republic No. 731 of 8 December 2021 on the Higher Education Internationalisation Strategy 2030 (<a href="http://www.minedu.sk/list-of-the-programmes-interests-of-slovak-republic/" target="_blank" title="List of programmes covered by the Higher Education Internationalisation Strategy 2030">list of programmes covered by the Strategy</a>);</li>
+		<li>(*) based on the <a href="https://www.mzv.sk/documents/30297/13307907/National-Visa-Regulation-113-2023-EN.pdf/7d255b18-94a5-28ef-dbec-751ebe16e4f2?t=1682661735725" target="_blank" title="Regulation of the Government of the Slovak Republic No. 113/2023 in PDF format, 1.15 MB">Regulation of the Government of the Slovak Republic No. 113/2023 (pdf, 1.15 MB)</a> on the interest of the Slovak Republic to grant a national visa to selected categories of third-country nationals (citizens of Armenia, Azerbaijan, Belarus, Bosnia and Herzegovina, Montenegro, the Philippines, Georgia, India, Indonesia, Kazakhstan, Kyrgyzstan, Moldova, Nepal, North Macedonia, Serbia, Turkmenistan, Tajikistan, Ukraine, and Uzbekistan);</li>
+		<li>based on the <a href="https://www.mzv.sk/documents/30297/13307907/National-Visa-Regulation-521-2021-EN.pdf/576258c7-e630-1146-4348-49f148c138a9?t=1696270058654" target="_blank" title="Regulation of the Government of the Slovak Republic No. 521/2021 in PDF format, 1.01 MB">Regulation of the Government of the Slovak Republic No. 521/2021 (pdf, 1.01 MB)</a> on the interest of the Slovak Republic to grant a national visa to highly qualified third-country nationals;</li>
+		<li>(*) based on the <a href="https://www.mzv.sk/documents/30297/13307907/National-Visa-Regulation-269-2022-EN.pdf/7119f06f-810f-6500-2fc9-5c50aa787656?t=1696267343048" target="_blank" title="Regulation of the Government of the Slovak Republic No. 269/2022 in PDF format, 72.75 KB">Regulation of the Government of the Slovak Republic No. 269/2022 (pdf, 72.75 KB)</a> on the interest of the Slovak Republic to grant a national visa to relocated third-country nationals and their family members;</li>
+		<li>(*) based on Regulation of the Government of the Slovak Republic No. 160/2025 on the interest of the Slovak Republic to grant a national visa to selected categories of citizens of the People's Republic of China in connection with the promotion of trade relations and investment development between the People's Republic of China and the Slovak Republic.</li>
+	</ul>
+	</li>
+	<li>if it is necessary in order to fulfil the obligations of the Slovak Republic following from international treaties;</li>
+	<li>if the applicant is a family member of a foreigner who was granted asylum or subsidiary protection.</li>
+</ol>
+
+<div class="govuk-inset-text">
+<p><strong>Please note:</strong> In the case of an application for a visa under the Regulation marked with an asterisk (*), only a foreigner who is on the list maintained by the competent national authority may apply for a national visa. See the respective regulation for more information.</p>
+</div>
+
+<p>&nbsp;</p>
+
+<h3 id="4398_xmsp_inpage_nav_2">Where you can lodge a national visa application</h3>
+
+<p>The application for a national visa can be submitted at the <a href="https://www.mzv.sk/documents/30297/13302700/The_list_of_diplomatic_missions_of_the_Slovak_Republic.pdf/68fd87e7-54b2-4c5d-b22b-c57a6c68cbca?t=1724758996552" target="_blank" title="List of diplomatic missions of the Slovak Republic in PDF format, 151 kB">diplomatic mission of the Slovak Republic (pdf, 151 kB)</a>. In some locations certain categories of national visa applications may be submitted also in a visa centre. Further information will be provided by the diplomatic mission.</p>
+
+<p>&nbsp;</p>
+
+<h3 id="4398_xmsp_inpage_nav_3">Which documents should be submitted with the national visa application</h3>
+
+<p>An application for the national visa shall consist of the following documents (<strong>basic documents</strong>):</p>
+
+<ul>
+	<li>a <a href="/documents/10182/16274933/004-ziadost-o-narodne-vizum-EN.pdf/3e457269-c704-45a0-3ec5-5ce02f650af9?t=1675076524476" target="_blank" title="National visa application form in PDF format, 174.9 kB">national visa application form (pdf, 174.9 kB)</a>;</li>
+	<li>a valid travel document (its validity shall be at least 90 days after the intended date of departure from the Slovak Republic);</li>
+	<li>a full-face colour photograph, conform to <a href="https://ec.europa.eu/home-affairs/sites/homeaffairs/files/what-we-do/policies/borders-and-visas/visa-policy/docs/icao_photograph_guidelines_en.pdf" target="_blank" title="ICAO photograph standards in PDF format, 437.64 kB">ICAO standards (pdf, 437.64 kB)</a>, 3 x 3.5 cm showing the applicant´s current appearance;</li>
+	<li>a document confirming the purpose of residence (e.g. information from the police authority about the granting of the temporary or permanent residence, a decision on the acceptance of the student for language education at the <a href="https://www.cvtisr.sk/buxus/docs/JH/stat_zus.pdf" target="_blank" title="List of state language schools in Slovakia in PDF format, 1.15 MB">language school (pdf, 1.15 MB)</a> in the required extent, or other document confirming that the issuance of the national visa is necessary in order to fulfil the obligations of the Slovak Republic following from international treaties or in the interest of the Slovak Republic);</li>
+	<li>proof that the applicant will have health insurance upon entry and throughout their stay in the Slovak Republic (e.g. commercial health insurance taken out abroad that covers medical expenses in the Slovak Republic, commercial health insurance taken out in Slovakia, proof of public health insurance in Slovakia, or proof that the applicant will be covered by public health insurance, etc.);</li>
+	<li>the date of entry into public health insurance, if this is not directly apparent from the law, shall be proven by the applicant with relevant documentation. If the applicant is unable to provide relevant proof of the date of entry into public health insurance, they shall submit proof of health insurance for the duration of the visa granted with their application.</li>
+</ul>
+
+<p>In addition to the basic documents listed above, <strong>a student at the language school</strong> shall also submit the following documents:</p>
+
+<ul>
+	<li>a document confirming the accommodation in the Slovak Republic during the whole course of language study (e.g. confirmation from the accommodation facility, affidavit of the property owner on provision of accommodation, or the statutory declaration of the occupant on provision of the accommodation);</li>
+	<li>documents indicating that the applicant possesses sufficient means of subsistence during his stay in the Slovak Republic (e.g. bank account statement confirming the financial means of 56 EUR per each day of stay; if the applicant has already paid for the accommodation, the amount is reduced to 26 EUR per each day of stay).</li>
+</ul>
+
+<p>In addition to the basic documents listed above, <strong>an applicant for a residence permit</strong> shall also submit the following documents:</p>
+
+<ul>
+	<li>the complete application including the supporting documentation for the residence permit which is to be submitted in the Slovak Republic;</li>
+	<li>documents indicating that the applicant possesses sufficient means of subsistence during his stay in the Slovak Republic (e.g. bank account statement confirming the financial means of 56 EUR per each day of stay); a separate document on the means of subsistence is not required if the relevant document submitted as part of the application for the residence permit covers the whole period of validity of the national visa;</li>
+	<li>a document indicating the date and means of transport to the Slovak Republic.</li>
+</ul>
+
+<p>An application for a D visa for the purpose of submission of the residence permit application in the Slovak Republic may be submitted for the following types of residence: employment, study, special activity, research and development, family reunification, Slovak living abroad, permanent residence for 5 years.</p>
+
+<p><strong>A family member of a foreigner who has been granted asylum or subsidiary protection</strong> shall submit:</p>
+
+<ul>
+	<li>a national visa application form</li>
+	<li>a valid travel document</li>
+	<li>a document which proves his/her family relationship with a person who has been granted asylum or subsidiary protection</li>
+	<li>a document confirming the dependency, if required</li>
+</ul>
+
+<p>An applicant for a national visa based on the Resolution of the Government of the Slovak Republic No. 731 of 8 December 2021 on the <strong>Higher Education Internationalisation Strategy 2030</strong> shall submit:</p>
+
+<ul>
+	<li>a valid passport (its validity shall be at least 90 days after the intended date of departure from the Slovak Republic)</li>
+	<li>a completed <a href="/documents/10182/16274933/004-ziadost-o-narodne-vizum-EN.pdf/3e457269-c704-45a0-3ec5-5ce02f650af9?t=1675076524476" target="_blank" title="National visa application form in PDF format, 174.9 kB">national visa application form (pdf, 174.9 kB)</a></li>
+	<li>a full-face colour photograph, conform to <a href="https://ec.europa.eu/home-affairs/sites/homeaffairs/files/what-we-do/policies/borders-and-visas/visa-policy/docs/icao_photograph_guidelines_en.pdf" target="_blank" title="ICAO photograph standards in PDF format, 437.64 kB">ICAO standards (pdf, 437.64 kB)</a>, 3 x 3.5 cm showing the applicant´s current facial image</li>
+	<li>a certificate of study or an acceptance letter from the relevant educational establishment</li>
+</ul>
+
+<p>&nbsp;</p>
+
+<p>An applicant for a national visa on the basis of the <a href="/documents/30297/13307907/National-Visa-Regulation-521-2021-EN.pdf/576258c7-e630-1146-4348-49f148c138a9?t=1696270058654" target="_blank" title="Regulation of the Government of the Slovak Republic No. 521/2021 in PDF format, 1.01 MB">Regulation of the Government of the Slovak Republic No. 521/2021 (pdf, 1.01 MB)</a> on the interest of the Slovak Republic <strong>to grant a national visa to highly qualified third-country nationals</strong> shall submit:</p>
+
+<p><strong>Application for a national visa for the purpose of employment</strong></p>
+
+<ul>
+	<li>a valid passport (its validity shall be at least 90 days after the intended date of departure from the Slovak Republic)</li>
+	<li>a completed application for a national visa</li>
+	<li>a full-face colour photograph, conform to <a href="https://ec.europa.eu/home-affairs/sites/homeaffairs/files/what-we-do/policies/borders-and-visas/visa-policy/docs/icao_photograph_guidelines_en.pdf" target="_blank" title="ICAO photograph standards in PDF format, 437.64 kB">ICAO standards (pdf, 437.64 kB)</a>, 3 x 3.5 cm showing the applicant´s current facial image</li>
+	<li>proof of education:
+	<ul>
+		<li>a university diploma or confirmation of successful completion of a second-level study at a higher education institution in the Slovak Republic or the Czech Republic, or</li>
+		<li>a higher education diploma or a certificate of successful completion of a university or educational establishment as referred to in Annex 1 to the Regulation in a study programme lasting at least three years, or</li>
+		<li>a university diploma or certificate of successful completion of a university or educational establishment in a study programme of at least four years in the case of employment listed in Annex 2 to the Regulation</li>
+	</ul>
+	</li>
+	<li>a letter of employment of the third-country national issued by the employer or a valid employment contract</li>
+	<li>proof of health insurance in the territory of the Slovak Republic valid until the period of entry into force of the employment contract</li>
+</ul>
+
+<p><strong>Application for a national visa of a highly qualified job seeker</strong></p>
+
+<ul>
+	<li>a valid passport (its validity shall be at least 90 days after the intended date of departure from the Slovak Republic);</li>
+	<li>a completed application for a national visa;</li>
+	<li>a full-face colour photograph, conform to&nbsp;<a href="https://ec.europa.eu/home-affairs/sites/homeaffairs/files/what-we-do/policies/borders-and-visas/visa-policy/docs/icao_photograph_guidelines_en.pdf">ICAO standards (PDF, 437,64 kB)</a>, 3 x 3,5 cm showing applicant´s current facial image;</li>
+	<li>proof of education
+	<ul>
+		<li>a university diploma or confirmation of successful completion of a second-level study at a higher education institution in the Slovak Republic or the Czech Republic, or</li>
+		<li>a higher education diploma or a certificate of successful completion of a university or educational establishment as referred to in Annex 1 to the Regulation in a study programme lasting at least three years, or</li>
+		<li>a university diploma or certificate of successful completion of a university or educational establishment in a study programme of at least four years in the case of employment listed in Annex 2 to the Regulation;</li>
+	</ul>
+	</li>
+</ul>
+
+<ul>
+	<li>a solemn declaration of the applicant on the purpose of the stay with the applicant's certified signature;</li>
+	<li>proof of health insurance in the territory of the Slovak Republic for a period of 90 days.</li>
+</ul>
+
+<p>&nbsp;</p>
+
+<p>An applicant for a national visa on the basis of the <a href="/documents/30297/13307907/National-Visa-Regulation-269-2022-EN.pdf/7119f06f-810f-6500-2fc9-5c50aa787656?t=1696267343048" target="_blank" title="Regulation of the Government of the Slovak Republic No. 269/2022 in PDF format, 72.75 kB">Regulation of the Government of the Slovak Republic No. 269/2022 (pdf, 72.75 kB)</a> on the interest of the Slovak Republic to issue a national visa to <strong>relocated third-country nationals and their family members</strong> shall submit:</p>
+
+<p><strong>Applicant — relocated employee:</strong></p>
+
+<ul>
+	<li>a valid passport (its validity shall be at least 90 days after the intended date of departure from the Slovak Republic)</li>
+	<li>a completed <a href="/documents/10182/16274933/004-ziadost-o-narodne-vizum-EN.pdf/3e457269-c704-45a0-3ec5-5ce02f650af9?t=1675076524476" target="_blank" title="National visa application form in PDF format, 174.9 kB">national visa application form (pdf, 174.9 kB)</a></li>
+	<li>a full-face colour photograph, conform to <a href="https://ec.europa.eu/home-affairs/sites/homeaffairs/files/what-we-do/policies/borders-and-visas/visa-policy/docs/icao_photograph_guidelines_en.pdf" target="_blank" title="ICAO photograph standards in PDF format, 437.64 kB">ICAO standards (pdf, 437.64 kB)</a>, 3 x 3.5 cm showing the applicant´s current appearance</li>
+	<li>a letter of employment of the third-country national issued by the employer or a valid employment contract</li>
+	<li>proof of health insurance in the territory of the Slovak Republic valid until the period of entry into force of the employment contract</li>
+</ul>
+
+<p><strong>Applicant — family member of the relocated employee:</strong></p>
+
+<ul>
+	<li>a valid passport (its validity shall be at least 90 days after the intended date of departure from the Slovak Republic)</li>
+	<li>a completed <a href="/documents/10182/16274933/004-ziadost-o-narodne-vizum-EN.pdf/3e457269-c704-45a0-3ec5-5ce02f650af9?t=1675076524476" target="_blank" title="National visa application form in PDF format, 174.9 kB">national visa application form (pdf, 174.9 kB)</a></li>
+	<li>a full-face colour photograph, conform to <a href="https://ec.europa.eu/home-affairs/sites/homeaffairs/files/what-we-do/policies/borders-and-visas/visa-policy/docs/icao_photograph_guidelines_en.pdf" target="_blank" title="ICAO photograph standards in PDF format, 437.64 kB">ICAO standards (pdf, 437.64 kB)</a>, 3 x 3.5 cm showing the applicant´s current appearance</li>
+	<li>a registry document (marriage or birth certificate) confirming the family relationship with the relocated employee</li>
+	<li>proof of health insurance in the territory of the Slovak Republic valid for the period of validity of the granted national visa</li>
+</ul>
+
+<p>An applicant for a national visa on the <a href="https://www.mzv.sk/documents/30297/13307907/National-Visa-Regulation-113-2023-EN.pdf/7d255b18-94a5-28ef-dbec-751ebe16e4f2?t=1682661735725" target="_blank" title="Regulation of the Government of the Slovak Republic No. 113/2023 in PDF format, 245 kB">Regulation of the Government of the Slovak Republic No. 113/2023 (pdf, 245 kB)</a> on the interest of the Slovak Republic to issue a national visa to <strong>selected categories of third-country nationals</strong> shall submit:</p>
+
+<ul>
+	<li>a valid passport (its validity shall be at least 90 days after the intended date of departure from the Slovak Republic)</li>
+	<li>a completed <a href="https://www.mzv.sk/documents/10182/16274933/004-ziadost-o-narodne-vizum-EN.pdf/3e457269-c704-45a0-3ec5-5ce02f650af9" target="_blank" title="National visa application form in PDF format, 174.9 kB">national visa application form (pdf, 174.9 kB)</a></li>
+	<li>a full-face colour photograph, conform to <a href="https://ec.europa.eu/home-affairs/sites/homeaffairs/files/what-we-do/policies/borders-and-visas/visa-policy/docs/icao_photograph_guidelines_en.pdf" target="_blank" title="ICAO photograph standards in PDF format, 437.64 kB">ICAO standards (pdf, 437.64 kB)</a>, 3 x 3.5 cm showing the applicant´s current facial image</li>
+	<li>a valid employment contract</li>
+	<li>proof of health insurance in the territory of the Slovak Republic valid until the period of entry into force of the employment contract</li>
+	<li>the respective authorisation to drive a motor vehicle (driving licence)</li>
+</ul>
+
+<p>To apply for a national visa based on the Regulation of the Government of the Slovak Republic No. 160/2025 on the Slovak Republic's interest to grant a national visa to selected categories of citizens of the People's Republic of China in connection with the promotion of trade relations and investment development between the People's Republic of China and the Slovak Republic, applicants must submit:</p>
+
+<ul>
+	<li>a valid passport</li>
+	<li>a completed <a href="https://www.mzv.sk/documents/10182/16274933/004-ziadost-o-narodne-vizum-EN.pdf/3e457269-c704-45a0-3ec5-5ce02f650af9?t=1675076524476" target="_blank" title="National visa application form in PDF format, 174.9 kB">national visa application form (pdf, 174.9 kB)</a></li>
+	<li>a full-face colour photograph, conform to <a href="https://ec.europa.eu/home-affairs/sites/homeaffairs/files/what-we-do/policies/borders-and-visas/visa-policy/docs/icao_photograph_guidelines_en.pdf" target="_blank" title="ICAO photograph standards in PDF format, 437.64 kB">ICAO standards (pdf, 437.64 kB)</a>, 3 x 3.5 cm showing the applicant´s current facial image</li>
+	<li>an employment contract or a written promise from the employer to hire a third-country national</li>
+	<li>proof of health insurance in the territory of the Slovak Republic valid until the employment contract takes effect</li>
+</ul>
+
+<h3 id="4398_xmsp_inpage_nav_4">Higher verification and translation of documents</h3>
+
+<p>Foreign language documents of education or documents of professional qualification necessary for the performance of employment must be submitted with respective superlegalization for use abroad and accompanied by an official translation into the Slovak language&nbsp;or Czech language.</p>
+
+<p>&nbsp;</p>
+
+<h3 id="4398_xmsp_inpage_nav_5">Collecting of biometric data</h3>
+
+<p>The applicant for a national visa shall allow the collection of his/her fingerprints. Fingerprints are not collected from the applicants under 12 years of age.</p>
+
+<p>&nbsp;</p>
+
+<h3 id="4398_xmsp_inpage_nav_6">Appointment for submission of the visa application</h3>
+
+<p>Diplomatic missions may require prior appointment for submission of the visa application. Further information will be provided by the respective diplomatic mission.</p>
+
+<p>&nbsp;</p>
+
+<h3 class="govuk-heading-m" id="4398_xmsp_inpage_nav_7">Visa Fee</h3>
+
+<p class="govuk-body">The list of fees</p>
+
+<table class="govuk-table">
+	<thead class="govuk-table__head">
+		<tr class="govuk-table__row">
+			<th class="govuk-table__header" scope="col" style="width: 70%; text-align: left;">Visa Type</th>
+			<th class="govuk-table__header" scope="col" style="width: 30%; text-align: right;">Fee</th>
+		</tr>
+	</thead>
+	<tbody class="govuk-table__body">
+		<tr class="govuk-table__row">
+			<td class="govuk-table__cell">National (long-stay) visa granted in connection with the performance of commitments of the Slovak Republic under international treaties or for the benefit of the Slovak Republic</td>
+			<td class="govuk-table__cell" style="text-align: right;">50 eur</td>
+		</tr>
+		<tr class="govuk-table__row">
+			<td class="govuk-table__cell">National (long-stay) visa granted in connection with a residence permit application to be submitted in the Slovak Republic</td>
+			<td class="govuk-table__cell" style="text-align: right;">90 eur</td>
+		</tr>
+		<tr class="govuk-table__row">
+			<td class="govuk-table__cell">National (long-stay) visa issued to the holder of the residence permit in the Slovak Republic</td>
+			<td class="govuk-table__cell" style="text-align: right;">15 eur</td>
+		</tr>
+		<tr class="govuk-table__row">
+			<td class="govuk-table__cell">National visa issued to the applicant older than 15 years and accepted for language education at a language school in the extent of not less than 25 lessons per week</td>
+			<td class="govuk-table__cell" style="text-align: right;">30 eur</td>
+		</tr>
+	</tbody>
+</table>
+
+<p>&nbsp;</p>
+
+<p>In case of the refusal of granting of the national visa the fee is non-refundable.</p>
+
+<p>&nbsp;</p>
+
+<h3 id="4398_xmsp_inpage_nav_8">Decision Making Deadlines</h3>
+
+<p>The diplomatic mission shall decide about an application for the granting of national visa within 30 days from its receipt. The diplomatic mission may grant the national visa only after prior consent of the Ministry of Interior of the Slovak Republic.</p>
+
+<p>&nbsp;</p>
+
+<h3 id="4398_xmsp_inpage_nav_9">Validity of the national visa</h3>
+
+<p>The national visas are issued for stays longer than 3 months, with maximum validity of one year. The national visa may be issued:</p>
+
+<ol>
+	<li>for 90 days to the holder of the residence permit in the Slovak Republic,</li>
+	<li>for 120 days for submission of a&nbsp;residence permit application in the territory of the Slovak Republic,</li>
+	<li>for the necessary period of time, in case of the family member of a foreigner who was granted asylum or subsidiary protection,</li>
+	<li>for the necessary period of time, in case of the national visa issued in connection with the performance of commitments of the Slovak Republic under international treaties or for the benefit of the Slovak Republic.</li>
+</ol>
+
+<p>&nbsp;</p>
+
+<p>It is not possible to appeal a&nbsp;decision on the refusal on the granting of the national visa. Exception applies to the national visa application in accordance with §15 par. 2 of the Act No. 404/2011 Coll. on Residence of Foreigners and on the Amendment and Supplementation to Certain Acts.</p>
+            </div>
+    </div>
+
+
+</div>
+
+
+
+
+
+							
+						</div>
+					
+				
+			
+		
+	
+
+
+
+
+	
+
+	
+
+	
+
+	
+
+	
+
+	
+
+
+
+
+	
+	
+
+					
+				
+			
+		
+	
+	
+
+
+
+	</div>
+
+			</div>
+		
+	</div>
+</section>
+	
+
+		
+		
+	
+
+
+
+
+
+
+
+	</div>
+
+
+
+
+
+
+</div>
+						</div>
+					
+				
+			</div>
+
+</div>
+		</div>
+	</div>
+</div></div><script>(function() {var configuration = {"useH5":false,"useH6":false,"useH3":true,"useH4":false,"showTitle":true,"useH1":true,"useH2":false}; var fragmentElement = document.querySelector('#fragment-4398-xmsp'); var fragmentNamespace = 'xmsp';var navItemsContainer = fragmentElement.querySelector('.inpage_nav_items_container');
+var fragmentSubId = fragmentElement.getAttribute('id').split('-');
+const navItemSubId = fragmentSubId[1] + (!!fragmentSubId[2] ? ('_' + fragmentSubId[2]) : '') + '_inpage_nav_';
+const useForHeadings = [];
+const usedInpageHeaders = [];
+const activeLinkClass = 'idsk-in-page-navigation__list-item--active';
+const fixedNavigationClass = 'inpage_navigation_fixed';
+const linkPanelBtnClass = 'idsk-in-page-navigation__link-panel-button';
+const inPageNavAnchorClass = 'in-page-navigation-anchor';
+const navigationWrapperClass = 'idsk-in-page-navigation-wrapper';
+const navigationExpandClass = 'idsk-in-page-navigation--expand';
+const inPageNavClass = 'idsk-in-page-navigation';
+const navMenuContentContainerClass = 'inpage_navigation_menu_content_container';
+const contentContainerClass = 'inpage_content_container';
+
+
+for (i=1; i <= 6; i++) {
+	if (!!configuration['useH'+i]) {
+		useForHeadings.push('h'+i);
+	}
+}
+
+if (useForHeadings.length == 0) {
+	useForHeadings.push('h1');
+}
+
+const headingsSelector = useForHeadings.join();
+
+function assembleInpageMenu() {
+	const contentContainer = fragmentElement.querySelector('.' + contentContainerClass);
+	const inpageHeaders = Array.prototype.slice.call(contentContainer.querySelectorAll(headingsSelector));
+	if (!!inpageHeaders && !!inpageHeaders.length) {
+		var listItems = '';
+
+		for (i = 0; i < inpageHeaders.length; i++){
+			var item = inpageHeaders[i];
+			if (!!item.innerText){
+				const navItemId = navItemSubId + i;
+				item.setAttribute('id', navItemId);
+				usedInpageHeaders.push(item);
+				listItems += '<li class="idsk-in-page-navigation__list-item">' +
+					'<a class="idsk-in-page-navigation__link in-page-navigation-anchor" href="#' + navItemId + 
+					'" data-navItemId="' + navItemId + '"><span class="idsk-in-page-navigation__link-title">' + 
+					item.innerText + '</span></a></li>';
+			}
+    };
+		navItemsContainer.innerHTML = listItems;
+		checkEmptyBtnLabel();
+	}
+}
+
+function setActive(anchorId, innerInvocation){
+	const navItems = Array.prototype.slice.call(fragmentElement.querySelectorAll('a.idsk-in-page-navigation__link'));
+	var collapsedMenuBtn = fragmentElement.querySelector('.' + linkPanelBtnClass);
+	navItems.forEach(function(navItem) {
+		if (navItem.getAttribute('href').substr(1) === anchorId) {
+			navItem.parentElement.classList.add(activeLinkClass);
+			collapsedMenuBtn.innerHTML = navItem.innerText;
+		} else {
+			navItem.parentElement.classList.remove(activeLinkClass);
+		}
+	});
+	if (!innerInvocation) {
+		var navigation = fragmentElement.querySelector('.' + inPageNavClass);
+		setTimeout(navigation.classList.remove(navigationExpandClass), 1);
+	}
+}
+
+function couldBeMenuExpanded() {
+	var couldBeNavigationExpanded = false;
+	if (window.innerWidth <= 768) {
+		couldBeNavigationExpanded = true;
+	}
+	return couldBeNavigationExpanded;
+}
+
+function checkEmptyBtnLabel() {
+	var collapsedMenuBtn = fragmentElement.querySelector('.' + linkPanelBtnClass);
+	if (!collapsedMenuBtn.innerText) {
+		var activeLink = fragmentElement.querySelector('.' + activeLinkClass);
+		const navItem = fragmentElement.querySelector('a');
+		collapsedMenuBtn.innerHTML = !!activeLink ? activeLink.innerText : !!navItem ? navItem.innerText : '';
+	}
+}
+
+function adjustNavMenuWidth() {
+	var oneQuarterContainerWidth = fragmentElement.offsetWidth / 4;
+	var sideNavMenuContainer = fragmentElement.querySelector('.' + navigationWrapperClass);
+	var sideNavMenuContentContainer = fragmentElement.querySelector('.' + navMenuContentContainerClass);
+	if (couldBeMenuExpanded()) {
+		sideNavMenuContainer.style.maxWidth = '';
+		sideNavMenuContainer.style.width = sideNavMenuContentContainer.offsetWidth + 'px';
+		checkEmptyBtnLabel();
+	} else {
+		sideNavMenuContainer.style.width = '';
+		sideNavMenuContainer.style.maxWidth = ((oneQuarterContainerWidth - 30 ) + 'px');
+	}
+
+	var snmContentContainerBCR = sideNavMenuContentContainer.getBoundingClientRect();
+	var snmContentContainerVisibleHeight = snmContentContainerBCR.height + snmContentContainerBCR.y;
+	// var snmContentContainerBottom = snmContentContainerBCR.bottom;
+
+	var snmContainerBCR = sideNavMenuContainer.getBoundingClientRect();
+	var currentShift = Math.abs(snmContainerBCR.top);
+	var snmContainerHeight = snmContainerBCR.height;
+	// var snmContainerBottom = snmContainerBCR.bottom;
+
+	var snmActiveNavLink = fragmentElement.querySelector('.' + activeLinkClass);
+	var snmAnLinkYposition = 0;
+	var snmAnLinkHeight = 0;
+	if (snmActiveNavLink) {
+		var snmAnLinkBCR = snmActiveNavLink.getBoundingClientRect();
+		snmAnLinkYposition = snmAnLinkBCR.y;
+		snmAnLinkHeight = snmAnLinkBCR.height;
+	}
+	
+	var windowHeight = window.innerHeight;
+
+	if ((snmContainerHeight < currentShift) || ((snmContainerHeight - currentShift) >= snmContentContainerVisibleHeight)) {
+		if (snmContainerHeight - currentShift - snmContentContainerVisibleHeight > 0) {
+			sideNavMenuContainer.style.top = (0 - (snmContainerHeight - snmContentContainerVisibleHeight)) + 'px';
+		}
+	} else if ((snmContentContainerVisibleHeight > windowHeight) || (snmContainerHeight < windowHeight)) {
+		if (snmAnLinkYposition != 0 && ((snmAnLinkYposition + currentShift) > windowHeight)) {
+			var shift = windowHeight - currentShift - snmAnLinkYposition - snmAnLinkHeight;
+			sideNavMenuContainer.style.top = shift + 'px';
+		} else {
+			sideNavMenuContainer.style.top = '0px';
+		}
+	}
+
+}
+
+// collapse or expand in page navigation menu
+function handleClickLinkPanel() {
+    var navigation = fragmentElement.querySelector('.' + inPageNavClass);
+		if (navigation.classList.contains(navigationExpandClass)) {
+			navigation.classList.remove(navigationExpandClass);
+		} else {
+			navigation.classList.add(navigationExpandClass);
+		}
+};
+
+/**
+ * close navigation if the user click outside navigation
+ * @param {object} e 
+ */
+/*InPageNavigation.prototype.checkCloseClick = function (e) {
+    var $el = e.target || e.srcElement;
+    var $navigationList = $el.closest('.idsk-in-page-navigation__list');
+    var $module = fragmentElement;
+    var $linkPanelButton = $module.querySelector('.idsk-in-page-navigation__link-panel');
+
+    if ($navigationList == null) {
+        e.stopPropagation(); // prevent bubbling
+        $module.classList.remove(navigationExpandClass);
+        $linkPanelButton.addEventListener('click', $module.boundHandleClickLinkPanel, true);
+        document.removeEventListener('click', $module.boundCheckCloseClick, true);
+    }
+};*/
+
+/**
+ * An event handler for click event on $link - add actual title to link panel
+ * @param {object} e
+ */
+/*InPageNavigation.prototype.handleClickLink = function (e) {
+    var $link = e.target || e.srcElement;
+    var $id = $link.closest('.idsk-in-page-navigation__link').href.split('#')[1];
+    var $panelHeight = fragmentElement.getElementsByClassName('idsk-in-page-navigation__link-panel')[0].offsetHeight;
+
+    setTimeout(function () {
+        if (document.getElementById($id) != null) {
+            fragmentElement.labelChanged = true;
+            this.changeCurrentLink($link);
+            window.scrollTo(0, document.getElementById($id).offsetTop - ($panelHeight * 2.5));
+        } else {
+            this.changeCurrentLink($link);
+        }
+    }.bind(this), 10);
+};*/
+
+function fixSideMenu(scrollPos) {
+	var sideNavMenuContainer = fragmentElement.querySelector('.' + navigationWrapperClass);
+	var topPosition = fragmentElement.getBoundingClientRect().top + window.scrollY;
+	if (scrollPos > topPosition) {
+		adjustNavMenuWidth();
+		sideNavMenuContainer.classList.add(fixedNavigationClass);
+	} else {
+		sideNavMenuContainer.classList.remove(fixedNavigationClass);
+		sideNavMenuContainer.style.removeProperty('top');
+	}
+
+	usedInpageHeaders.some(function(item) {
+		const itemPositionWithOffset = item.getBoundingClientRect().top + window.scrollY + 1;
+		if (itemPositionWithOffset >= scrollPos && itemPositionWithOffset <= (scrollPos + window.innerHeight)) {
+			setActive(item.getAttribute('id'), true);
+			return true;
+		}
+	});
+}
+
+
+function addEventListeners() {
+    var collapsedMenuBtn = fragmentElement.querySelector('.' + linkPanelBtnClass);
+    collapsedMenuBtn.addEventListener('click', handleClickLinkPanel);
+    Array.prototype.slice.call(fragmentElement.querySelectorAll('.' + inPageNavAnchorClass)).forEach(function(navItem) {
+        navItem.addEventListener('mousedown', function(){
+            setActive(navItem.getAttribute('data-navItemId'));
+        });
+    });
+
+    document.addEventListener('scroll', function(e) {
+		// lastKnownScrollPosition = window.scrollY;
+		fixSideMenu(window.scrollY);
+    });
+	fixSideMenu(window.scrollY);
+
+    window.addEventListener('resize', adjustNavMenuWidth);
+}
+
+
+AUI().ready('aui-module', function(){ 
+    // This code will fire on DOM ready 
+    // and when this module and its
+    // dependencies are ready
+    if (!fragmentElement) {
+        return;
+    }
+	assembleInpageMenu();
+    addEventListeners();
+});;}());</script>
+						</div>
+					
+				
+			</div>
+
+</div>
+	</div>
+</div></div>
+						</div>
+					
+				
+			</div>
+		
+		
+		
+	
+
+
+
+	
+		
+		
+		
+		
+		
+			<div class="">
+
+				
+
+				
+
+					
+
+					
+
+						
+
+						<div class=" mb-lg-0 ml-lg-0 mr-lg-0 mt-lg-0 pb-lg-0 pl-lg-0 pr-lg-0 pt-lg-0" style="box-sizing: border-box;border-style: solid; border-width: 0px;opacity: 1.0;">
+							<div id="fragment-4462-ymtj"> <div class="content-container">
+	<div class="content-container-column content-container-content-area">
+		<div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	
+
+</div>
+	</div>
+</div></div>
+						</div>
+					
+				
+			</div>
+		
+		
+		
+	
+
+
+
+	
+		
+		
+		
+		
+		
+			<div class="">
+
+				
+
+				
+
+					
+
+					
+
+						
+
+						<div class=" mb-lg-0 ml-lg-0 mr-lg-0 mt-lg-0 pb-lg-0 pl-lg-0 pr-lg-0 pt-lg-0" style="box-sizing: border-box;border-style: solid; border-width: 0px;opacity: 1.0;">
+							<div id="fragment-4462-dihf"> <div class="content-container">
+	<div class="content-container-column content-container-content-area">
+		<div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	<div class="">
+
+				
+
+				
+
+					
+
+					
+
+						
+
+						<div class=" mb-lg-0 ml-lg-0 mr-lg-0 mt-lg-0 pb-lg-0 pl-lg-0 pr-lg-0 pt-lg-0" style="box-sizing: border-box;border-style: solid; border-width: 0px;opacity: 1.0;">
+							<div id="fragment-4478-tlwp"> <div class="mzv-content-separator">
+	<hr style="border: solid 4px #000000;
+						 border-bottom: 0px;
+						 margin-top: 50px;
+						 margin-bottom: 50px;">
+</div></div>
+						</div>
+					
+				
+			</div>
+
+</div>
+	</div>
+</div></div>
+						</div>
+					
+				
+			</div>
+
+
+		</div>
+	
+
+
+<form action="#" aria-hidden="true" class="hide" id="hrefFm" method="post" name="hrefFm"><span></span><input hidden="" type="submit"></form>
+
+
+
+	
+		</section>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	<div class="portlet-boundary portlet-boundary_sk_mzv_portal_feedback_portlet_FeedbackPortlet_  portlet-static portlet-static-end portlet-borderless  " id="p_p_id_sk_mzv_portal_feedback_portlet_FeedbackPortlet_">
+		<span id="p_sk_mzv_portal_feedback_portlet_FeedbackPortlet"></span>
+
+
+
+
+	
+
+	
+		
+			
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+	
+	
+		
+<section class="portlet" id="portlet_sk_mzv_portal_feedback_portlet_FeedbackPortlet">
+
+
+	<div class="portlet-content">
+
+
+		
+			<div class=" portlet-content-container">
+				
+
+
+	<div class="portlet-body">
+
+
+
+	
+		
+			
+			
+				
+					
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+				
+
+				
+					
+					
+						
+
+
+	
+
+		
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    
+    
+    
+
+
+
+    
+    
+    
+
+
+
+    
+    
+    
+
+
+
+
+
+
+
+
+<script>
+    function MZV_FooterFeedback($module) {
+        this.$module = $module;
+        // module IDs and Classes
+        this.yesBtnId = "idsk-footer-extended-feedback-yes-button";
+        this.noBtnId = "idsk-footer-extended-feedback-no-button";
+        this.errBtnId = "idsk-footer-extended-error-button";
+        this.writeUsBtnId = "idsk-footer-extended-write-us-button";
+        this.closeHlpBtnId = "idsk-footer-extended-close-help-form-button";
+        this.closeErrBtnId = "idsk-footer-extended-close-error-form-button";
+        this.hlpDescId = "help-description";
+        this.errDescId = "error-description";
+        this.hlpSubmitBtnId = "submit-button-help-form";
+        this.errSubmitBtnId = "submit-button-error-form";
+        this.yesSubmitBtnId = "submit-button-yes-form";
+        this.hlpFormId = "idsk-footer-extended-help-form";
+        this.errFormId = "idsk-footer-extended-error-form";
+        this.yesFormId = "idsk-footer-extended-yes-form";
+        this.infoQuestionId = "idsk-footer-extended-info-question";
+        this.heartIdAndClass = "idsk-footer-extended-heart";
+        this.heartVisibleClass = "idsk-footer-extended-heart-visible";
+        this.displayNoneClass = "idsk-footer-extended-display-none";
+        this.displayHiddenClass = "idsk-footer-extended-display-hidden";
+        this.displayOpenClass = "idsk-footer-extended-open";
+        this.feedbackQuestionId = "idsk-footer-extended-feedback";
+        this.feedbackQuestionContentIdAndClass = "idsk-footer-extended-feedback-content";
+        this.mzvFeedbackCaptchaId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-feedback-form-captcha";
+        this.mzvFeedbackCaptchaAudioId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-feedback-form-captcha-audio";
+        this.reloadFeedbackCaptchaBtnId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-feedback-form-captcha-reload-btn";
+        this.playFeedbackCaptchaBtnId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-feedback-form-captcha-play-btn";
+        this.mzvErrorCaptchaId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-error-form-captcha";
+        this.mzvErrorCaptchaAudioId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-error-form-captcha-audio";
+        this.reloadErrorCaptchaBtnId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-error-form-captcha-reload-btn";
+        this.playErrorCaptchaBtnId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-error-form-captcha-play-btn";
+        this.feedbackCaptchaInputId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-feedback-form-captcha-input";
+        this.errorCaptchaInputId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-error-form-captcha-input";
+        this.errorFromCaptchaErrorId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-error-form-captcha-error";
+        this.feedbackFromCaptchaErrorId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-feedback-form-captcha-error";
+        this.mzvYesCaptchaId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-yes-form-captcha";
+        this.mzvYesCaptchaAudioId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-yes-form-captcha-audio";
+        this.reloadYesCaptchaBtnId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-yes-form-captcha-reload-btn";
+        this.playYesCaptchaBtnId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-yes-form-captcha-play-btn";
+        this.yesCaptchaInputId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-yes-form-captcha-input";
+        this.yesFromCaptchaErrorId = "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-yes-form-captcha-error";
+    }
+
+    MZV_FooterFeedback.prototype.prepareUrl = function (url)  {
+        const joint = url.indexOf('?') === -1 ? '?' : '&';
+        return url + joint + 'reload=' + (new Date).getTime(); // just to prevent cacheing
+    }
+
+    MZV_FooterFeedback.prototype.reloadCaptcha = function ()  {
+        if (!this.$module) {
+            return;
+        }
+        let url = this.prepareUrl('https://www.mzv.sk/en/web/en/visa-and-services/national-visa?p_p_id=sk_mzv_portal_feedback_portlet_FeedbackPortlet&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=%2FcaptchaGraphic.png&p_p_cacheability=cacheLevelPage');
+        this.$module.querySelector('#' + this.mzvFeedbackCaptchaId).setAttribute('src', url);
+        this.$module.querySelector('#' + this.mzvErrorCaptchaId).setAttribute('src', url);
+        this.$module.querySelector('#' + this.mzvYesCaptchaId).setAttribute('src', url);
+    }
+
+    MZV_FooterFeedback.prototype.playCaptcha = function (audioToPlayId)  {
+        if (!this.$module) {
+            return;
+        }
+        let url = this.prepareUrl('https://www.mzv.sk/en/web/en/visa-and-services/national-visa?p_p_id=sk_mzv_portal_feedback_portlet_FeedbackPortlet&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=%2FcaptchaAudio.mp3&p_p_cacheability=cacheLevelPage');
+        this.$module.querySelector('#' + this.mzvFeedbackCaptchaAudioId).setAttribute('src', url);
+        this.$module.querySelector('#' + this.mzvErrorCaptchaAudioId).setAttribute('src', url);
+        this.$module.querySelector('#' + this.mzvYesCaptchaAudioId).setAttribute('src', url);
+        this.$module.querySelector('#' + audioToPlayId).play();
+    }
+
+    MZV_FooterFeedback.prototype.toggleClass = function(node, className) {
+        if (node === null) {
+            return;
+        }
+
+        if (node.className.indexOf(className) > 0) {
+            node.className = node.className.replace(' ' + className, '');
+        } else {
+            node.className += ' ' + className;
+        }
+    }
+
+    MZV_FooterFeedback.prototype.handleYesClick = function() {
+        if (!this.$module) {
+            return;
+        }
+        var yesOption = this.$module.querySelector('#' + this.yesFormId);
+        var feedbackQuestion = this.$module.querySelector('#' + this.feedbackQuestionId);
+        var helpAndErrorContainer = this.$module.querySelector('#' + this.feedbackQuestionContentIdAndClass);
+
+        this.toggleClass(helpAndErrorContainer, this.feedbackQuestionContentIdAndClass);
+        this.toggleClass(feedbackQuestion, this.displayNoneClass);
+        this.toggleClass(yesOption, this.displayHiddenClass);
+        this.toggleClass(yesOption, this.displayOpenClass);
+    }
+
+    MZV_FooterFeedback.prototype.handleNoClick = function() {
+        if (!this.$module) {
+            return;
+        }
+        var helpOption = this.$module.querySelector('#' + this.hlpFormId);
+        var feedbackQuestion = this.$module.querySelector('#' + this.feedbackQuestionId);
+        var helpAndErrorContainer = this.$module.querySelector('#' + this.feedbackQuestionContentIdAndClass);
+
+        this.toggleClass(helpAndErrorContainer, this.feedbackQuestionContentIdAndClass);
+        this.toggleClass(feedbackQuestion, this.displayNoneClass);
+        this.toggleClass(helpOption, this.displayHiddenClass);
+        this.toggleClass(helpOption, this.displayOpenClass);
+    }
+
+    MZV_FooterFeedback.prototype.handleErrorClick = function() {
+        if (!this.$module) {
+            return;
+        }
+        var errorOption = this.$module.querySelector('#' + this.errFormId);
+        var helpOption = this.$module.querySelector('#' + this.hlpFormId);
+        var feedbackQuestion = this.$module.querySelector('#' + this.feedbackQuestionId);
+        var helpAndErrorContainer = this.$module.querySelector('#' + this.feedbackQuestionContentIdAndClass);
+
+        this.toggleClass(helpAndErrorContainer, this.feedbackQuestionContentIdAndClass);
+        this.toggleClass(feedbackQuestion, this.displayNoneClass);
+        helpOption.classList.add(this.displayHiddenClass);
+        helpOption.classList.remove(this.displayOpenClass);
+        this.toggleClass(errorOption, this.displayHiddenClass);
+        this.toggleClass(errorOption, this.displayOpenClass);
+    }
+
+    MZV_FooterFeedback.prototype.handleCloseHelpFormClick = function() {
+        if (!this.$module) {
+            return;
+        }
+        this.clearErrors();
+        var helpOption = this.$module.querySelector('#' + this.hlpFormId);
+        var feedbackQuestion = this.$module.querySelector('#' + this.feedbackQuestionId);
+        var helpAndErrorContainer = this.$module.querySelector('#' + this.feedbackQuestionContentIdAndClass);
+
+        this.toggleClass(helpAndErrorContainer, this.feedbackQuestionContentIdAndClass);
+        this.toggleClass(feedbackQuestion, this.displayNoneClass);
+        this.toggleClass(helpOption, this.displayOpenClass);
+        this.toggleClass(helpOption, this.displayHiddenClass);
+    }
+
+    MZV_FooterFeedback.prototype.handleCloseErrorFormClick = function() {
+        if (!this.$module) {
+            return;
+        }
+        this.clearErrors();
+        var errorOption = this.$module.querySelector('#' + this.errFormId);
+        var feedbackQuestion = this.$module.querySelector('#' + this.feedbackQuestionId);
+        var helpAndErrorContainer = this.$module.querySelector('#' + this.feedbackQuestionContentIdAndClass);
+
+        this.toggleClass(helpAndErrorContainer, this.feedbackQuestionContentIdAndClass);
+        this.toggleClass(feedbackQuestion, this.displayNoneClass);
+        this.toggleClass(errorOption, this.displayOpenClass);
+        this.toggleClass(errorOption, this.displayHiddenClass);
+    }
+
+    MZV_FooterFeedback.prototype.handleDescriptionTextAreaCount = function(elId) {
+        if (!this.$module) {
+            return;
+        }
+        var textArea = this.$module.querySelector('#' + elId);
+        if (textArea) {
+            var countHolder = this.$module.querySelector('#' + elId + '-actual-char-count');
+            countHolder.innerHTML = (350 - textArea.value.length);
+        }
+    }
+
+    MZV_FooterFeedback.prototype.handleHelpDescriptionTextAreaCount = function() {
+        if (!this.$module) {
+            return;
+        }
+        this.handleDescriptionTextAreaCount(this.hlpDescId);
+    }
+
+    MZV_FooterFeedback.prototype.handleErrorDescriptionTextAreaCount = function() {
+        if (!this.$module) {
+            return;
+        }
+        this.handleDescriptionTextAreaCount(this.errDescId);
+    }
+
+    MZV_FooterFeedback.prototype.handleSubmitHelpClick = function() {
+        if (!this.$module) {
+            return;
+        }
+        this.handleSubmit('help-form');
+    }
+
+    MZV_FooterFeedback.prototype.handleSubmitErrorClick = function() {
+        if (!this.$module) {
+            return;
+        }
+        this.handleSubmit('error-form');
+    }
+
+    MZV_FooterFeedback.prototype.handleSubmitYesClick = function() {
+        if (!this.$module) {
+            return;
+        }
+        this.handleSubmit('yes-form');
+    }
+
+    MZV_FooterFeedback.prototype.postRequest = function(action, requestContent) {
+        jQuery.ajax({
+            type: 'POST',
+            url: action,
+            data: requestContent
+        });
+    }
+
+    MZV_FooterFeedback.prototype.handleSubmit = function(formId) {
+        if (!this.$module) {
+            return;
+        }
+        var ajaxCall;
+        switch (formId) {
+            case 'help-form':
+                var joint = "https://www.mzv.sk/en/web/en/visa-and-services/national-visa?p_p_id=sk_mzv_portal_feedback_portlet_FeedbackPortlet&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=addNegativeFeedback&p_p_cacheability=cacheLevelPage&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_pageTitle=National+visa&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_pageUrl=https%3A%2F%2Fwww.mzv.sk%2Fen%2Fweb%2Fen%2Fvisa-and-services%2Fnational-visa&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mvcActionCommand=addNegativeFeedback".indexOf("?") === -1 ? '?' : '&';
+                var url = "https://www.mzv.sk/en/web/en/visa-and-services/national-visa?p_p_id=sk_mzv_portal_feedback_portlet_FeedbackPortlet&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=addNegativeFeedback&p_p_cacheability=cacheLevelPage&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_pageTitle=National+visa&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_pageUrl=https%3A%2F%2Fwww.mzv.sk%2Fen%2Fweb%2Fen%2Fvisa-and-services%2Fnational-visa&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mvcActionCommand=addNegativeFeedback"
+                    + joint + "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_" + 'description=' + this.$module.querySelector('#' + this.hlpDescId).value
+                    + joint + "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_" + 'captchaAnswer=' + this.$module.querySelector('#' + this.feedbackCaptchaInputId).value
+                ajaxCall = jQuery.ajax({
+                    type: 'POST',
+                    url: url
+                });
+                break;
+            case 'error-form':
+                var joint = "https://www.mzv.sk/en/web/en/visa-and-services/national-visa?p_p_id=sk_mzv_portal_feedback_portlet_FeedbackPortlet&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=addDiscrepancyFeedback&p_p_cacheability=cacheLevelPage&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_pageTitle=National+visa&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_pageUrl=https%3A%2F%2Fwww.mzv.sk%2Fen%2Fweb%2Fen%2Fvisa-and-services%2Fnational-visa&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mvcActionCommand=addDiscrepancyFeedback".indexOf("?") === -1 ? '?' : '&';
+                var url = "https://www.mzv.sk/en/web/en/visa-and-services/national-visa?p_p_id=sk_mzv_portal_feedback_portlet_FeedbackPortlet&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=addDiscrepancyFeedback&p_p_cacheability=cacheLevelPage&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_pageTitle=National+visa&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_pageUrl=https%3A%2F%2Fwww.mzv.sk%2Fen%2Fweb%2Fen%2Fvisa-and-services%2Fnational-visa&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mvcActionCommand=addDiscrepancyFeedback"
+                    + joint + "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_" + 'errorType=' + this.$module.querySelector('#fbcksort').value
+                    + joint + "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_" + 'description=' + this.$module.querySelector('#' + this.errDescId).value
+                    + joint + "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_" + 'captchaAnswer=' + this.$module.querySelector('#' + this.errorCaptchaInputId).value
+                ajaxCall = jQuery.ajax({
+                    type: 'POST',
+                    url: url
+                });
+                break;
+            case 'yes-form':
+                var joint = "https://www.mzv.sk/en/web/en/visa-and-services/national-visa?p_p_id=sk_mzv_portal_feedback_portlet_FeedbackPortlet&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=addPositiveFeedback&p_p_cacheability=cacheLevelPage&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_pageTitle=National+visa&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_pageUrl=https%3A%2F%2Fwww.mzv.sk%2Fen%2Fweb%2Fen%2Fvisa-and-services%2Fnational-visa&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mvcActionCommand=addPositiveFeedback".indexOf("?") === -1 ? '?' : '&';
+                var url = "https://www.mzv.sk/en/web/en/visa-and-services/national-visa?p_p_id=sk_mzv_portal_feedback_portlet_FeedbackPortlet&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=addPositiveFeedback&p_p_cacheability=cacheLevelPage&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_pageTitle=National+visa&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_pageUrl=https%3A%2F%2Fwww.mzv.sk%2Fen%2Fweb%2Fen%2Fvisa-and-services%2Fnational-visa&_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mvcActionCommand=addPositiveFeedback"
+                    + joint + "_sk_mzv_portal_feedback_portlet_FeedbackPortlet_" + 'captchaAnswer=' + this.$module.querySelector('#' + this.yesCaptchaInputId).value
+                ajaxCall = jQuery.ajax({
+                    type: 'POST',
+                    url: url
+                });
+                break;
+        }
+        const self = this;
+
+        if (ajaxCall) {
+            ajaxCall.done(function ()  {
+                var yesOption = self.$module.querySelector('#' + self.yesFormId);
+                var noOption = self.$module.querySelector('#' + self.hlpFormId);
+                var errorOption = self.$module.querySelector('#' + self.errFormId);
+                var questionContainer = self.$module.querySelector('#' + self.infoQuestionId);
+                var heartContainer = self.$module.querySelector('#' + self.heartIdAndClass);
+                var feedbackQuestion = self.$module.querySelector('#' + self.feedbackQuestionId);
+                var helpAndErrorContainer = self.$module.querySelector('#' + self.feedbackQuestionContentIdAndClass);
+
+                self.toggleClass(helpAndErrorContainer, self.feedbackQuestionContentIdAndClass);
+                yesOption.classList.add(self.displayHiddenClass);
+                noOption.classList.add(self.displayHiddenClass);
+                errorOption.classList.add(self.displayHiddenClass);
+                yesOption.classList.remove(self.displayOpenClass);
+                noOption.classList.remove(self.displayOpenClass);
+                errorOption.classList.remove(self.displayOpenClass);
+
+                self.toggleClass(questionContainer, self.heartIdAndClass);
+                self.toggleClass(heartContainer, self.heartVisibleClass);
+                self.toggleClass(feedbackQuestion, self.displayNoneClass);
+                self.clearErrors();
+            }).fail(function (jqXHR) {
+                if (jqXHR.status === 422 && jqXHR.responseText === 'captchaValidationFailed') {
+                    switch (formId) {
+                        case 'help-form':
+                            var feedbackErr = self.$module.querySelector('#' + self.feedbackFromCaptchaErrorId);
+                            feedbackErr.classList.remove("mzv-invisible");
+                            var feedbackInput = self.$module.querySelector('#' + self.feedbackCaptchaInputId);
+                            feedbackInput.classList.add("govuk-input--error");
+                            feedbackInput.setAttribute("aria-describedby", self.feedbackFromCaptchaErrorId);
+                            break;
+                        case 'error-form':
+                            var errorErr = self.$module.querySelector('#' + self.errorFromCaptchaErrorId);
+                            errorErr.classList.remove("mzv-invisible");
+                            var errorInput = self.$module.querySelector('#' + self.errorCaptchaInputId);
+                            errorInput.classList.add("govuk-input--error");
+                            errorInput.setAttribute("aria-describedby", self.errorFromCaptchaErrorId);
+                            break;
+                        case 'yes-form':
+                            var yesErr = self.$module.querySelector('#' + self.yesFromCaptchaErrorId);
+                            yesErr.classList.remove("mzv-invisible");
+                            var yesInput = self.$module.querySelector('#' + self.yesCaptchaInputId);
+                            yesInput.classList.add("govuk-input--error");
+                            yesInput.setAttribute("aria-describedby", self.yesFromCaptchaErrorId);
+                            break;
+                    }
+                }
+            });
+        }
+    }
+
+    MZV_FooterFeedback.prototype.clearErrors = function () {
+        var feedbackErr = this.$module.querySelector('#' + this.feedbackFromCaptchaErrorId);
+        feedbackErr.classList.add("mzv-invisible");
+        var feedbackInput = this.$module.querySelector('#' + this.feedbackCaptchaInputId);
+        feedbackInput.classList.remove("govuk-input--error");
+        feedbackInput.removeAttribute("aria-describedby");
+
+        var errorErr = this.$module.querySelector('#' + this.errorFromCaptchaErrorId);
+        errorErr.classList.add("mzv-invisible");
+        var errorInput = this.$module.querySelector('#' + this.errorCaptchaInputId);
+        errorInput.classList.remove("govuk-input--error");
+        errorInput.removeAttribute("aria-describedby");
+
+        var yesErr = this.$module.querySelector('#' + this.yesFromCaptchaErrorId);
+        yesErr.classList.add("mzv-invisible");
+        var yesInput = this.$module.querySelector('#' + this.yesCaptchaInputId);
+        yesInput.classList.remove("govuk-input--error");
+        yesInput.removeAttribute("aria-describedby");
+    }
+
+    MZV_FooterFeedback.prototype.initializeButtons = function() {
+        if (!this.$module) {
+            return;
+        }
+
+        var yesBtn = this.$module.querySelector('#' + this.yesBtnId);
+        var noBtn = this.$module.querySelector('#' + this.noBtnId);
+        var errorBtn = this.$module.querySelector('#' + this.errBtnId);
+        var writeUsButton = this.$module.querySelector('#' + this.writeUsBtnId);
+        var closeHelpFormBtn = this.$module.querySelector('#' + this.closeHlpBtnId);
+        var closeErrorFormBtn = this.$module.querySelector('#' + this.closeErrBtnId);
+        var helpDescriptionTextArea = this.$module.querySelector('#' + this.hlpDescId);
+        var errorDescriptionTextArea = this.$module.querySelector('#' + this.errDescId);
+        var submitHelpBtn = this.$module.querySelector('#' + this.hlpSubmitBtnId);
+        var submitErrorBtn = this.$module.querySelector('#' + this.errSubmitBtnId);
+        var submitYesBtn = this.$module.querySelector('#' + this.yesSubmitBtnId);
+        var reloadFeedbackCaptchaBtn = this.$module.querySelector('#' + this.reloadFeedbackCaptchaBtnId);
+        var playFeedbackCaptchaBtn = this.$module.querySelector('#' + this.playFeedbackCaptchaBtnId);
+        var reloadErrorCaptchaBtn = this.$module.querySelector('#' + this.reloadErrorCaptchaBtnId);
+        var playErrorCaptchaBtn = this.$module.querySelector('#' + this.playErrorCaptchaBtnId);
+        var reloadYesCaptchaBtn = this.$module.querySelector('#' + this.reloadYesCaptchaBtnId);
+        var playYesCaptchaBtn = this.$module.querySelector('#' + this.playYesCaptchaBtnId);
+
+        if (yesBtn) {
+            yesBtn.addEventListener('click', this.handleYesClick.bind(this));
+        }
+        if (noBtn) {
+            noBtn.addEventListener('click', this.handleNoClick.bind(this));
+        }
+        if (errorBtn) {
+            errorBtn.addEventListener('click', this.handleErrorClick.bind(this));
+        }
+        if (writeUsButton) {
+            writeUsButton.addEventListener('click', this.handleErrorClick.bind(this));
+        }
+        if (closeErrorFormBtn) {
+            closeErrorFormBtn.addEventListener('click', this.handleCloseErrorFormClick.bind(this));
+        }
+        if (closeHelpFormBtn) {
+            closeHelpFormBtn.addEventListener('click', this.handleCloseHelpFormClick.bind(this));
+        }        
+        if (helpDescriptionTextArea) {
+            helpDescriptionTextArea.addEventListener('input', this.handleHelpDescriptionTextAreaCount.bind(this));
+        }
+        if (errorDescriptionTextArea) {
+            errorDescriptionTextArea.addEventListener('input', this.handleErrorDescriptionTextAreaCount.bind(this));
+        }
+        if (submitHelpBtn) {
+            submitHelpBtn.addEventListener('click',  this.handleSubmitHelpClick.bind(this));
+        }
+        if (submitErrorBtn) {
+            submitErrorBtn.addEventListener('click',  this.handleSubmitErrorClick.bind(this));
+        }
+        if (submitYesBtn) {
+            submitYesBtn.addEventListener('click',  this.handleSubmitYesClick.bind(this));
+        }
+        if (reloadFeedbackCaptchaBtn) {
+            reloadFeedbackCaptchaBtn.addEventListener('click',  this.reloadCaptcha.bind(this));
+        }
+        if (playFeedbackCaptchaBtn) {
+            playFeedbackCaptchaBtn.addEventListener('click',  this.playCaptcha.bind(this, this.mzvFeedbackCaptchaAudioId));
+        }
+        if (reloadErrorCaptchaBtn) {
+            reloadErrorCaptchaBtn.addEventListener('click',  this.reloadCaptcha.bind(this));
+        }
+        if (playErrorCaptchaBtn) {
+            playErrorCaptchaBtn.addEventListener('click',  this.playCaptcha.bind(this, this.mzvErrorCaptchaAudioId));
+        }
+        if (reloadYesCaptchaBtn) {
+            reloadYesCaptchaBtn.addEventListener('click',  this.reloadCaptcha.bind(this));
+        }
+        if (playYesCaptchaBtn) {
+            playYesCaptchaBtn.addEventListener('click',  this.playCaptcha.bind(this, this.mzvYesCaptchaAudioId));
+        }
+    }
+
+    // Initialize component
+    MZV_FooterFeedback.prototype.init = function () {
+        if (!this.$module) {
+            return;
+        }
+        this.initializeButtons();
+    };
+
+    AUI().ready(() => {
+        new MZV_FooterFeedback(
+            document.querySelector("#_sk_mzv_portal_feedback_portlet_FeedbackPortlet_esmzv-footer-feedback")
+        ).init();
+    })
+</script>
+
+<div class="esmzv-footer-feedback" id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_esmzv-footer-feedback">
+    <div class="idsk-footer-extended-feedback">
+        <div class="govuk-width-container">
+            <div id="idsk-footer-extended-feedback" class="idsk-footer-extended-feedback-text">
+                <div class="idsk-footer-extended-feedback-container">
+                    <div id="idsk-footer-extended-info-question">
+                        <div class="govuk-grid-column-two-thirds idsk-footer-extended-usefull-question">
+                            <span class="idsk-footer-extended-feedback-question-info-usefull">
+                                Was this information helpful to you?
+                            </span>
+                            <span class="idsk-footer-extended-usefull-question-mobile">
+                                Is this page useful?
+                            </span>
+                            <div class="idsk-footer-extended-usefull-answers-mobile">
+                                <div>
+                                    <button id="idsk-footer-extended-feedback-yes-button" type="button" class="idsk-footer-extended-feedback-text-answers idsk-footer-extended-help-button">
+                                        Yes
+                                        <span class="govuk-visually-hidden">
+                                            Was this information helpful to you?
+                                        </span>
+                                    </button>
+                                    <button id="idsk-footer-extended-feedback-no-button" type="button" class="idsk-footer-extended-feedback-text-answers idsk-footer-extended-help-button">
+                                        No
+                                        <span class="govuk-visually-hidden">
+                                            Was this information helpful to you?
+                                        </span>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="govuk-grid-column-one-third idsk-footer-extended-usefull-question idsk-footer-extended-white-border">
+                            <div class="idsk-footer-extended-feedback-question-info-usefull">
+                                <button id="idsk-footer-extended-error-button" type="button" class="idsk-footer-extended-feedback-text-answers idsk-footer-extended-help-button">
+                                    Did you find a mistake on the page?
+                                </button>
+                            </div>
+                            <div class="idsk-footer-extended-usefull-question-mobile ">
+                                <span>
+                                    Did you find a mistake on the page?
+                                </span>
+                                <button id="idsk-footer-extended-write-us-button" type="button" class="idsk-footer-extended-write-us-button idsk-footer-extended-feedback-text-answers idsk-footer-extended-help-button">
+                                    Write to us
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    <div id="idsk-footer-extended-heart" class="idsk-footer-extended-heart govuk-grid-column-full">
+                        Thank you for your feedback
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="idsk-footer-extended-feedback-content">
+        <div class="govuk-width-container">
+            <div class="govuk-grid-row">
+                <div id="idsk-footer-extended-help-form" class="idsk-footer-extended-feedback-hidden idsk-footer-extended-display-hidden">
+                    <div id="idsk-help-container" class="idsk-footer-extended-feedback-container">
+                        <div class="govuk-grid-column-full">
+                            <div class="idsk-footer-extended-feedback-question-container">
+                                <div class="govuk-grid-column-two-thirds idsk-footer-extended-help-form-header-mobile">
+                                    <h3 class="govuk-heading-x">
+                                        Help us improve the content of the site
+                                    </h3>
+                                </div>
+                                <div class="govuk-grid-column-one-third idsk-footer-extended-close-button-mobile">
+                                    <button id="idsk-footer-extended-close-help-form-button" type="button" class="idsk-footer-extended-feedback-button idsk-footer-extended-help-button">
+                                        Close
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="govuk-form-group help-description-t-p">
+                                <label class="govuk-label" for="help-description">
+                                    Tell us what information you were looking for and did not find:
+                                </label>
+                                <textarea class="govuk-textarea govuk-js-character-count" id="help-description" name="help-description" rows="5" maxlength="350" aria-describedby="help-description-hint"></textarea>
+                                <div id="help-description-hint" class="govuk-hint">
+                                    You can enter 
+                                    <span id="help-description-actual-char-count">350</span>/350 
+                                    characters.
+                                    <p>In your 'Feedback' response, the Ministry, as the operator, does not process your personal data. The feedback is used to indicate the content deficiencies of the page that you have noticed, so we ask that you do not enter any of your personal data in the text.</p>
+                                </div>            
+                            </div>
+
+                            <div class="govuk-form-group action-flex-div">
+                                <img id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-feedback-form-captcha" src="https://www.mzv.sk/en/web/en/visa-and-services/national-visa?p_p_id=sk_mzv_portal_feedback_portlet_FeedbackPortlet&amp;p_p_lifecycle=2&amp;p_p_state=normal&amp;p_p_mode=view&amp;p_p_resource_id=%2FcaptchaGraphic.png&amp;p_p_cacheability=cacheLevelPage" alt="Captcha image">
+                                <audio class="hidden-element" id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-feedback-form-captcha-audio" aria-hidden="true"></audio>
+
+                                <button type="button" class="idsk-button mzv-sa-btn" id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-feedback-form-captcha-reload-btn" aria-label="Reload new captcha image">
+                                    Reload
+                                </button>
+
+                                <button type="button" class="idsk-button mzv-sa-btn" id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-feedback-form-captcha-play-btn" aria-label="Play text from captcha image">
+                                    Play
+                                </button>
+                            </div>
+
+                            <div class="govuk-form-group">
+                                <label class="govuk-label" for="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-feedback-form-captcha-input">
+                                    Complete the characters from the picture
+                                </label>
+                                <span id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-feedback-form-captcha-error" class="govuk-error-message mzv-invisible">
+                                    <span class="govuk-visually-hidden">
+                                        Error:
+                                    </span>
+                                    <span class="errorText">
+                                        Incorrectly inserted characters from the image
+                                    </span>
+                                </span>
+                                <input class="govuk-input" id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-feedback-form-captcha-input" name="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-feedback-form-captcha-input" type="text" value="" required="">
+                            </div>
+
+                            <div class="idsk-footer-extended-feedback-button">
+                                <button id="submit-button-help-form" type="submit" class="idsk-button" data-module="idsk-button">
+                                    Send
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div id="idsk-footer-extended-error-form" class="idsk-footer-extended-feedback-hidden idsk-footer-extended-display-hidden">
+                    <div class="idsk-footer-extended-feedback-container">
+                        <div class="govuk-grid-column-full">
+                            <div class="idsk-footer-extended-feedback-question-container">
+                                <div class="govuk-grid-column-two-thirds idsk-footer-extended-help-form-header-mobile">
+                                    <h3 class="govuk-heading-x">
+                                        Help us improve the site
+                                    </h3>
+                                </div>
+                                <div class="govuk-grid-column-one-third idsk-footer-extended-close-button-mobile">
+                                    <button id="idsk-footer-extended-close-error-form-button" type="button" class="idsk-footer-extended-feedback-button idsk-footer-extended-help-button">
+                                        Close
+                                    </button>
+                                </div>
+                            </div>
+                            <div class="idsk-footer-extended-close-button">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label" for="fbcksort">
+                                        What type of deficiency did you find?   
+                                    </label>
+                                    <select class="govuk-select" id="fbcksort" name="sort">
+                                        <option value="content_out_of_date">
+                                            Out of date content
+                                          </option>
+                                        <option value="content_uncomplete">
+                                            The content needs to be supplemented
+                                        </option>
+                                        <option value="responsivity_error">
+                                            Responsiveness error
+                                        </option>
+                                        <option value="other_error">
+                                            Another shortcoming
+                                        </option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div class="govuk-form-group">
+                                <label class="govuk-label" for="error-description">
+                                    Describe the mistake:
+                                </label>
+                                <textarea class="govuk-textarea govuk-js-character-count " id="error-description" name="error-description" rows="5" maxlength="350" aria-describedby="error-description-hint"></textarea>
+                                <div id="error-description-hint" class="govuk-hint">
+                                    You can enter 
+                                    <span id="error-description-actual-char-count">350</span>/350 
+                                    characters.
+                                    <p>In your 'Feedback' response, the Ministry, as the operator, does not process your personal data. The feedback is used to indicate the content deficiencies of the page that you have noticed, so we ask that you do not enter any of your personal data in the text.</p>
+                                </div>
+                            </div>
+
+                            <div class="govuk-form-group action-flex-div">
+                                <img id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-error-form-captcha" src="https://www.mzv.sk/en/web/en/visa-and-services/national-visa?p_p_id=sk_mzv_portal_feedback_portlet_FeedbackPortlet&amp;p_p_lifecycle=2&amp;p_p_state=normal&amp;p_p_mode=view&amp;p_p_resource_id=%2FcaptchaGraphic.png&amp;p_p_cacheability=cacheLevelPage" alt="Captcha image">
+                                <audio class="hidden-element" id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-error-form-captcha-audio" aria-hidden="true"></audio>
+
+                                <button type="button" class="idsk-button mzv-sa-btn" id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-error-form-captcha-reload-btn" aria-label="Reload new captcha image">
+                                    Reload
+                                </button>
+
+                                <button type="button" class="idsk-button mzv-sa-btn" id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-error-form-captcha-play-btn" aria-label="Play text from captcha image">
+                                    Play
+                                </button>
+                            </div>
+
+                            <div class="govuk-form-group">
+                                <label class="govuk-label" for="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-error-form-captcha-input">
+                                    Complete the characters from the picture
+                                </label>
+                                <span id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-error-form-captcha-error" class="govuk-error-message mzv-invisible">
+                                    <span class="govuk-visually-hidden">
+                                        Error:
+                                    </span>
+                                    <span class="errorText">
+                                        Incorrectly inserted characters from the image
+                                    </span>
+                                </span>
+                                <input class="govuk-input" id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-error-form-captcha-input" name="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-error-form-captcha-input" type="text" value="" required="">
+                            </div>
+
+                            <div class="idsk-footer-extended-feedback-button">
+                                <button id="submit-button-error-form" type="submit" class="idsk-button" data-module="idsk-button">
+                                    Send
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div id="idsk-footer-extended-yes-form" class="idsk-footer-extended-feedback-hidden idsk-footer-extended-display-hidden">
+                    <div id="idsk-yes-container" class="idsk-footer-extended-feedback-container">
+                        <div class="govuk-grid-column-full">
+                            <div class="govuk-form-group action-flex-div">
+                                <img id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-yes-form-captcha" src="https://www.mzv.sk/en/web/en/visa-and-services/national-visa?p_p_id=sk_mzv_portal_feedback_portlet_FeedbackPortlet&amp;p_p_lifecycle=2&amp;p_p_state=normal&amp;p_p_mode=view&amp;p_p_resource_id=%2FcaptchaGraphic.png&amp;p_p_cacheability=cacheLevelPage" alt="Captcha image">
+                                <audio class="hidden-element" id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-yes-form-captcha-audio" aria-hidden="true"></audio>
+
+                                <button type="button" class="idsk-button mzv-sa-btn" id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-yes-form-captcha-reload-btn" aria-label="Reload new captcha image">
+                                    Reload
+                                </button>
+
+                                <button type="button" class="idsk-button mzv-sa-btn" id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-yes-form-captcha-play-btn" aria-label="Play text from captcha image">
+                                    Play
+                                </button>
+                            </div>
+
+                            <div class="govuk-form-group">
+                                <label class="govuk-label" for="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-yes-form-captcha-input">
+                                    Complete the characters from the picture
+                                </label>
+                                <span id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-yes-form-captcha-error" class="govuk-error-message mzv-invisible">
+                                    <span class="govuk-visually-hidden">
+                                        Error:
+                                    </span>
+                                    <span class="errorText">
+                                        Incorrectly inserted characters from the image
+                                    </span>
+                                </span>
+                                <input class="govuk-input" id="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-yes-form-captcha-input" name="_sk_mzv_portal_feedback_portlet_FeedbackPortlet_mzv-yes-form-captcha-input" type="text" value="" required="">
+                            </div>
+
+                            <div class="idsk-footer-extended-yes-button">
+                                <button id="submit-button-yes-form" type="submit" class="idsk-button" data-module="idsk-button">
+                                    Send
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+	
+	
+
+					
+				
+			
+		
+	
+	
+
+
+
+	</div>
+
+			</div>
+		
+	</div>
+</section>
+	
+
+		
+		
+	
+
+
+
+
+
+
+
+	</div>
+
+
+
+
+
+
+<div style="display: none">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	<div class="portlet-boundary portlet-boundary_sk_mzv_portal_pdf_viewer_embedded_PDFViewerPortlet_  portlet-static portlet-static-end portlet-borderless  " id="p_p_id_sk_mzv_portal_pdf_viewer_embedded_PDFViewerPortlet_">
+		<span id="p_sk_mzv_portal_pdf_viewer_embedded_PDFViewerPortlet"></span>
+
+
+
+
+	
+
+	
+		
+			
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+	
+	
+		
+<section class="portlet" id="portlet_sk_mzv_portal_pdf_viewer_embedded_PDFViewerPortlet">
+
+
+	<div class="portlet-content">
+
+
+		
+			<div class=" portlet-content-container">
+				
+
+
+	<div class="portlet-body">
+
+
+
+	
+		
+			
+			
+				
+					
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+				
+
+				
+					
+					
+						
+
+
+	
+
+		
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="embedded-viewer-body pdfviewer-hidden ">
+    <nav class="navbar sticky-top navbar-light header">
+        <div class="container-fluid">
+            <div class="float-start">
+                <a class="navbar-brand"></a>
+            </div>
+            <div class="float-end">
+                <button class="main-menu-button js-viewer-bottom-menu js-viewer-page-info" id="pages-button" type="submit">
+                </button>
+            </div>
+            <div class="float-none">
+                <button class="main-menu-button js-viewer-main-menu" type="submit">
+                    <i class="fa fa-bars"></i>
+                    Možnosti dokumentu
+                </button>
+                <button class="main-menu-button js-viewer-close" type="submit">
+                    <i class="fa fa-sign-out-alt"></i>
+                    Zatvoriť
+                </button>
+            </div>
+        </div>
+    </nav>
+
+    <div class="d-flex flex-column flex-shrink-0 hidden" id="main-navbar">
+        <div class="main-navbar-header">
+
+            <span class="main-navbar-header-title">Sidebar</span>
+            <button class="main-navbar-header-x js-viewer-main-menu" type="submit">
+                <i class="fa fa-times"></i>
+            </button>
+            <hr>
+        </div>
+        <ul class="nav nav-pills flex-column mb-auto main-navbar-list p-3">
+            <li class="nav-item main-navbar-item">
+                <a href="" target="_blank" data-disable-pdf-viewer="true" class="nav-link text-black js-viewer-download">
+                    <svg class="bi me-2" width="16" height="16">
+                        <use xlink:href="#speedometer2"></use>
+                    </svg>
+                    Stiahni PDF
+                </a>
+            </li>
+            <li class="nav-item clickable-item main-navbar-item">
+                <a class="nav-link text-black js-viewer-bottom-menu">
+                    <svg class="bi me-2" width="16" height="16">
+                        <use xlink:href="#speedometer2"></use>
+                    </svg>
+                    Náhľad
+                </a>
+            </li>
+            <li class="nav-item main-navbar-item">
+                <a class="nav-link text-black js-viewer-main-menu">
+                    <svg class="bi me-2" width="16" height="16">
+                        <use xlink:href="#speedometer2"></use>
+                    </svg>
+                    Zatvoriť
+                </a>
+            </li>
+        </ul>
+    </div>
+
+    <div id="main-content" class="fullScreen">
+        <div class="container main-content-container js-viewer-large-slide-container" id="main-content-container">
+
+            <div class="mySlides js-viewer-large-slide" style="cursor:zoom-in;">
+                <img src="" style="width:100%;" class="big-image noselect">
+            </div>
+
+
+            <a class="prev js-viewer-prev" id="arrow-prev">
+                <i class="fa-solid fa-chevron-left"></i>
+            </a>
+            <a class="next js-viewer-next" id="arrow-next">
+                <i class="fa-solid fa-chevron-right"></i>
+            </a>
+
+        </div>
+    </div>
+    <div class="flex-column flex-shrink-0 p-1 hidden" id="bottom-navbar">
+        <div class="gallery-row js-viewer-small-slide-container" id="bottom-gallery-scrollable ">
+
+
+            <div class="gallery-column js-viewer-small-slide">
+                <img class="demo cursor js-viewer-slide" src="" data-slide="1" alt="">
+                <span class="number">1</span>
+            </div>
+
+
+        </div>
+    </div>
+</div>
+
+<script>
+    
+    
+
+    jQuery(function () {
+
+        jQuery(document).on('click', 'a', function (e) {
+            const $e = jQuery(e.target);
+            const $disableViewer = $e.attr('data-disable-pdf-viewer');
+            if ($disableViewer === 'true') {
+                return;
+            }
+
+            const href = $e.attr('href');
+
+            if (!href || href.startsWith('#')) {
+                return;
+            }
+
+            //dont preview pdfs from other sites
+            if (href.startsWith('http')) {
+                const windowDomain = (new URL(window.location.href)).hostname;
+                const linkDomain = (new URL(href)).hostname;
+                if (windowDomain !== linkDomain) {
+                    return;
+                }
+            }
+
+            if (href.indexOf(".pdf") !== -1) {
+                e.preventDefault();
+
+                jQuery('.js-viewer-download').attr('href', href);
+
+                const url = 'https://www.mzv.sk/en/web/en/visa-and-services/national-visa?p_p_id=sk_mzv_portal_pdf_viewer_embedded_PDFViewerPortlet&p_p_lifecycle=2&p_p_state=normal&p_p_mode=view&p_p_resource_id=%2Fmetadata&p_p_cacheability=cacheLevelPage';
+                const urlParts = href.split('/');
+                const urlParts2 = urlParts[urlParts.length - 1].split('?');
+
+                $.getJSON(url + "&uuid=" + urlParts2[0], function (response) {
+                    const numberOfPages = response.numberOfPages;
+
+                    let imageUrls = [];
+                    for (let i = 0; i < numberOfPages; i++) {
+                        imageUrls.push(href + (href.indexOf("?") > 0 ? "&" : "?") + "previewFileIndex=" + (i + 1));
+                    }
+
+                    new PDFViewer().show(imageUrls);
+
+                })
+            }
+        })
+    })
+</script>
+
+	
+	
+
+					
+				
+			
+		
+	
+	
+
+
+
+	</div>
+
+			</div>
+		
+	</div>
+</section>
+	
+
+		
+		
+	
+
+
+
+
+
+
+
+	</div>
+
+
+
+
+
+
+</div>
+<footer class="idsk-footer " role="contentinfo">
+	<div class="govuk-width-container">
+		<!--div class="govuk-grid-column-two-thirds">
+			<h3 class="govuk-heading-m ">
+				Target groups
+			</h3>
+			<div class="idsk-footer-extended-subtitle footer-nav-div">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	<div class="portlet-boundary portlet-boundary_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_  portlet-static portlet-static-end portlet-barebone portlet-navigation " id="p_p_id_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_main_navigation_menu_">
+		<span id="p_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_main_navigation_menu"></span>
+
+
+
+
+	
+
+	
+		
+			
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+	
+	
+		
+<section class="portlet" id="portlet_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_main_navigation_menu">
+
+
+	<div class="portlet-content">
+
+
+		
+			<div class=" portlet-content-container">
+				
+
+
+	<div class="portlet-body">
+
+
+
+	
+		
+			
+			
+				
+					
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+				
+
+				
+					
+					
+						
+
+
+	
+
+		
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+	
+	
+
+		
+
+		
+			
+			
+				<div class="alert alert-warning">
+					There is no <em>Primary Navigation</em> available for the current site.
+				</div>
+			
+		
+	
+	
+
+
+	
+	
+
+					
+				
+			
+		
+	
+	
+
+
+
+	</div>
+
+			</div>
+		
+	</div>
+</section>
+	
+
+		
+		
+	
+
+
+
+
+
+
+
+	</div>
+
+
+
+
+
+
+			</div>
+		</div>
+		<div class="govuk-grid-column-one-third">
+			<h3 class="govuk-heading-m">
+				Electronic services
+			</h3>
+			<div class="govuk-grid-column-three-thirds idsk-footer-extended-subtitle">
+				<ul style="padding: 0; margin-bottom: 2px;">
+					<li class="idsk-footer-extended-list-item">
+						<a class="e-sluzby-link govuk-link" title="elektronicke sluzby" href="#">Electronic services MZV SR</a>
+					</li>
+				</ul>
+			</div>
+		</div-->
+		<div class="govuk-grid-column-full" style="margin-top: 2rem;">
+			<ul class="idsk-footer__inline-list">
+				<li class="idsk-footer__inline-list-item">
+					<a class="idsk-footer__link" href="/en/web/en/contact/opening-hours-to-public">
+						Contacts
+					</a>
+				</li>
+				<li class="idsk-footer__inline-list-item">
+					<a class="idsk-footer__link" href="/en/web/en/representation-about-accessibility">
+						Accessibility statement
+					</a>
+				</li>
+				<li class="idsk-footer__inline-list-item">
+					<a class="idsk-footer__link" href="/en/web/en/technical-support">
+						Technical support
+					</a>
+				</li>
+				<li class="idsk-footer__inline-list-item">
+					<a class="idsk-footer__link" href="/en/web/en/content-manager">
+						Content manager
+					</a>
+				</li>
+				<li class="idsk-footer__inline-list-item">
+					<a class="idsk-footer__link" href="/en/web/en/cookies">
+						Cookies
+					</a>
+				</li>
+				<li class="idsk-footer__inline-list-item">
+					<a class="idsk-footer__link" href="/en/web/en/mzv-site-map">
+						Site map
+					</a>
+				</li>
+				<li class="idsk-footer__inline-list-item">
+					<a class="idsk-footer__link" href="/en/web/en/home/-/journal/rss/10182/13409199">
+						RSS
+					</a>
+				</li>
+				<li class="idsk-footer__inline-list-item">
+					<a class="idsk-footer__link" href="/en/web/en/privacy-protection-policy">
+						Privacy
+					</a>
+				</li>
+			</ul>
+
+			<ul class="idsk-footer__inline-list footer__inline-list_social">
+				<li class="idsk-footer__inline-list-item">
+					<a class="idsk-footer__link" href="https://www.instagram.com/diplomacia.sk/">
+						<img class="footer_social_link" src="/o/mzvTheme/images/social_media/instagram_logo_icon_footer.svg" alt="instagram">
+					</a>
+				</li>
+				<li class="idsk-footer__inline-list-item">
+					<a class="idsk-footer__link" href="https://www.linkedin.com/company/mzvezsr/mycompany/">
+						<img class="footer_social_link" src="/o/mzvTheme/images/social_media/linkedin_logo_icon_footer.svg" alt="linkedinn">
+					</a>
+				</li>
+				<li class="idsk-footer__inline-list-item">
+					<a class="idsk-footer__link" href="https://www.facebook.com/mzv.sk">
+						<img class="footer_social_link" src="/o/mzvTheme/images/social_media/facebook_logo_icon_footer.svg" alt="facebook">
+					</a>
+				</li>
+				<li class="idsk-footer__inline-list-item">
+					<a class="idsk-footer__link" href="https://twitter.com/SlovakiaMFA">
+						<img class="footer_social_link" src="/o/mzvTheme/images/social_media/twitter_logo_icon_footer.svg" alt="twitter">
+					</a>
+				</li>
+				<li class="idsk-footer__inline-list-item">
+					<a class="idsk-footer__link" href="https://www.flickr.com/photos/mzvsr/">
+						<img class="footer_social_link" src="/o/mzvTheme/images/social_media/flicker_logo_icon_footer.svg" alt="flickr">
+					</a>
+				</li>
+				<li class="idsk-footer__inline-list-item">
+					<a class="idsk-footer__link" href="https://www.youtube.com/user/mzvsr">
+						<img class="footer_social_link" src="/o/mzvTheme/images/social_media/youtube_logo_icon_footer.svg" alt="youtube">
+					</a>
+				</li>
+			</ul>
+		</div>
+
+		<div class="govuk-grid-column-full">
+			<div class="idsk-footer__meta">
+				<div class="idsk-footer__meta-item idsk-footer__meta-item--grow">
+					<span class="idsk-footer__licence-description">
+						Created in accordance with 
+						<a href="https://idsk.gov.sk/">uniform design of the electronic services manual.</a>
+					</span>
+					<span class="idsk-footer__licence-description">
+						The service is operated by the Ministry of Foreign Affairs and European Affairs of the Slovak Republic. Request for information <a href="mailto:info@mzv.sk">info@mzv.sk</a>.
+					</span>
+				</div>
+				<div class="idsk-footer__meta-item footer_logo">
+					<a class="idsk-footer__licence-logo idsk-footer__link" href="/en/web/en/" title="Anchor to main page of the Ministry of Foreign Affairs and European Affairs of the Slovak Republic">
+						<img aria-hidden="true" alt="Logo" src="/o/mzvTheme/images/mzvLogoBlackEn.svg">
+					</a>
+				</div>
+			</div>
+		</div>
+	</div>
+</footer>		<span onclick="scrollOnTop()" title="Back to top" id="return-to-top" role="button">
+			<em class="return-to-top-em"></em>
+			<span class="sr-only">Back To Top</span>
+		</span>
+	</div>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	
+
+
+
+
+
+	
+
+
+
+	
+
+
+
+
+
+
+
+
+
+	
+
+	
+
+
+
+
+
+	
+
+
+
+	
+
+
+
+
+
+
+
+
+
+<script type="text/javascript">
+// <![CDATA[
+
+	
+		
+		
+
+			
+
+			
+		
+	
+
+// ]]>
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+<script type="text/javascript">
+	// <![CDATA[
+
+		
+
+		Liferay.currentURL = '\x2fen\x2fweb\x2fen\x2fvisa-and-services\x2fnational-visa';
+		Liferay.currentURLEncoded = '\x252Fen\x252Fweb\x252Fen\x252Fvisa-and-services\x252Fnational-visa';
+
+	// ]]>
+</script>
+
+
+
+	
+
+	
+
+	<script type="text/javascript">
+		// <![CDATA[
+			
+				
+
+				
+
+				
+			
+		// ]]>
+	</script>
+
+
+
+
+
+
+
+
+
+
+
+
+	
+
+	
+
+		
+
+		
+	
+
+
+<script type="text/javascript">
+// <![CDATA[
+(function() {var $ = AUI.$;var _ = AUI._;
+	var onShare = function (data) {
+		if (window.Analytics) {
+			Analytics.send('shared', 'SocialBookmarks', {
+				className: data.className,
+				classPK: data.classPK,
+				type: data.type,
+				url: data.url,
+			});
+		}
+	};
+
+	var onDestroyPortlet = function () {
+		Liferay.detach('socialBookmarks:share', onShare);
+		Liferay.detach('destroyPortlet', onDestroyPortlet);
+	};
+
+	Liferay.on('socialBookmarks:share', onShare);
+	Liferay.on('destroyPortlet', onDestroyPortlet);
+})();(function() {var $ = AUI.$;var _ = AUI._;
+	var onDestroyPortlet = function () {
+		Liferay.detach('messagePosted', onMessagePosted);
+		Liferay.detach('destroyPortlet', onDestroyPortlet);
+	};
+
+	Liferay.on('destroyPortlet', onDestroyPortlet);
+
+	var onMessagePosted = function (event) {
+		if (window.Analytics) {
+			Analytics.send('posted', 'Comment', {
+				className: event.className,
+				classPK: event.classPK,
+				commentId: event.commentId,
+				text: event.text,
+			});
+		}
+	};
+
+	Liferay.on('messagePosted', onMessagePosted);
+})();(function() {var $ = AUI.$;var _ = AUI._;
+	var pathnameRegexp = /\/documents\/(\d+)\/(\d+)\/(.+?)\/([^&]+)/;
+
+	function handleDownloadClick(event) {
+		if (event.target.nodeName.toLowerCase() === 'a' && window.Analytics) {
+			var anchor = event.target;
+			var match = pathnameRegexp.exec(anchor.pathname);
+
+			var fileEntryId =
+				anchor.dataset.analyticsFileEntryId ||
+				(anchor.parentElement &&
+					anchor.parentElement.dataset.analyticsFileEntryId);
+
+			if (fileEntryId && match) {
+				var getParameterValue = function (parameterName) {
+					var result = null;
+
+					anchor.search
+						.substr(1)
+						.split('&')
+						.forEach(function (item) {
+							var tmp = item.split('=');
+
+							if (tmp[0] === parameterName) {
+								result = decodeURIComponent(tmp[1]);
+							}
+						});
+
+					return result;
+				};
+
+				Analytics.send('documentDownloaded', 'Document', {
+					groupId: match[1],
+					fileEntryId: fileEntryId,
+					preview: !!window._com_liferay_document_library_analytics_isViewFileEntry,
+					title: decodeURIComponent(match[3].replace(/\+/gi, ' ')),
+					version: getParameterValue('version'),
+				});
+			}
+		}
+	}
+
+	Liferay.once('destroyPortlet', function () {
+		document.body.removeEventListener('click', handleDownloadClick);
+	});
+
+	Liferay.once('portletReady', function () {
+		document.body.addEventListener('click', handleDownloadClick);
+	});
+})();(function() {var $ = AUI.$;var _ = AUI._;
+	var onVote = function (event) {
+		if (window.Analytics) {
+			Analytics.send('VOTE', 'Ratings', {
+				className: event.className,
+				classPK: event.classPK,
+				ratingType: event.ratingType,
+				score: event.score,
+			});
+		}
+	};
+
+	var onDestroyPortlet = function () {
+		Liferay.detach('ratings:vote', onVote);
+		Liferay.detach('destroyPortlet', onDestroyPortlet);
+	};
+
+	Liferay.on('ratings:vote', onVote);
+	Liferay.on('destroyPortlet', onDestroyPortlet);
+})();
+	if (window.svg4everybody && Liferay.Data.ICONS_INLINE_SVG) {
+		svg4everybody(
+			{
+				polyfill: true,
+				validate: function (src, svg, use) {
+					return !src || !src.startsWith('#');
+				}
+			}
+		);
+	}
+
+	
+		Liferay.Portlet.register('sk_mzv_portal_feedback_portlet_FeedbackPortlet');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 0,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_sk_mzv_portal_feedback_portlet_FeedbackPortlet_',
+			portletId: 'sk_mzv_portal_feedback_portlet_FeedbackPortlet',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d4898762\x26p_p_id\x3dsk_mzv_portal_feedback_portlet_FeedbackPortlet\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3dnull\x26p_p_col_pos\x3dnull\x26p_p_col_count\x3dnull\x26p_p_static\x3d1\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Fweb\x252Fen\x252Fvisa-and-services\x252Fnational-visa\x26settingsScope\x3dportletInstance',
+			refreshURLData: {}
+		}
+	);
+
+	
+		Liferay.Portlet.register('com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_ngmj');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 0,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_ngmj_',
+			portletId: 'com_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_ngmj',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d4898762\x26p_p_id\x3dcom_liferay_journal_content_web_portlet_JournalContentPortlet_INSTANCE_ngmj\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3dnull\x26p_p_col_pos\x3dnull\x26p_p_col_count\x3dnull\x26p_p_static\x3d1\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Fweb\x252Fen\x252Fvisa-and-services\x252Fnational-visa\x26settingsScope\x3dportletInstance',
+			refreshURLData: {}
+		}
+	);
+
+	
+		Liferay.Portlet.register('com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_main_navigation_menu');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 0,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_main_navigation_menu_',
+			portletId: 'com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_main_navigation_menu',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d4898762\x26p_p_id\x3dcom_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_INSTANCE_main_navigation_menu\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3dnull\x26p_p_col_pos\x3dnull\x26p_p_col_count\x3dnull\x26p_p_static\x3d1\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Fweb\x252Fen\x252Fvisa-and-services\x252Fnational-visa\x26settingsScope\x3dportletInstance',
+			refreshURLData: {}
+		}
+	);
+
+	
+		Liferay.Portlet.register('sk_mzv_portal_breadcrumb_portlet_BreadcrumbPortlet_INSTANCE_dbzm');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 0,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_sk_mzv_portal_breadcrumb_portlet_BreadcrumbPortlet_INSTANCE_dbzm_',
+			portletId: 'sk_mzv_portal_breadcrumb_portlet_BreadcrumbPortlet_INSTANCE_dbzm',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d4898762\x26p_p_id\x3dsk_mzv_portal_breadcrumb_portlet_BreadcrumbPortlet_INSTANCE_dbzm\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3dnull\x26p_p_col_pos\x3dnull\x26p_p_col_count\x3dnull\x26p_p_static\x3d1\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Fweb\x252Fen\x252Fvisa-and-services\x252Fnational-visa\x26settingsScope\x3dportletInstance',
+			refreshURLData: {}
+		}
+	);
+
+	
+		Liferay.Portlet.register('sk_mzv_portal_pdf_viewer_embedded_PDFViewerPortlet');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 0,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_sk_mzv_portal_pdf_viewer_embedded_PDFViewerPortlet_',
+			portletId: 'sk_mzv_portal_pdf_viewer_embedded_PDFViewerPortlet',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d4898762\x26p_p_id\x3dsk_mzv_portal_pdf_viewer_embedded_PDFViewerPortlet\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3dnull\x26p_p_col_pos\x3dnull\x26p_p_col_count\x3dnull\x26p_p_static\x3d1\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Fweb\x252Fen\x252Fvisa-and-services\x252Fnational-visa\x26settingsScope\x3dportletInstance',
+			refreshURLData: {}
+		}
+	);
+
+	
+		Liferay.Portlet.register('com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet');
+	
+
+	Liferay.Portlet.onLoad(
+		{
+			canEditTitle: false,
+			columnPos: 0,
+			isStatic: 'end',
+			namespacedId: 'p_p_id_com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet_',
+			portletId: 'com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet',
+			refreshURL: '\x2fen\x2fc\x2fportal\x2frender_portlet\x3fp_l_id\x3d4898762\x26p_p_id\x3dcom_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet\x26p_p_lifecycle\x3d0\x26p_t_lifecycle\x3d0\x26p_p_state\x3dnormal\x26p_p_mode\x3dview\x26p_p_col_id\x3dnull\x26p_p_col_pos\x3dnull\x26p_p_col_count\x3dnull\x26p_p_static\x3d1\x26p_p_isolated\x3d1\x26currentURL\x3d\x252Fen\x252Fweb\x252Fen\x252Fvisa-and-services\x252Fnational-visa\x26settingsScope\x3dportletInstance',
+			refreshURLData: {}
+		}
+	);
+Liferay.Loader.require('metal-dom/src/all/dom', 'frontend-js-web/liferay/toast/commands/OpenToast.es', function(metalDomSrcAllDom, frontendJsWebLiferayToastCommandsOpenToastEs) {
+try {
+(function() {
+var dom = metalDomSrcAllDom;
+var $ = AUI.$;var _ = AUI._;
+	var focusInPortletHandler = dom.delegate(
+		document,
+		'focusin',
+		'.portlet',
+		function(event) {
+			dom.addClasses(dom.closest(event.delegateTarget, '.portlet'), 'open');
+		}
+	);
+
+	var focusOutPortletHandler = dom.delegate(
+		document,
+		'focusout',
+		'.portlet',
+		function(event) {
+			dom.removeClasses(dom.closest(event.delegateTarget, '.portlet'), 'open');
+		}
+	);
+
+})();
+(function() {
+var toastCommands = frontendJsWebLiferayToastCommandsOpenToastEs;
+var $ = AUI.$;var _ = AUI._;
+			AUI().use(
+				'liferay-session',
+				function() {
+					Liferay.Session = new Liferay.SessionBase(
+						{
+							autoExtend: true,
+							redirectOnExpire: false,
+							redirectUrl: 'https\x3a\x2f\x2fwww\x2emzv\x2esk\x2fweb\x2fsk',
+							sessionLength: 28770,
+							warningLength: 0
+						}
+					);
+
+					
+				}
+			);
+		
+})();
+} catch (err) {
+	console.error(err);
+}
+});AUI().use('liferay-menu', 'aui-base', function(A) {(function() {var $ = AUI.$;var _ = AUI._;
+	if (A.UA.mobile) {
+		Liferay.Util.addInputCancel();
+	}
+})();(function() {var $ = AUI.$;var _ = AUI._;
+	new Liferay.Menu();
+
+	var liferayNotices = Liferay.Data.notices;
+
+	for (var i = 0; i < liferayNotices.length; i++) {
+		Liferay.Util.openToast(liferayNotices[i]);
+	}
+
+})();});
+// ]]>
+</script>
+
+
+
+
+
+
+
+	
+	<link data-senna-track="temporary" href="/o/product-navigation-product-menu-web/css/main.css?browserId=chrome&amp;themeId=mzvtheme_WAR_mzvTheme&amp;minifierType=css&amp;languageId=en_US&amp;b=7307&amp;t=1623129696000" rel="stylesheet" type="text/css">
+<link data-senna-track="temporary" href="/o/portal-search-web/css/main.css?browserId=chrome&amp;themeId=mzvtheme_WAR_mzvTheme&amp;minifierType=css&amp;languageId=en_US&amp;b=7307&amp;t=1623128752000" rel="stylesheet" type="text/css">
+<link data-senna-track="temporary" href="/o/sk.mzv.portal.feedback/css/main.css?browserId=chrome&amp;themeId=mzvtheme_WAR_mzvTheme&amp;minifierType=css&amp;languageId=en_US&amp;b=7307&amp;t=1763468238000" rel="stylesheet" type="text/css">
+<link data-senna-track="temporary" href="/o/com.liferay.product.navigation.user.personal.bar.web/css/main.css?browserId=chrome&amp;themeId=mzvtheme_WAR_mzvTheme&amp;minifierType=css&amp;languageId=en_US&amp;b=7307&amp;t=1611597002000" rel="stylesheet" type="text/css">
+<link data-senna-track="temporary" href="/o/sk.mzv.portal.pdf.viewer.embedded/css/main.css?browserId=chrome&amp;themeId=mzvtheme_WAR_mzvTheme&amp;minifierType=css&amp;languageId=en_US&amp;b=7307&amp;t=1674645816000" rel="stylesheet" type="text/css">
+<script data-senna-track="permanent" src="/o/sk.mzv.portal.pdf.viewer.embedded/js/init.js?browserId=chrome&amp;minifierType=js&amp;languageId=en_US&amp;b=7307&amp;t=1674645816000" type="text/javascript"></script>
+<link data-senna-track="temporary" href="/o/journal-content-web/css/main.css?browserId=chrome&amp;themeId=mzvtheme_WAR_mzvTheme&amp;minifierType=css&amp;languageId=en_US&amp;b=7307&amp;t=1617816530000" rel="stylesheet" type="text/css">
+<link data-senna-track="temporary" href="/o/sk.mzv.portal.search.global/css/input.css?browserId=chrome&amp;themeId=mzvtheme_WAR_mzvTheme&amp;minifierType=css&amp;languageId=en_US&amp;b=7307&amp;t=1763466230000" rel="stylesheet" type="text/css">
+
+
+
+
+
+
+
+<script src="https://www.mzv.sk/o/mzvTheme/js/main.js?browserId=chrome&amp;minifierType=js&amp;languageId=en_US&amp;b=7307&amp;t=1771511136000" type="text/javascript"></script>
+
+
+
+
+<script type="text/javascript">
+	// <![CDATA[
+		AUI().use(
+			'aui-base',
+			function(A) {
+				var frameElement = window.frameElement;
+
+				if (frameElement && frameElement.getAttribute('id') === 'simulationDeviceIframe') {
+					A.getBody().addClass('lfr-has-simulation-panel');
+				}
+			}
+		);
+	// ]]>
+</script><script type="text/javascript">
+// <![CDATA[
+Liferay.Loader.require('frontend-js-tabs-support-web@1.0.8/index', function(frontendJsTabsSupportWeb108Index) {
+try {
+(function() {
+var TabsProvider = frontendJsTabsSupportWeb108Index;
+TabsProvider.default()
+})();
+} catch (err) {
+	console.error(err);
+}
+});
+// ]]>
+</script><script type="text/javascript">
+// <![CDATA[
+Liferay.Loader.require('frontend-js-alert-support-web@1.0.7/index', function(frontendJsAlertSupportWeb107Index) {
+try {
+(function() {
+var AlertProvider = frontendJsAlertSupportWeb107Index;
+AlertProvider.default()
+})();
+} catch (err) {
+	console.error(err);
+}
+});
+// ]]>
+</script><script type="text/javascript">
+// <![CDATA[
+Liferay.Loader.require('frontend-js-collapse-support-web@1.0.10/index', function(frontendJsCollapseSupportWeb1010Index) {
+try {
+(function() {
+var CollapseProvider = frontendJsCollapseSupportWeb1010Index;
+CollapseProvider.default()
+})();
+} catch (err) {
+	console.error(err);
+}
+});
+// ]]>
+</script><script type="text/javascript">
+// <![CDATA[
+Liferay.Loader.require('frontend-js-dropdown-support-web@1.0.8/index', function(frontendJsDropdownSupportWeb108Index) {
+try {
+(function() {
+var DropdownProvider = frontendJsDropdownSupportWeb108Index;
+DropdownProvider.default()
+})();
+} catch (err) {
+	console.error(err);
+}
+});
+// ]]>
+</script><script type="text/javascript">
+// <![CDATA[
+Liferay.Loader.require('frontend-js-tooltip-support-web@3.0.4/index', function(frontendJsTooltipSupportWeb304Index) {
+try {
+(function() {
+var TooltipSupport = frontendJsTooltipSupportWeb304Index;
+TooltipSupport.default()
+})();
+} catch (err) {
+	console.error(err);
+}
+});
+// ]]>
+</script><script type="text/javascript">
+// <![CDATA[
+Liferay.Loader.require('remote-app-support-web@1.0.5/index', function(remoteAppSupportWeb105Index) {
+try {
+(function() {
+var RemoteAppSupport = remoteAppSupportWeb105Index;
+RemoteAppSupport.default()
+})();
+} catch (err) {
+	console.error(err);
+}
+});
+// ]]>
+</script>
+<script defer="" src="https://static.cloudflareinsights.com/beacon.min.js/v833ccba57c9e4d2798f2e76cebdd09a11778172276447" integrity="sha512-57MDmcccJXYtNnH+ZiBwzC4jb2rvgVCEokYN+L/nLlmO8rfYT/gIpW2A569iJ/3b+0UEasghjuZH/ma3wIs/EQ==" data-cf-beacon="{&quot;version&quot;:&quot;2024.11.0&quot;,&quot;token&quot;:&quot;f978764ee57e449c82ec0a3f92ac4386&quot;,&quot;server_timing&quot;:{&quot;name&quot;:{&quot;cfCacheStatus&quot;:true,&quot;cfEdge&quot;:true,&quot;cfExtPri&quot;:true,&quot;cfL4&quot;:true,&quot;cfOrigin&quot;:true,&quot;cfSpeedBrain&quot;:true},&quot;location_startswith&quot;:null}}" crossorigin="anonymous"></script>
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'a0c58a083f491fb5',t:'MTc4MTU2ODA3OA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script><iframe height="1" width="1" style="position: absolute; top: 0px; left: 0px; border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; visibility: hidden;"></iframe>
+
+
+		
+	
+
+<div id="yui3-css-stamp" style="position: absolute !important; visibility: hidden !important" class=""></div><div id="tooltipContainer"></div></body></html>

--- a/sources/SK_NATIONALVISA_MZV_2026-06-16.html.meta.json
+++ b/sources/SK_NATIONALVISA_MZV_2026-06-16.html.meta.json
@@ -1,0 +1,7 @@
+{
+  "source_id": "SK_NATIONALVISA_MZV_2026",
+  "url": "https://www.mzv.sk/en/web/en/visa-and-services/national-visa",
+  "retrieved_at": "2026-06-16T00:00:00Z",
+  "sha256": "03571b2f20d5d17803d2f1ea79adcd3fafe31af936e0987a0a60a818ddda07e6",
+  "local_path": "sources/SK_NATIONALVISA_MZV_2026-06-16.html"
+}

--- a/tools/build_content_hubs.py
+++ b/tools/build_content_hubs.py
@@ -643,6 +643,20 @@ VISA_FAQS = {
             "answer": "The health-insurance condition is a general granting requirement, but the source notes several permit types are exempt from demonstrating it (such as the Red-White-Red card, EU Blue Card, researchers, students and ICT workers). Confirm your specific permit type.",
         },
     ],
+    "SK_NATIONALVISA_MZV_2026": [
+        {
+            "question": "What insurance does a Slovak national (long-stay) visa require?",
+            "answer": "The Ministry of Foreign and European Affairs requires proof of health insurance upon entry and throughout the stay in Slovakia; commercial insurance taken out abroad that covers medical expenses in the Slovak Republic is accepted.",
+        },
+        {
+            "question": "Why is only Genki Native GREEN for this route?",
+            "answer": "The insurance must cover medical expenses in the Slovak Republic. Genki Native documents global coverage that includes Slovakia; the other products do not document Slovakia coverage, so the engine records UNKNOWN rather than assuming a foreign policy qualifies.",
+        },
+        {
+            "question": "Is there a minimum coverage amount?",
+            "answer": "The documents page states no coverage amount, so the engine encodes none and models that insurance is mandatory, must cover Slovakia, and must cover the whole stay.",
+        },
+    ],
 }
 
 RELATED_POSTS = {
@@ -862,6 +876,11 @@ RELATED_POSTS = {
     ],
     "AT_RESIDENCE_BMI_2026": [
         ("/posts/austria-residence-insurance/", "Austria residence permit insurance requirements"),
+        ("/posts/digital-nomad-insurance-europe/", "Digital nomad insurance in Europe"),
+        ("/guides/how-to-read-results/", "How to read compliance results"),
+    ],
+    "SK_NATIONALVISA_MZV_2026": [
+        ("/posts/slovakia-national-visa-insurance/", "Slovakia national visa insurance requirements"),
         ("/posts/digital-nomad-insurance-europe/", "Digital nomad insurance in Europe"),
         ("/guides/how-to-read-results/", "How to read compliance results"),
     ],

--- a/tools/editorial_targets.json
+++ b/tools/editorial_targets.json
@@ -410,5 +410,13 @@
   "content/posts/austria-residence-insurance.md": [
     450,
     1250
+  ],
+  "content/visas/slovakia/national-long-stay-visa/national-visa-documents-ministry-of-foreign-and-european-affairs/index.md": [
+    900,
+    1400
+  ],
+  "content/posts/slovakia-national-visa-insurance.md": [
+    450,
+    1250
   ]
 }


### PR DESCRIPTION
## Summary
- New route **SK_NATIONALVISA_MZV_2026** — Slovakia National (Long-Stay) Visa
- Primary source (byte-exact, sha256-validated; browser-captured past a 403): Ministry of Foreign and European Affairs national-visa documents page (mzv.sk)
- Rules encoded verbatim only: `insurance.mandatory`, `insurance.authorized_in_country` ("covers medical expenses in the Slovak Republic"), `insurance.must_cover_full_period` ("upon entry and throughout their stay")
- No coverage amount stated, so none encoded (UNKNOWN > Wrong)
- Reuses the generic `AuthorizedInCountryRule`; Genki Native gains `jurisdiction_facts.SK`

## Mapping outcomes
Only **Genki Native GREEN**; all other products **UNKNOWN**. No existing mapping changed.

## Content
- Hub: /visas/slovakia/national-long-stay-visa/national-visa-documents-ministry-of-foreign-and-european-affairs/
- Post: /posts/slovakia-national-visa-insurance/ (dated 2026-06-14, past in UTC)
- Affiliate: Genki Native paid link, after results only

## Gates
All gates + ui_compliance_tests.ps1 + mapping_engine_tests.ps1 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)