### PR TITLE
feat(seo): shorten generated hub detail titles

### DIFF
--- a/tools/build_content_hubs.py
+++ b/tools/build_content_hubs.py
@@ -1407,7 +1407,7 @@ def render_detail(visa: dict, sources: dict, snapshot_id: str) -> None:
 
     frontmatter = [
         "---",
-        f'title: "{visa["country"]} {visa["visa_name"]} - {visa["route"]}"',
+        f'title: "{visa["country"]} {visa["visa_name"]}"',
         f'visa_id: "{visa_id}"',
         f'last_verified: "{visa.get("last_verified", "")}"',
         f'source_ids: {json.dumps(source_ids)}',


### PR DESCRIPTION
## Summary
Phase 1.3 + striking-distance support. Hub detail `<title>` was `{country} {visa_name} - {route} | VisaFact` (up to 162 chars). Now `{country} {visa_name} | VisaFact` (e.g. "Colombia Digital Nomad Visa | VisaFact").

- One-line change in `render_detail` (build_content_hubs.py). Route is preserved in the H1 + "Route:" line, so nothing is lost.
- **142 → ~11** pages with title >60 chars (the rest are inherently long visa names: Cape Verde, Luxembourg, etc.).
- Verified **no duplicate titles**: all 54 `country+visa_name` pairs are unique.
- Helps CTR for striking-distance hubs that already rank page 1-2 (Costa Rica, Spain DNV, Portugal per GSC).

Hub pages are regenerated at deploy, so only the generator is committed (per the project's hub-churn convention).

## Note (separate, pre-existing)
`/visas/.../page/1/` paginator pages render a URL as their `<title>` — a minor pre-existing quirk on low-value duplicate pages, not addressed here.

## Verification
`build_content_hubs` + `hugo` build ✅ · sample detail titles confirmed short ✅ · duplicate check ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)