### PR TITLE
feat(seo): expand Americas + Asia roundups into comprehensive hubs

### DIFF
--- a/content/posts/digital-nomad-insurance-americas.md
+++ b/content/posts/digital-nomad-insurance-americas.md
@@ -1,7 +1,8 @@
 ---
-title: "Digital nomad insurance requirements (Americas - verified subset)"
+title: "Digital nomad visa insurance in the Americas (evidence-based)"
 date: 2026-01-16
-description: "Evidence-based summary of verified insurance requirements for Americas routes in this dataset."
+lastmod: 2026-06-16
+description: "Evidence-based health insurance requirements for digital nomad and long-stay visas across the Americas and Caribbean, with links to every route we track."
 tags: ["digital-nomad", "insurance", "americas", "compliance"]
 faq:
   - question: "What is the minimum coverage in the Americas routes listed?"
@@ -16,7 +17,7 @@ faq:
 
 ## Short answer
 
-The verified Americas subset in this dataset is Costa Rica Digital Nomad Visa. Executive Decree 43619 requires health insurance with at least US $50,000 in medical coverage and coverage for the full authorized legal stay period (Source: `CR_DECREE_43619_2026`, locator: Article 9; verified 2026-01-12).
+Insurance requirements across the Americas and Caribbean vary widely — from no insurance requirement, to a fixed minimum amount, to coverage that must be valid in the destination's territory. This hub links every Americas route we track (see the directory below) and works through Costa Rica in detail as an example: Executive Decree 43619 requires health insurance with at least US $50,000 in medical coverage and coverage for the full authorized legal stay period (Source: `CR_DECREE_43619_2026`, locator: Article 9; verified 2026-01-12). For any route, the compliance checker shows the live, evidence-based status.
 
 ## Key findings at a glance
 
@@ -24,7 +25,7 @@ The verified Americas subset in this dataset is Costa Rica Digital Nomad Visa. E
 |---|---|
 | Route covered | Costa Rica Digital Nomad Visa |
 | Evidence verified | 2026-01-12 |
-| Snapshot | releases/2026-01-15 |
+| Snapshot | 2026-06-13 |
 | Minimum coverage | US $50,000 (medical expenses) |
 | Coverage duration | Full authorized legal stay |
 
@@ -87,11 +88,11 @@ In practice, the two most common gaps are missing coverage amounts and unclear d
 
 Use [the compliance checker](/ui/) for route-specific results. Example link:
 
-- [/ui/?visa=CR_DN_DECREE_43619_2026&product=GENKI_TRAVELER_2026&snapshot=releases/2026-01-15](/ui/?visa=CR_DN_DECREE_43619_2026&product=GENKI_TRAVELER_2026&snapshot=releases/2026-01-15)
+- [/ui/?visa=CR_DN_DECREE_43619_2026&product=GENKI_TRAVELER_2026&snapshot=2026-06-13](/ui/?visa=CR_DN_DECREE_43619_2026&product=GENKI_TRAVELER_2026&snapshot=2026-06-13)
 
 ## Mapping results summary
 
-As of snapshot `releases/2026-01-15`, example product outcomes for Costa Rica are:
+As of snapshot `2026-06-13`, example product outcomes for Costa Rica are:
 
 | Route | SafetyWing | World Nomads | Genki |
 |---|---|---|---|
@@ -100,6 +101,22 @@ As of snapshot `releases/2026-01-15`, example product outcomes for Costa Rica ar
 YELLOW indicates partial evidence in the current snapshot. It often means the policy meets some requirements but lacks explicit documentation for the minimum amount or full-stay duration.
 
 If you see YELLOW or UNKNOWN, open the route page and compare the authority wording to your policy certificate. The checker is intentionally conservative when amounts or dates are not explicit.
