### PR TITLE
feat(seo): add Bing Webmaster site verification tag

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -19,6 +19,8 @@ canonifyURLs = true
   [params.analytics]
     src = ""
     id = ""
+    [params.analytics.bing]
+      SiteVerificationTag = "f105995883e543d0a55612178fb6c391"
   [params.gtm]
     id = "GTM-N4JLPLC2"
   [params.giscus]


### PR DESCRIPTION
## Summary
Phase 0.2 — adds Bing Webmaster verification. `params.analytics.bing.SiteVerificationTag` → PaperMod renders `<meta name="msvalidate.01" ...>` site-wide.

GSC is already verified (DNS domain property `sc-domain:visafact.org`); this completes the Bing side so we can submit the sitemap and pull Bing data too.

## Verification
`hugo` build ✅ · `msvalidate.01` meta confirmed in `public/index.html` + post pages ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)