### PR TITLE
feat(seo): add About + Contact pages (E-E-A-T)

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,0 +1,44 @@
+---
+title: "About"
+description: "What VisaFact is, who runs it, and how our evidence-based visa insurance compliance checker works."
+date: 2026-01-15
+lastmod: 2026-06-17
+---
+
+## What VisaFact is
+
+VisaFact is an independent, evidence-based reference that compares official visa health-insurance requirements against insurance product specifications. For each visa route we record what the authority actually requires, then a rule engine compares those requirements to documented product facts and returns a clear status: GREEN, YELLOW, RED, UNKNOWN, or NOT_REQUIRED.
+
+The site is operated by the VisaFact team as an informational project. It is not a visa agency, an insurer, or a broker, and it does not sell insurance.
+
+## Our core principle: evidence before answers
+
+Every requirement and every product fact is backed by a primary source. If a detail is not stated in an official source, we mark it UNKNOWN rather than guessing. We would rather say "unknown" than be wrong.
+
+In practice this means:
+
+- **Requirements** come from primary government sources (ministries, consulates, official gazettes, immigration authorities). We store each source as a byte-exact snapshot and verify it with a SHA-256 hash, so the wording we encode can be traced to the exact document we read.
+- **We encode only what the source states verbatim.** We do not infer coverage amounts, territories, or conditions that an official document leaves out.
+- **Product facts** come from each insurer's own published policy or coverage documentation, quoted with a locator.
+
+## How the statuses work
+
+- **GREEN** — the product's documented facts satisfy every modeled requirement for that route.
+- **YELLOW** — an operational caution (for example, a monthly subscription that can lapse before a stay ends).
+- **RED** — a documented requirement is not met.
+- **UNKNOWN** — a requirement or product detail lacks an official source, so no claim is made.
+- **NOT_REQUIRED** — the authority does not require insurance for that route.
+
+Read the full logic on the [Methodology](/methodology/) page.
+
+## Independence
+
+Compliance results are generated from sources and rules, not from commercial relationships. Some pages contain affiliate links, and they appear only after results. An affiliate link never changes a status. See our [Affiliate Disclosure](/affiliate-disclosure/) for details.
+
+## Not legal advice
+
+VisaFact provides informational, evidence-based snapshots. It is not legal advice. Always confirm current requirements with the official authority before you apply. See the [Disclaimer](/disclaimer/).
+
+## Contact
+
+Questions, corrections, or a source that looks out of date? Email **support@visafact.org** or see the [Contact](/contact/) page.

--- a/content/contact/_index.md
+++ b/content/contact/_index.md
@@ -1,0 +1,26 @@
+---
+title: "Contact"
+description: "How to contact VisaFact and report an outdated or incorrect visa insurance requirement."
+date: 2026-01-15
+lastmod: 2026-06-17
+---
+
+## Get in touch
+
+For any question, correction, or feedback about VisaFact, email us:
+
+**[support@visafact.org](mailto:support@visafact.org)**
+
+## Report a source that looks out of date
+
+Our results are only as good as the official sources behind them, and authorities update their pages. If you believe a requirement or a product fact is outdated or incorrect, please tell us. It helps to include:
+
+- The route or page (a link is ideal).
+- What looks wrong, and what the official source now says.
+- A link to the official government or insurer page, if you have it.
+
+We review reports against the primary source and update the record when the evidence supports a change. Where an official source is unclear or missing, the route stays UNKNOWN.
+
+## What we cannot do
+
+VisaFact is an independent informational project, not a visa agency, insurer, or broker. We cannot process visa applications, sell insurance, or provide legal advice. For your specific case, confirm requirements with the official authority before you apply — see the [Disclaimer](/disclaimer/).

--- a/hugo.toml
+++ b/hugo.toml
@@ -62,10 +62,18 @@ canonifyURLs = true
     pageRef = "methodology"
     weight = 6
   [[menu.main]]
+    name = "About"
+    pageRef = "about"
+    weight = 7
+  [[menu.main]]
+    name = "Contact"
+    pageRef = "contact"
+    weight = 8
+  [[menu.main]]
     name = "Disclaimer"
     pageRef = "disclaimer"
-    weight = 7
+    weight = 9
   [[menu.main]]
     name = "Affiliate"
     pageRef = "affiliate-disclosure"
-    weight = 8
+    weight = 10

--- a/layouts/partials/templates/schema_json.html
+++ b/layouts/partials/templates/schema_json.html
@@ -27,6 +27,11 @@
         "@type" "ImageObject"
         "url" $faviconUrl
       )
+      "contactPoint" (dict
+        "@type" "ContactPoint"
+        "email" "support@visafact.org"
+        "contactType" "customer support"
+      )
     )
   )
 -}}


### PR DESCRIPTION
## Summary
Phase 2 of the approved SEO plan — the highest-impact lever for this YMYL topic (GSC shows avg position ~36; Trust signals help rankings climb).

- **`/about/`** — what VisaFact is, who operates it (VisaFact, independent informational project), evidence-first methodology, status meanings, independence from affiliates, not-legal-advice.
- **`/contact/`** — `support@visafact.org`, how to report an outdated/incorrect source, scope limits.
- Both added to the **main menu** (alongside Methodology/Disclaimer/Affiliate).
- **Organization JSON-LD** gains a `contactPoint` (email). No `sameAs` added (no verified social profiles — not invented).
- Operator shown as "VisaFact" + support email only (owner's choice; no personal data). No banned words.

## Verification
`hugo` build ✅ · titles "About | VisaFact" / "Contact | VisaFact" ✅ · menu links + mailto + schema contactPoint confirmed in rendered HTML ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)