+
+## Americas routes in this dataset
+
+Every Americas and Caribbean route we track, with its insurance guide. Open any one for the verbatim authority requirement and the live product status, or use the [compliance checker](/ui/) directly.
+
+- **Anguilla** — [Student permit insurance](/posts/anguilla-student-permit-insurance/)
+- **Barbados** — [Welcome Stamp insurance](/posts/barbados-welcome-stamp-insurance/)
+- **Belize** — [Long Stay permit insurance](/posts/belize-long-stay-insurance/)
+- **Bermuda** — [Partner residence insurance](/posts/bermuda-partner-residence-insurance/)
+- **Brazil** — [Digital Nomad Visa (VITEM XIV) insurance](/posts/brazil-dnv-insurance/)
+- **Colombia** — [Digital Nomad Visa insurance](/posts/colombia-dnv-insurance/)
+- **Costa Rica** — [Digital Nomad Visa insurance](/posts/costa-rica-dn-insurance/)
+- **Dominica** — [Work In Nature insurance](/posts/dominica-work-in-nature-insurance/)
+- **Ecuador** — [Digital nomad (rentista) insurance](/posts/ecuador-nomad-insurance/)
+- **Panama** — [Remote Worker Visa insurance](/posts/panama-remote-worker-insurance/)
+- **Uruguay** — [Working Holiday insurance](/posts/uruguay-working-holiday-insurance/)
 
 ## Related reading
 
@@ -115,7 +132,7 @@ Not legal advice. Compliance results are evidence-based snapshots.
 
 If an affiliate link is present, it appears only after results and does not change the compliance outcome.
 
-Last updated: 2026-02-05
+Last updated: 2026-06-16
 
 ## Evidence log
 

--- a/content/posts/digital-nomad-insurance-asia.md
+++ b/content/posts/digital-nomad-insurance-asia.md
@@ -1,7 +1,8 @@
 ---
-title: "Digital nomad insurance requirements (Asia - verified subset)"
+title: "Digital nomad visa insurance in Asia & Pacific (evidence-based)"
 date: 2026-01-16
-description: "Evidence-based summary of verified insurance requirements for Asia routes in this dataset."
+lastmod: 2026-06-16
+description: "Evidence-based health insurance requirements for digital nomad and long-stay visas across Asia, the Middle East and the Pacific, with links to every route we track."
 tags: ["digital-nomad", "insurance", "asia", "compliance"]
 faq:
   - question: "What does NOT_REQUIRED mean in Asia routes?"
@@ -16,7 +17,7 @@ faq:
 
 ## Short answer
 
-The verified Asia subset in this dataset is Thailand DTV (Thai E-Visa). The official DTV Workcation requirements list does not include insurance among required documents, so the checker marks insurance as NOT_REQUIRED for this route (Source: `TH_MFA_DTV_2026`, locator: Complete requirements list for all DTV categories; verified 2026-01-12).
+Insurance requirements across Asia, the Middle East and the Pacific range from none at all to a documented amount or territory-specific cover. This hub links every route we track in the region (see the directory below) and works through Thailand in detail as an example: the official DTV Workcation requirements list does not include insurance among required documents, so the checker marks insurance as NOT_REQUIRED for that route (Source: `TH_MFA_DTV_2026`, locator: Complete requirements list for all DTV categories; verified 2026-01-12). For any route, the compliance checker shows the live, evidence-based status.
 
 ## Key findings at a glance
 
@@ -24,7 +25,7 @@ The verified Asia subset in this dataset is Thailand DTV (Thai E-Visa). The offi
 |---|---|
 | Route covered | Thailand DTV (Thai E-Visa) |
 | Evidence verified | 2026-01-12 |
-| Snapshot | releases/2026-01-15 |
+| Snapshot | 2026-06-13 |
 | Insurance status | NOT_REQUIRED |
 | Required documents (non-insurance) | Passport, photo, proof of location, financial proof, employment/portfolio |
 
@@ -91,17 +92,32 @@ Evidence boundaries matter here: the only claim we make is that insurance is not
 
 Use [the compliance checker](/ui/) for route-specific results. Example link:
 
-- [/ui/?visa=TH_DTV_MFA_2026&product=SAFETYWING_NOMAD_2026&snapshot=releases/2026-01-15](/ui/?visa=TH_DTV_MFA_2026&product=SAFETYWING_NOMAD_2026&snapshot=releases/2026-01-15)
+- [/ui/?visa=TH_DTV_MFA_2026&product=SAFETYWING_NOMAD_2026&snapshot=2026-06-13](/ui/?visa=TH_DTV_MFA_2026&product=SAFETYWING_NOMAD_2026&snapshot=2026-06-13)
 
 ## Mapping results summary
 
