### PR TITLE
feat: apply Genki affiliate link sitewide on GREEN routes

### DIFF
--- a/content/posts/albania-unique-permit-insurance.md
+++ b/content/posts/albania-unique-permit-insurance.md
@@ -86,7 +86,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement is a health-insurance policy valid for at least a year, so a full-period policy is what to look for. In the current snapshot, Genki Native shows GREEN: it is an international health policy with a full term that covers Albania, rather than a cancellable monthly subscription. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the year ends.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/anguilla-student-permit-insurance.md
+++ b/content/posts/anguilla-student-permit-insurance.md
@@ -82,7 +82,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The process lists health insurance for the applicant and any dependents, with no amount or territory specified, so most health and travel policies will meet the stated requirement. In the current snapshot, the tracked products show GREEN, including Genki Traveler and Genki Native. Because the published detail is minimal, confirm the exact terms with the Higher Education Licensing Board before applying.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/austria-residence-insurance.md
+++ b/content/posts/austria-residence-insurance.md
@@ -89,7 +89,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The requirement is a comprehensive health policy covering all risks in Austria, and travel insurance is explicitly not sufficient. In the current snapshot, Genki Native shows GREEN: it documents global comprehensive coverage that includes Austria. SafetyWing and World Nomads show RED because they are travel-medical products, which the Ministry states are not sufficient. Confirm your permit type, since some are exempt.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/barbados-welcome-stamp-insurance.md
+++ b/content/posts/barbados-welcome-stamp-insurance.md
@@ -84,7 +84,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement is valid health insurance covering the 12-month Stamp period, so a full-period policy is what to look for. In the current snapshot, most full-period products show GREEN, including Genki Traveler and Genki Native. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the Stamp period ends.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/belgium-national-d-insurance.md
+++ b/content/posts/belgium-national-d-insurance.md
@@ -87,7 +87,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement is health insurance covering all risks in Belgium. In the current snapshot, Genki Native shows GREEN: it documents global comprehensive coverage that includes Belgium. The travel-medical and Spanish products show UNKNOWN because their documents do not state all-risk coverage in Belgium. Confirm with the Immigration Office whether a certificate of registration with a healthcare fund is required for your category.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/belize-long-stay-insurance.md
+++ b/content/posts/belize-long-stay-insurance.md
@@ -82,7 +82,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement is a documented health coverage limit of at least USD 50,000. In the current snapshot, Genki Traveler, Genki Native, SafetyWing and World Nomads show GREEN: each documents a limit that converts to at least USD 50,000. The Spanish health products show UNKNOWN because their documents state no overall limit to compare.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/bermuda-partner-residence-insurance.md
+++ b/content/posts/bermuda-partner-residence-insurance.md
@@ -84,7 +84,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The requirement is private health insurance for the whole intended stay, with no amount specified. In the current snapshot, full-period policies show GREEN, including Genki Native and the Spanish health insurers; SafetyWing shows YELLOW because it is a monthly subscription that does not establish full-period coverage by itself.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/cabo-verde-student-residence-insurance.md
+++ b/content/posts/cabo-verde-student-residence-insurance.md
@@ -82,7 +82,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The law lists health insurance for higher-education students, with no amount or territory specified, so most health and travel policies will meet the stated requirement. In the current snapshot, the tracked products show GREEN, including Genki Traveler and Genki Native. Because the published detail is minimal, confirm the exact terms with the Cabo Verde authorities before applying.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/croatia-dnv-insurance.md
+++ b/content/posts/croatia-dnv-insurance.md
@@ -91,7 +91,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 In the current snapshot, the product that shows GREEN for this route is Genki Native: its documentation states global coverage that includes Croatia and a full term, satisfying the Croatian-territory and full-period rules. The travel-medical and Spanish health policies in the checker stay UNKNOWN because they do not document coverage in Croatia, and SafetyWing also bills monthly.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/cyprus-dnv-insurance.md
+++ b/content/posts/cyprus-dnv-insurance.md
@@ -92,7 +92,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 In the current snapshot, the product that shows GREEN for this route is Genki Native: it documents comprehensive care (inpatient and outpatient) and global coverage that includes Cyprus, satisfying the modeled rules. The travel-medical and Spanish health policies stay UNKNOWN because they do not document coverage valid for care in Cyprus.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/dominica-work-in-nature-insurance.md
+++ b/content/posts/dominica-work-in-nature-insurance.md
@@ -84,7 +84,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement is health insurance valid in Dominica covering the whole family. In the current snapshot, Genki Native shows GREEN: it documents global coverage that includes Dominica. The travel-medical and Spanish products show UNKNOWN because their documents do not state validity in Dominica.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/ecuador-nomad-insurance.md
+++ b/content/posts/ecuador-nomad-insurance.md
@@ -85,7 +85,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement combines full-period validity with a coverage-in-Ecuador clause for foreign policies. In the current snapshot, Genki Native shows GREEN: it documents global coverage that includes Ecuador and a full policy term. The travel-medical and Spanish products show UNKNOWN because their documents do not state validity in Ecuador.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/estonia-dnv-insurance.md
+++ b/content/posts/estonia-dnv-insurance.md
@@ -90,7 +90,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement is travel medical insurance valid for the whole visa period, so a full-period policy that covers the stay is what to look for. In the current snapshot, Genki Native shows GREEN: it is an international health policy with global coverage that includes Estonia and a full term rather than a cancellable monthly subscription. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the visa period ends.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/finland-study-insurance.md
+++ b/content/posts/finland-study-insurance.md
@@ -88,7 +88,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 For studies under two years, the requirement combines a full-stay term with a EUR 120,000 medical limit. In the current snapshot, Genki Traveler, Genki Native and World Nomads show GREEN: each documents a limit at or above the threshold and a full-period term. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the stay ends. Check that your excess is no more than EUR 300.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/georgia-long-term-visa-insurance.md
+++ b/content/posts/georgia-long-term-visa-insurance.md
@@ -86,7 +86,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official criteria require travel/health insurance valid all over Georgia for the visa validity period. In the current snapshot, Genki Native shows GREEN: it documents global coverage that includes Georgia and a full policy term. The travel-medical and Spanish products show UNKNOWN because their documents do not state validity in Georgia.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/greece-dnv-insurance.md
+++ b/content/posts/greece-dnv-insurance.md
@@ -90,7 +90,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official checklist accepts travel insurance but requires a validity period equal to the visa, so a full-period policy that covers Greece is what to look for. In the current snapshot, Genki Native shows GREEN: it is an international health policy with global coverage that includes Greece and a full term rather than a cancellable monthly subscription, so it satisfies both modeled rules. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the visa period ends.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/iceland-residence-insurance.md
+++ b/content/posts/iceland-residence-insurance.md
@@ -85,7 +85,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement combines a valid-in-Iceland clause with a minimum of ISK 2,000,000. In the current snapshot, Genki Native shows GREEN: it documents global coverage including Iceland and a limit above the threshold. The travel-medical and Spanish products show UNKNOWN because their documents do not state validity in Iceland.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/ireland-student-insurance.md
+++ b/content/posts/ireland-student-insurance.md
@@ -88,7 +88,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The first-registration requirement combines a one-year term with a 25,000 EUR minimum for accident and disease. In the current snapshot, Genki Traveler, Genki Native and World Nomads show GREEN: each documents a limit at or above the threshold and a full-period term. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the year ends. Remember that later registrations require a fuller private medical policy.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/italy-selfemployment-insurance.md
+++ b/content/posts/italy-selfemployment-insurance.md
@@ -95,7 +95,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 In the current snapshot, the products that show GREEN for this route are those with a documented medical-expenses limit at or above 30,000 euro: Genki Traveler, SafetyWing Nomad Insurance, and World Nomads Explorer. The Spanish health policies in the checker (ASISA, DKV, Sanitas) show UNKNOWN here because their documents do not state an overall coverage limit to compare against the threshold.
 
