### PR TITLE
docs: link affiliate-disclosure page from all Genki affiliate posts

### DIFF
--- a/content/posts/albania-unique-permit-insurance.md
+++ b/content/posts/albania-unique-permit-insurance.md
@@ -88,6 +88,8 @@ The official requirement is a health-insurance policy valid for at least a year,
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/anguilla-student-permit-insurance.md
+++ b/content/posts/anguilla-student-permit-insurance.md
@@ -84,6 +84,8 @@ The process lists health insurance for the applicant and any dependents, with no
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/austria-residence-insurance.md
+++ b/content/posts/austria-residence-insurance.md
@@ -91,6 +91,8 @@ The requirement is a comprehensive health policy covering all risks in Austria, 
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/barbados-welcome-stamp-insurance.md
+++ b/content/posts/barbados-welcome-stamp-insurance.md
@@ -86,6 +86,8 @@ The official requirement is valid health insurance covering the 12-month Stamp p
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/belgium-national-d-insurance.md
+++ b/content/posts/belgium-national-d-insurance.md
@@ -89,6 +89,8 @@ The official requirement is health insurance covering all risks in Belgium. In t
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/belize-long-stay-insurance.md
+++ b/content/posts/belize-long-stay-insurance.md
@@ -84,6 +84,8 @@ The official requirement is a documented health coverage limit of at least USD 5
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/bermuda-partner-residence-insurance.md
+++ b/content/posts/bermuda-partner-residence-insurance.md
@@ -86,6 +86,8 @@ The requirement is private health insurance for the whole intended stay, with no
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/cabo-verde-student-residence-insurance.md
+++ b/content/posts/cabo-verde-student-residence-insurance.md
@@ -84,6 +84,8 @@ The law lists health insurance for higher-education students, with no amount or 
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/croatia-dnv-insurance.md
+++ b/content/posts/croatia-dnv-insurance.md
@@ -93,6 +93,8 @@ In the current snapshot, the product that shows GREEN for this route is Genki Na
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/cyprus-dnv-insurance.md
+++ b/content/posts/cyprus-dnv-insurance.md
@@ -94,6 +94,8 @@ In the current snapshot, the product that shows GREEN for this route is Genki Na
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/dominica-work-in-nature-insurance.md
+++ b/content/posts/dominica-work-in-nature-insurance.md
@@ -86,6 +86,8 @@ The official requirement is health insurance valid in Dominica covering the whol
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/ecuador-nomad-insurance.md
+++ b/content/posts/ecuador-nomad-insurance.md
@@ -87,6 +87,8 @@ The official requirement combines full-period validity with a coverage-in-Ecuado
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/estonia-dnv-insurance.md
+++ b/content/posts/estonia-dnv-insurance.md
@@ -92,6 +92,8 @@ The official requirement is travel medical insurance valid for the whole visa pe
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/finland-study-insurance.md
+++ b/content/posts/finland-study-insurance.md
@@ -90,6 +90,8 @@ For studies under two years, the requirement combines a full-stay term with a EU
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/georgia-long-term-visa-insurance.md
+++ b/content/posts/georgia-long-term-visa-insurance.md
@@ -88,6 +88,8 @@ The official criteria require travel/health insurance valid all over Georgia for
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/greece-dnv-insurance.md
+++ b/content/posts/greece-dnv-insurance.md
@@ -92,6 +92,8 @@ The official checklist accepts travel insurance but requires a validity period e
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/iceland-residence-insurance.md
+++ b/content/posts/iceland-residence-insurance.md
@@ -87,6 +87,8 @@ The official requirement combines a valid-in-Iceland clause with a minimum of IS
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/ireland-student-insurance.md
+++ b/content/posts/ireland-student-insurance.md
@@ -90,6 +90,8 @@ The first-registration requirement combines a one-year term with a 25,000 EUR mi
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/kazakhstan-neo-nomad-insurance.md
+++ b/content/posts/kazakhstan-neo-nomad-insurance.md
@@ -86,6 +86,8 @@ The official requirement is medical insurance covering the requested visa validi
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/korea-workation-visa-insurance.md
+++ b/content/posts/korea-workation-visa-insurance.md
@@ -86,6 +86,8 @@ The official requirement is a documented coverage limit above 100 million won (a
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/latvia-remote-work-insurance.md
+++ b/content/posts/latvia-remote-work-insurance.md
@@ -87,6 +87,8 @@ The official requirement combines an amount (at least 42,600 EUR) with a territo
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/luxembourg-student-insurance.md
+++ b/content/posts/luxembourg-student-insurance.md
@@ -87,6 +87,8 @@ The requirement is a certificate covering all risks on Luxembourg territory. In 
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/maldives-resident-visa-insurance.md
+++ b/content/posts/maldives-resident-visa-insurance.md
@@ -84,6 +84,8 @@ The page lists health insurance for first-time applicants, with no amount or ter
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/mauritius-premium-visa-insurance.md
+++ b/content/posts/mauritius-premium-visa-insurance.md
@@ -84,6 +84,8 @@ The EDB statement asks for travel and health insurance for the initial period of
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/montenegro-dnv-insurance.md
+++ b/content/posts/montenegro-dnv-insurance.md
@@ -84,6 +84,8 @@ The official page asks only for proof of health insurance, with no amount or ter
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/new-zealand-student-visa-insurance.md
+++ b/content/posts/new-zealand-student-visa-insurance.md
@@ -88,6 +88,8 @@ The official condition is cover from course start to visa expiry, so a full-peri
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/portugal-d7-insurance.md
+++ b/content/posts/portugal-d7-insurance.md
@@ -92,6 +92,8 @@ The official requirement is valid travel insurance covering medical expenses and
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/romania-dnv-insurance.md
+++ b/content/posts/romania-dnv-insurance.md
@@ -90,6 +90,8 @@ The official requirement is a full-period travel medical policy of at least 30,0
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/san-marino-elective-residence-insurance.md
+++ b/content/posts/san-marino-elective-residence-insurance.md
@@ -84,6 +84,8 @@ The statement asks only for a health insurance policy, with no amount or territo
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/slovakia-national-visa-insurance.md
+++ b/content/posts/slovakia-national-visa-insurance.md
@@ -87,6 +87,8 @@ The requirement is health insurance covering Slovak medical expenses for the who
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/slovenia-long-stay-d-insurance.md
+++ b/content/posts/slovenia-long-stay-d-insurance.md
@@ -89,6 +89,8 @@ The official requirement is a full-period travel medical policy of at least 30,0
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/sri-lanka-dnv-insurance.md
+++ b/content/posts/sri-lanka-dnv-insurance.md
@@ -85,6 +85,8 @@ The official requirement is international health insurance that covers medical c
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/sweden-study-insurance.md
+++ b/content/posts/sweden-study-insurance.md
@@ -87,6 +87,8 @@ The requirement is comprehensive health insurance valid for the whole stay. In t
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/taiwan-dnv-insurance.md
+++ b/content/posts/taiwan-dnv-insurance.md
@@ -86,6 +86,8 @@ The official requirement is health and full hospitalization insurance covering t
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/turkey-residence-permit-insurance.md
+++ b/content/posts/turkey-residence-permit-insurance.md
@@ -88,6 +88,8 @@ The official requirement is that the policy cover the requested permit duration,
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/uae-virtual-work-insurance.md
+++ b/content/posts/uae-virtual-work-insurance.md
@@ -84,6 +84,8 @@ The service page asks for a valid health insurance document, with no amount or t
 
 - [Genki Traveler](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure

--- a/content/posts/uruguay-working-holiday-insurance.md
+++ b/content/posts/uruguay-working-holiday-insurance.md
@@ -86,6 +86,8 @@ The requirement is comprehensive health insurance, with no amount or territory s
 
 - [Genki Native](https://genki.world/with/visafact) — paid link. We may earn a commission if you purchase through this link.
 
+Affiliate disclosure: the Genki link above is an affiliate link; we may earn a commission at no extra cost to you, and it does not change the evidence-based compliance result. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
+
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
 ## Disclaimer + Affiliate disclosure


### PR DESCRIPTION
## Summary
Closes the disclosure-consistency gap from the sitewide Genki affiliate rollout (#352). Adds a uniform affiliate-disclosure paragraph — linking to `https://visafact.org/affiliate-disclosure/` — directly after the Genki affiliate link on the **37** posts that previously had only the inline "paid link" note. The 6 posts that already linked the disclosure page are untouched.

All 43 Genki-affiliate posts now reference the disclosure page.

## Verification
- Banned-words scan: clean · `lint_content`, `check_editorial_targets`, `check_internal_links`, `hugo` build: pass
- Confirmed: every post containing `genki.world/with/visafact` now links `/affiliate-disclosure/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)