### PR TITLE
🎨 Palette: Improve accessibility of mobile menu and form selects

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-16 - Accessibility improvements for mobile menu and form selects
+**Learning:** Input labels in flex-col layouts require explicit `for` attributes for accessibility to properly associate with inputs. Icon-only interactive buttons like mobile menus need `aria-controls` and dynamic `aria-expanded` attributes to convey their state to screen readers.
+**Action:** Always ensure custom styled `<select>` or `<input>` fields have a corresponding `<label for="...">` and helpful text mapped with `aria-describedby`. Ensure dynamic toggles update `aria-expanded`.

--- a/ui/index.html
+++ b/ui/index.html
@@ -111,7 +111,7 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+        aria-label="Toggle menu" aria-expanded="false" aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -183,12 +183,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -200,12 +200,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select an insurance product</option>
             </select>
@@ -1178,6 +1178,7 @@
       const btn = $("mobileMenuBtn");
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
+      btn.setAttribute("aria-expanded", String(!isOpen));
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
     });
 


### PR DESCRIPTION
## 💡 What:
Added missing ARIA attributes to the mobile menu and explicitly linked labels to form selects.

## 🎯 Why:
To ensure the interface is intuitive and fully accessible to screen reader users. Specifically, inputs inside flex-col layouts need explicit `for` attributes to correctly trigger focus when their text is clicked, and icon-only mobile toggle buttons require dynamic ARIA states to broadcast their status.

## ♿ Accessibility:
- `#mobileMenuBtn` now properly broadcasts its toggle state via `aria-expanded` and indicates what it controls via `aria-controls`.
- Both `#visaSelect` and `#productSelect` are explicitly associated with their labels and hints.

---
*PR created automatically by Jules for task [7515542924371229486](https://jules.google.com/task/7515542924371229486) started by @W73QB*