-- [Genki Traveler](https://genki.world/products/traveler) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/japan-dnv-insurance.md
+++ b/content/posts/japan-dnv-insurance.md
@@ -94,7 +94,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 In the current snapshot, the products that show GREEN for this route are those whose documented limit clears JPY 10 million once converted to a common currency: Genki Traveler, SafetyWing Nomad Insurance, and World Nomads Explorer. The Spanish health policies in the checker (ASISA, DKV, Sanitas) show UNKNOWN here because their documents do not state an overall coverage limit to compare against the threshold.
 
-- [Genki Traveler](https://genki.world/products/traveler) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/kazakhstan-neo-nomad-insurance.md
+++ b/content/posts/kazakhstan-neo-nomad-insurance.md
@@ -84,7 +84,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement is medical insurance covering the requested visa validity period, so a full-period policy is what to look for. In the current snapshot, most full-period products show GREEN, including Genki Traveler and Genki Native. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the visa period ends.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/korea-workation-visa-insurance.md
+++ b/content/posts/korea-workation-visa-insurance.md
@@ -84,7 +84,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement is a documented coverage limit above 100 million won (about USD 76,000) covering treatment and evacuation. In the current snapshot, Genki Traveler, Genki Native, SafetyWing and World Nomads show GREEN: each documents a limit that converts to at least the won threshold. The Spanish health products show UNKNOWN because their documents state no overall limit to compare.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/latvia-remote-work-insurance.md
+++ b/content/posts/latvia-remote-work-insurance.md
@@ -85,7 +85,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement combines an amount (at least 42,600 EUR) with a territory (valid in Latvia and Schengen). In the current snapshot, Genki Native shows GREEN: it documents global coverage including Latvia plus a limit above the threshold. The travel-medical and Spanish products show UNKNOWN because their documents do not state Latvia-specific validity.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/luxembourg-student-insurance.md
+++ b/content/posts/luxembourg-student-insurance.md
@@ -85,7 +85,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The requirement is a certificate covering all risks on Luxembourg territory. In the current snapshot, Genki Native shows GREEN: it documents global comprehensive coverage that includes Luxembourg. The travel-medical and Spanish products show UNKNOWN because their documents do not state all-risk coverage on Luxembourg territory.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/maldives-resident-visa-insurance.md
+++ b/content/posts/maldives-resident-visa-insurance.md
@@ -82,7 +82,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The page lists health insurance for first-time applicants, with no amount or territory specified, so most health and travel policies will meet the stated requirement. In the current snapshot, the tracked products show GREEN, including Genki Traveler and Genki Native. Because the published detail is minimal, confirm the exact terms with Maldives Immigration before applying.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/mauritius-premium-visa-insurance.md
+++ b/content/posts/mauritius-premium-visa-insurance.md
@@ -82,7 +82,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The EDB statement asks for travel and health insurance for the initial period of stay, with no amount or territory specified, so most travel and health policies will meet the stated requirement. In the current snapshot, the tracked products show GREEN, including Genki Traveler and Genki Native. Because the published detail is minimal, confirm the exact terms with the Economic Development Board before applying.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/montenegro-dnv-insurance.md
+++ b/content/posts/montenegro-dnv-insurance.md
@@ -82,7 +82,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official page asks only for proof of health insurance, with no amount or territory specified, so most health and travel policies will meet the stated requirement. In the current snapshot, the tracked products show GREEN, including Genki Traveler and Genki Native. Because the published detail is minimal, confirm the exact terms with the Ministry before applying.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/new-zealand-student-visa-insurance.md
+++ b/content/posts/new-zealand-student-visa-insurance.md
@@ -86,7 +86,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official condition is cover from course start to visa expiry, so a full-period policy is what to look for, alongside whatever your education provider specifies. In the current snapshot, most full-period products show GREEN, including Genki Traveler and Genki Native. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the visa expires.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/poland-national-d-insurance.md
+++ b/content/posts/poland-national-d-insurance.md
@@ -92,7 +92,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 In the current snapshot, Genki Traveler, Genki Native and World Nomads Explorer show GREEN: each documents a coverage limit at or above 30,000 EUR and a policy term that can span the full visa period. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the visa period ends. Whatever you pick, confirm the insurer against the MFA information list noted above, since the engine does not model the direct-settlement and assistance-centre clauses.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/portugal-d7-insurance.md
+++ b/content/posts/portugal-d7-insurance.md
@@ -90,7 +90,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement is valid travel insurance covering medical expenses and repatriation, valid for the visa, so a full-period policy is what to look for. In the current snapshot, Genki Native shows GREEN: it is an international health policy with global coverage that includes Portugal and a full term rather than a cancellable monthly subscription. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the visa period ends.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/romania-dnv-insurance.md
+++ b/content/posts/romania-dnv-insurance.md
@@ -88,7 +88,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement is a full-period travel medical policy of at least 30,000 EUR, so what matters is a documented limit and a term that spans the whole stay. In the current snapshot, Genki Traveler, Genki Native and World Nomads Explorer show GREEN: each documents a coverage limit at or above 30,000 EUR and a policy term that can span the full stay. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the stay ends.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/san-marino-elective-residence-insurance.md
+++ b/content/posts/san-marino-elective-residence-insurance.md
@@ -82,7 +82,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The statement asks only for a health insurance policy, with no amount or territory specified, so most health and travel policies will meet the stated requirement. In the current snapshot, the tracked products show GREEN, including Genki Traveler and Genki Native. Because the published detail is minimal, confirm the exact terms with the Department of Foreign Affairs before applying.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/slovakia-national-visa-insurance.md
+++ b/content/posts/slovakia-national-visa-insurance.md
@@ -85,7 +85,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The requirement is health insurance covering Slovak medical expenses for the whole stay, and foreign commercial insurance is accepted when it covers Slovakia. In the current snapshot, Genki Native shows GREEN: it documents global coverage that includes Slovakia. The travel-medical and Spanish products show UNKNOWN because their documents do not state coverage in the Slovak Republic.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/slovenia-long-stay-d-insurance.md
+++ b/content/posts/slovenia-long-stay-d-insurance.md
@@ -87,7 +87,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement is a full-period travel medical policy of at least 30,000 EUR, valid Schengen-wide. In the current snapshot, Genki Traveler, Genki Native and World Nomads show GREEN: each documents a limit at or above 30,000 EUR and a term that can span the visa validity. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the visa expires.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/sri-lanka-dnv-insurance.md
+++ b/content/posts/sri-lanka-dnv-insurance.md
@@ -83,7 +83,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement is international health insurance that covers medical care in Sri Lanka, so what matters is documented Sri Lanka coverage. In the current snapshot, Genki Native shows GREEN: it documents global coverage that includes Sri Lanka. The travel-medical and Spanish products show UNKNOWN because their documents do not state validity in Sri Lanka.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/sweden-study-insurance.md
+++ b/content/posts/sweden-study-insurance.md
@@ -85,7 +85,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The requirement is comprehensive health insurance valid for the whole stay. In the current snapshot, comprehensive health policies show GREEN, including Genki Native and the Spanish health insurers. The travel-medical products show UNKNOWN because their documents do not establish comprehensive cover for this route.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/taiwan-dnv-insurance.md
+++ b/content/posts/taiwan-dnv-insurance.md
@@ -84,7 +84,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement is health and full hospitalization insurance covering the entire stay, so a full-period policy is what to look for. In the current snapshot, most full-period products show GREEN, including Genki Traveler and Genki Native. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the stay ends.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/turkey-residence-permit-insurance.md
+++ b/content/posts/turkey-residence-permit-insurance.md
@@ -86,7 +86,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The official requirement is that the policy cover the requested permit duration, so a full-period policy is what to look for. In the current snapshot, most full-period products show GREEN, including Genki Traveler and Genki Native. SafetyWing Nomad Insurance shows YELLOW because it bills monthly and can lapse before the permit period ends.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/uae-virtual-work-insurance.md
+++ b/content/posts/uae-virtual-work-insurance.md
@@ -82,7 +82,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The service page asks for a valid health insurance document, with no amount or territory specified, so most health and travel policies will meet the stated requirement. In the current snapshot, the tracked products show GREEN, including Genki Traveler and Genki Native. Because the published detail is minimal, confirm the exact terms with GDRFA before applying.
 
-- [Genki Traveler](https://genki.world/) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/content/posts/uruguay-working-holiday-insurance.md
+++ b/content/posts/uruguay-working-holiday-insurance.md
@@ -84,7 +84,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 
 The requirement is comprehensive health insurance, with no amount or territory specified. In the current snapshot, comprehensive health policies show GREEN, including Genki Native and the Spanish health insurers. The travel-medical products show UNKNOWN because their documents do not establish comprehensive cover.
 
-- [Genki Native](https://genki.world/products/native) — paid link. We may earn a commission if you purchase through this link.
+- [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 

--- a/data/offers/offers.json
+++ b/data/offers/offers.json
@@ -2,13 +2,13 @@
   "offers": [
     {
       "product_id": "GENKI_TRAVELER_2026",
-      "affiliate_url": "https://genki.world/products/traveler",
+      "affiliate_url": "https://genki.world/with/visafact",
       "label": "View Genki Traveler",
       "disclosure": "Paid link. We may earn a commission if you purchase through this link."
     },
     {
       "product_id": "GENKI_NATIVE_2026",
-      "affiliate_url": "https://genki.world/products/native",
+      "affiliate_url": "https://genki.world/with/visafact",
       "label": "View Genki Native",
       "disclosure": "Paid link. We may earn a commission if you purchase through this link."
     },

--- a/data/ui_index.json
+++ b/data/ui_index.json
@@ -1,5 +1,5 @@
 {
-  "built_at": "2026-06-16T23:43:09.315421+00:00",
+  "built_at": "2026-06-17T04:48:32.667632+00:00",
   "snapshot_id": "2026-06-13",
   "visas": [
     {
@@ -3225,7 +3225,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "AE_VIRTUALWORK_GDRFA_2026",
@@ -3297,7 +3297,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "AI_STUDENT_GOVAI_2026",
@@ -3369,7 +3369,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "AL_LEJE_UNIKE_MB_2026",
@@ -3468,7 +3468,7 @@
         "specs.jurisdiction_facts.AT.authorized",
         "specs.comprehensive"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "AT_RESIDENCE_BMI_2026",
@@ -3579,7 +3579,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BB_WELCOMESTAMP_OAG_2026",
@@ -3667,7 +3667,7 @@
         "specs.jurisdiction_facts.BE.authorized",
         "specs.comprehensive"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BE_NATIONALD_DOFI_2026",
@@ -3750,7 +3750,7 @@
         "specs.overall_limit",
         "specs.eu_licensed_insurer"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BG_LONGSTAYD_MFA_2026",
@@ -3758,7 +3758,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BG_LONGSTAYD_MFA_2026",
@@ -3769,7 +3769,7 @@
         "specs.overall_limit",
         "specs.eu_licensed_insurer"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BG_LONGSTAYD_MFA_2026",
@@ -3780,7 +3780,7 @@
         "specs.overall_limit",
         "specs.eu_licensed_insurer"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BG_LONGSTAYD_MFA_2026",
@@ -3790,7 +3790,7 @@
       "missing": [
         "specs.eu_licensed_insurer"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BG_LONGSTAYD_MFA_2026",
@@ -3800,7 +3800,7 @@
       "missing": [
         "specs.eu_licensed_insurer"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BG_LONGSTAYD_MFA_2026",
@@ -3821,7 +3821,7 @@
       "missing": [
         "specs.eu_licensed_insurer"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BG_LONGSTAYD_MFA_2026",
@@ -3832,7 +3832,7 @@
         "specs.overall_limit",
         "specs.eu_licensed_insurer"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BG_LONGSTAYD_MFA_2026",
@@ -3842,7 +3842,7 @@
       "missing": [
         "specs.eu_licensed_insurer"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BH_GOLDEN_NPRA_2026",
@@ -3862,7 +3862,7 @@
       "missing": [
         "specs.jurisdiction_facts.BH.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BH_GOLDEN_NPRA_2026",
@@ -3948,7 +3948,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BM_PARTNERRESIDENCE_GOVBM_2026",
@@ -4035,7 +4035,7 @@
       "missing": [
         "specs.jurisdiction_facts.BR.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BR_DNV_LISBOA_2026",
@@ -4121,7 +4121,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "BZ_LONGSTAY_IMMIG_2026",
@@ -4204,7 +4204,7 @@
         "specs.jurisdiction_facts.CO.authorized",
         "specs.comprehensive"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "CO_DNV_CANCILLERIA_2026",
@@ -4294,7 +4294,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "CR_DN_DECREE_43619_2026",
@@ -4383,7 +4383,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "CV_STUDENTRES_DGTCV_2026",
@@ -4460,7 +4460,7 @@
         "specs.jurisdiction_facts.CY.authorized",
         "specs.comprehensive"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "CY_DNV_MD_2026",
@@ -4563,7 +4563,7 @@
       "missing": [
         "specs.deductible.amount"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "CZ_LONGTERM_BUSINESS_IPC_2026",
@@ -4701,7 +4701,7 @@
         }
       ],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "DE_FREELANCE_EMBASSY_LONDON_2026",
@@ -4801,7 +4801,7 @@
       "missing": [
         "specs.jurisdiction_facts.DM.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "DM_WIN_GOVDM_2026",
@@ -4889,7 +4889,7 @@
       "missing": [
         "specs.jurisdiction_facts.EC.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "EC_NOMAD_CANCILLERIA_2026",
@@ -4984,7 +4984,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "EE_DNV_VM_2026",
@@ -5085,7 +5085,7 @@
         "specs.copay",
         "specs.moratorium_days"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "ES_DNV_BLS_LONDON_2026",
@@ -5317,7 +5317,7 @@
         "specs.copay",
         "specs.moratorium_days"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "ES_NLV_LA_2026",
@@ -5555,7 +5555,7 @@
         }
       ],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "FI_STUDY_MIGRI_2026",
@@ -5648,7 +5648,7 @@
       "missing": [
         "specs.jurisdiction_facts.GE.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "GE_LONGVISA_GEOCONSUL_2026",
@@ -5743,7 +5743,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "GR_DNV_MFA_2026",
@@ -5830,7 +5830,7 @@
       "missing": [
         "specs.jurisdiction_facts.HR.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "HR_DNV_MUP_2026",
@@ -5927,7 +5927,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "IE_STUDENT_ISD_2026",
@@ -6021,7 +6021,7 @@
       "missing": [
         "specs.jurisdiction_facts.IS.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "IS_RESIDENCE_UTL_2026",
@@ -6110,7 +6110,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "IT_SELFEMP_SF_2026",
@@ -6190,7 +6190,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "JP_DNV_MOFA_2026",
@@ -6270,7 +6270,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "KR_F1D_MOFA_LA_2026",
@@ -6348,7 +6348,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "KZ_NEONOMAD_EGOV_2026",
@@ -6435,7 +6435,7 @@
       "missing": [
         "specs.jurisdiction_facts.LK.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "LK_DNV_IMMIGRATION_2026",
@@ -6524,7 +6524,7 @@
         "specs.jurisdiction_facts.LU.authorized",
         "specs.comprehensive"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "LU_STUDENT_GUICHET_2026",
@@ -6617,7 +6617,7 @@
       "missing": [
         "specs.jurisdiction_facts.LV.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "LV_REMOTEWORK_PMLP_2026",
@@ -6704,7 +6704,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "ME_DNV_GOVME_2026",
@@ -6780,7 +6780,7 @@
       "missing": [
         "specs.payment_cadence"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "MT_NOMAD_RESIDENCY_2026",
@@ -6871,7 +6871,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "MU_PREMIUM_EDB_2026",
@@ -6943,7 +6943,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "MV_RESIDENT_IMMIG_2026",
@@ -7015,7 +7015,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "NZ_STUDENT_INZ_2026",
@@ -7102,7 +7102,7 @@
       "missing": [
         "specs.jurisdiction_facts.PA.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "PA_REMOTEWORK_SNM_2026",
@@ -7199,7 +7199,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "PL_NATD_NICOSIA_2026",
@@ -7293,7 +7293,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "PT_D7_VISTOS_2026",
@@ -7376,7 +7376,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "PT_DNV_VFS_CHINA_2026",
@@ -7450,7 +7450,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "RO_DNV_EVIZA_2026",
@@ -7541,7 +7541,7 @@
       "missing": [
         "specs.comprehensive"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "SE_STUDY_MIGVERKET_2026",
@@ -7634,7 +7634,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "SI_D_GOVSI_2026",
@@ -7727,7 +7727,7 @@
       "missing": [
         "specs.jurisdiction_facts.SK.authorized"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "SK_NATIONALVISA_MZV_2026",
@@ -7822,7 +7822,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "SM_ELECTIVE_ESTERI_2026",
@@ -7916,7 +7916,7 @@
         }
       ],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "TH_DTV_MFA_2026",
@@ -8065,7 +8065,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "TR_RESIDENCE_PMM_2026",
@@ -8148,7 +8148,7 @@
       "status": "GREEN",
       "reasons": [],
       "missing": [],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "TW_DNV_BOCA_2026",
@@ -8233,7 +8233,7 @@
       "missing": [
         "specs.comprehensive"
       ],
-      "last_verified": ""
+      "last_verified": "2026-06-17"
     },
     {
       "visa_id": "UY_WORKINGHOLIDAY_GUBUY_2026",
@@ -8303,13 +8303,13 @@
   "offers": [
     {
       "product_id": "GENKI_TRAVELER_2026",
-      "affiliate_url": "https://genki.world/products/traveler",
+      "affiliate_url": "https://genki.world/with/visafact",
       "label": "View Genki Traveler",
       "disclosure": "Paid link. We may earn a commission if you purchase through this link."
     },
     {
       "product_id": "GENKI_NATIVE_2026",
-      "affiliate_url": "https://genki.world/products/native",
+      "affiliate_url": "https://genki.world/with/visafact",
       "label": "View Genki Native",
       "disclosure": "Paid link. We may earn a commission if you purchase through this link."
     },
@@ -8347,13 +8347,13 @@
   "offers_by_product": {
     "GENKI_TRAVELER_2026": {
       "product_id": "GENKI_TRAVELER_2026",
-      "affiliate_url": "https://genki.world/products/traveler",
+      "affiliate_url": "https://genki.world/with/visafact",
       "label": "View Genki Traveler",
       "disclosure": "Paid link. We may earn a commission if you purchase through this link."
     },
     "GENKI_NATIVE_2026": {
       "product_id": "GENKI_NATIVE_2026",
-      "affiliate_url": "https://genki.world/products/native",
+      "affiliate_url": "https://genki.world/with/visafact",
       "label": "View Genki Native",
       "disclosure": "Paid link. We may earn a commission if you purchase through this link."
     },


### PR DESCRIPTION
## Summary
Repoints every Genki link to the affiliate URL `genki.world/with/visafact`, but **only on routes where the engine rates the linked Genki product GREEN** — verified per-route against `data/mappings`.

- **40 posts** converted (19 `/products/native`, 19 generic `/` Genki-Traveler links, 2 `/products/traveler`). Combined with the 3 territory routes already live (Colombia/Brazil/Panama), **all 43 Genki post links now use `/with/visafact`**.
- **`offers.json`**: Genki Traveler + Genki Native `affiliate_url` → `/with/visafact`. The UI checker (`renderOffer`) hides the offer on RED/UNKNOWN/NOT_REQUIRED, and Genki is **never YELLOW** (status distribution: Native 46 GREEN/2 RED/4 UNKNOWN/1 N-R; Traveler 28 GREEN/3 RED/21 UNKNOWN/1 N-R) — so the UI link appears on GREEN routes only.

## Verification
- Every converted post confirmed GREEN for its linked Genki product (per `data/mappings`); no UNKNOWN/RED converted.
- No SafetyWing content altered; existing inline "paid link" disclosures retained.
- `validate.py` (offers schema + banned words), `lint_content`, `check_editorial_targets`, `check_internal_links`, `hugo`, `offers_tests.ps1`, `ui_compliance_tests.ps1` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)