### PR TITLE
feat(seo): add Microsoft UET tag + affiliate click conversion scaffold

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -19,6 +19,7 @@ canonifyURLs = true
   [params.analytics]
     src = ""
     id = ""
+    bing_uet_tag = ""
     [params.analytics.bing]
       SiteVerificationTag = "f105995883e543d0a55612178fb6c391"
   [params.gtm]

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -51,3 +51,34 @@
 </script>
 {{ partial "analytics.html" . }}
 {{ partial "gtm.html" . }}
+{{- with site.Params.analytics.bing_uet_tag }}
+{{- /* Microsoft Advertising UET tag + affiliate click conversion events.
+       Gated on the bing_uet_tag param (empty = not loaded) and on region consent
+       via vf_analytics_allowed(). Fires click_genki / click_safetywing on any
+       affiliate link click, so no per-link onclick markup is needed. */ -}}
+<script>
+  (function () {
+    if (typeof vf_analytics_allowed === "function" && !vf_analytics_allowed()) return;
+    (function (w, d, t, r, u) {
+      var f, n, i;
+      w[u] = w[u] || [];
+      f = function () { var o = { ti: "{{ . }}" }; o.q = w[u]; w[u] = new UET(o); w[u].push("pageLoad"); };
+      n = d.createElement(t); n.src = r; n.async = 1;
+      n.onload = n.onreadystatechange = function () {
+        var s = this.readyState;
+        if (!s || s === "loaded" || s === "complete") { f(); n.onload = n.onreadystatechange = null; }
+      };
+      i = d.getElementsByTagName(t)[0]; i.parentNode.insertBefore(n, i);
+    })(window, document, "script", "//bat.bing.com/bat.js", "uetq");
+    document.addEventListener("click", function (e) {
+      var a = e.target && e.target.closest ? e.target.closest("a[href]") : null;
+      if (!a) return;
+      var href = a.getAttribute("href") || "";
+      var ev = null;
+      if (href.indexOf("genki.world/with/visafact") !== -1) ev = "click_genki";
+      else if (href.indexOf("safetywing.com") !== -1) ev = "click_safetywing";
+      if (ev) { window.uetq = window.uetq || []; window.uetq.push("event", ev, {}); }
+    }, true);
+  })();
+</script>
+{{- end }}


### PR DESCRIPTION
## Summary
Website-side prep (Part A) for the Bing Ads CR/CPC test, parameterized so it ships now and activates with one config value.

- **UET tag** loaded via `layouts/partials/extend_head.html`, gated on `params.analytics.bing_uet_tag` (empty default → nothing loads) and on the existing `vf_analytics_allowed()` consent helper.
- **Conversion events**: a single delegated click listener fires `click_genki` (on `genki.world/with/visafact`) and `click_safetywing` (on `safetywing.com`) — site-wide, no per-link `onclick` markup needed.
- No-op until a real UET tag id is set, so safe to merge now.

## Verification
- Empty param → 0 files contain `bat.bing.com` ✅
- Dummy tag → UET snippet + `ti`, `click_genki`, `click_safetywing`, consent gate all render on home + posts ✅
- Reverted to empty; `hugo` build clean ✅

## To activate (owner)
1. Microsoft Ads → Tools → UET tag → create, copy the **tag id** → set `bing_uet_tag` in `hugo.toml`.
2. Create Conversion goals (Event): `click_genki` (+ optional `click_safetywing`), set as Secondary/observe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)