-As of snapshot `releases/2026-01-15`, the checker returns NOT_REQUIRED for all products on Thailand DTV because the authority list omits insurance:
+As of snapshot `2026-06-13`, the checker returns NOT_REQUIRED for all products on Thailand DTV because the authority list omits insurance:
 
 | Route | SafetyWing | World Nomads | Genki |
 |---|---|---|---|
 | Thailand DTV | NOT_REQUIRED | NOT_REQUIRED | NOT_REQUIRED |
 
 NOT_REQUIRED does not indicate a policy is good or bad; it only means there is no insurance requirement to evaluate for this route in the verified evidence.
+
+## Asia & Pacific routes in this dataset
+
+Every route we track across Asia, the Middle East, Central Asia and the Pacific, with its insurance guide. Open any one for the verbatim authority requirement and the live product status, or use the [compliance checker](/ui/) directly.
+
+- **Bahrain** — [Golden Residency insurance](/posts/bahrain-golden-residency-insurance/)
+- **Japan** — [Digital Nomad Visa insurance](/posts/japan-dnv-insurance/)
+- **Kazakhstan** — [Neo Nomad Visa insurance](/posts/kazakhstan-neo-nomad-insurance/)
+- **Maldives** — [Resident Visa insurance](/posts/maldives-resident-visa-insurance/)
+- **New Zealand** — [Fee-paying student visa insurance](/posts/new-zealand-student-visa-insurance/)
+- **South Korea** — [Workation (F-1-D) visa insurance](/posts/korea-workation-visa-insurance/)
+- **Sri Lanka** — [Digital Nomad Visa insurance](/posts/sri-lanka-dnv-insurance/)
+- **Taiwan** — [Digital Nomad Visa insurance](/posts/taiwan-dnv-insurance/)
+- **Thailand** — [DTV (Thai E-Visa) insurance](/posts/thailand-dtv-insurance/)
+- **UAE** — [Virtual Work residence insurance](/posts/uae-virtual-work-insurance/)
 
 ## Related reading
 
@@ -117,7 +133,7 @@ Not legal advice. Compliance results are evidence-based snapshots.
 
 If an affiliate link is present, it appears only after results and does not change the compliance outcome.
 
-Last updated: 2026-02-05
+Last updated: 2026-06-16
 
 ## Evidence log
 

--- a/tools/editorial_targets.json
+++ b/tools/editorial_targets.json
@@ -21,11 +21,11 @@
   ],
   "content/posts/digital-nomad-insurance-americas.md": [
     900,
-    1200
+    1500
   ],
   "content/posts/digital-nomad-insurance-asia.md": [
     900,
-    1200
+    1500
   ],
   "content/posts/digital-nomad-insurance-europe.md": [
     900,


### PR DESCRIPTION
## Summary
Mirrors the Europe hub (#361) for the other two regional roundups, which each covered only one route on a stale `2026-01-15` snapshot.

- **Americas** — internal-link directory to all 11 Americas/Caribbean routes (Anguilla, Barbados, Belize, Bermuda, Brazil, Colombia, Costa Rica, Dominica, Ecuador, Panama, Uruguay).
- **Asia & Pacific** — directory to all 10 routes (Bahrain, Japan, Kazakhstan, Maldives, New Zealand, South Korea, Sri Lanka, Taiwan, Thailand, UAE). Retitled "Asia & Pacific" to honestly cover Middle East/Central Asia/Pacific.
- Reframed intros as comprehensive hubs (Costa Rica / Thailand kept as worked examples), refreshed snapshot refs → `2026-06-13`, raised editorial max to 1500.
- Africa routes (Cabo Verde, Mauritius) intentionally not forced into these geographic hubs.

## Verification
banned-words clean ✅ · `lint_content` ✅ · `check_internal_links` ✅ · `check_editorial_targets` ✅ · `hugo` ✅ · rendered: Americas 12 / Asia 11 unique post links ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)