### PR TITLE
feat(seo): add visa insurance requirements comparison asset

### DIFF
--- a/content/visa-insurance-requirements/_index.md
+++ b/content/visa-insurance-requirements/_index.md
@@ -1,0 +1,98 @@
+---
+title: "Visa health insurance requirements by country (2026, evidence-based)"
+description: "A comprehensive, source-backed comparison of health insurance requirements for 54 long-stay and digital-nomad visa routes across 52 countries."
+date: 2026-06-16
+lastmod: 2026-06-16
+---
+
+This page compares the official health-insurance requirements for **54 long-stay, digital-nomad and residence visa routes across 52 countries**. Every entry is built from a primary government source, stored as a byte-exact snapshot and verified with a SHA-256 hash. Where an official source does not state a detail, we mark it UNKNOWN rather than guess.
+
+## Key findings
+
+- **53 of 54 routes require health insurance**; 1 do not list it as a required document.
+- **15 routes specify a minimum coverage amount.** Stated minimums range from EUR 5,792 (Lithuania national D visa) upward; Spain's digital-nomad and non-lucrative visas instead require *unlimited* cover from an insurer authorized in Spain.
+- **19 routes restrict the insurer or territory** — the policy must be valid in the destination, or issued by a locally-authorized or EU-licensed insurer.
+- **24 routes require the policy to cover the full period of stay**, which rules out subscriptions that can lapse mid-stay.
+- Stated amounts appear in several currencies (EUR, USD, GBP, JPY, KRW, ISK), so a like-for-like comparison needs currency conversion.
+
+## Requirements by country
+
+| Country | Visa / route | Insurance | Min. coverage | Key conditions |
+| --- | --- | --- | --- | --- |
+| Albania | [Unique Permit (Digital Mover)](/visas/albania/unique-permit-digital-mover/leje-unike-mb-e-albania/) | Required | — | full stay |
+| Anguilla | [Student Permit](/visas/anguilla/student-permit/student-permit-application-higher-education-licensing-board/) | Required | — | — |
+| Austria | [Residence Permit (third-country nationals)](/visas/austria/residence-permit-third-country-nationals/residence-permit-granting-requirements-federal-ministry-of-the-interior/) | Required | — | valid-in-country insurer, comprehensive, travel insurance not accepted |
+| Bahrain | [Golden Residency Visa](/visas/bahrain/golden-residency-visa/golden-residency-visa-issuance-request-npra/) | Required | — | valid-in-country insurer |
+| Barbados | [12 Month Barbados Welcome Stamp](/visas/barbados/12-month-barbados-welcome-stamp/remote-employment-act-2020-23-welcome-stamp/) | Required | — | full stay |
+| Belgium | [National Entry (Visa D)](/visas/belgium/national-entry-visa-d/national-entries-visa-d-health-insurance-immigration-office/) | Required | — | valid-in-country insurer, comprehensive |
+| Belize | [Long Stay Permit](/visas/belize/long-stay-permit/long-stay-permit-department-of-immigration/) | Required | 50,000 USD | — |
+| Bermuda | [Partner Residence](/visas/bermuda/partner-residence/partner-residence-application-department-of-immigration/) | Required | — | full stay |
+| Brazil | [Digital Nomad Visa (VITEM XIV)](/visas/brazil/digital-nomad-visa-vitem-xiv/visto-temporario-xiv-gov-br-lisboa/) | Required | — | valid-in-country insurer |
+| Bulgaria | [Long-stay Visa D](/visas/bulgaria/long-stay-visa-d/long-stay-visa-d-whole-period-of-stay-ministry-of-foreign-affairs/) | Required | 30,000 EUR | full stay, EU-licensed insurer |
+| Cape Verde | [Residence Authorisation for Higher-Education Students](/visas/cape-verde/residence-authorisation-for-higher-education-students/residence-authorisation-for-higher-education-students-lei-n-66-viii-2014-art-53/) | Required | — | — |
+| Colombia | [Digital Nomad Visa](/visas/colombia/digital-nomad-visa/visa-v-nomadas-digitales-cancilleria/) | Required | — | valid-in-country insurer, comprehensive |
+| Costa Rica | [Digital Nomad Visa](/visas/costa-rica/digital-nomad-visa/executive-decree-43619/) | Required | 50,000 | full stay |
+| Croatia | [Digital Nomad Temporary Stay](/visas/croatia/digital-nomad-temporary-stay/ministry-of-the-interior-mup/) | Required | — | full stay, valid-in-country insurer |
+| Cyprus | [Digital Nomad Visa](/visas/cyprus/digital-nomad-visa/migration-department-crmd/) | Required | — | valid-in-country insurer, comprehensive |
+| Czech Republic | [Long-term Business Visa](/visas/czech-republic/long-term-business-visa/doing-business-ipc/) | Required | 400,000 EUR | no deductible/copay |
+| Dominica | [Work In Nature (WIN) Extended Stay Visa](/visas/dominica/work-in-nature-win-extended-stay-visa/work-in-nature-application-process-government-of-dominica/) | Required | — | valid-in-country insurer |
+| Ecuador | [Digital Nomad Visa (Rentista Remote Worker)](/visas/ecuador/digital-nomad-visa-rentista-remote-worker/visa-de-residencia-temporal-rentista-para-trabajo-remoto-mremh/) | Required | — | full stay, valid-in-country insurer |
+| Estonia | [Digital Nomad Visa](/visas/estonia/digital-nomad-visa/long-stay-d-visa/) | Required | — | full stay |
+| Finland | [Residence Permit for Studies](/visas/finland/residence-permit-for-studies/student-residence-permit-studies-under-two-years-migri/) | Required | 120,000 EUR | full stay |
+| Georgia | [Long-Term Visa](/visas/georgia/long-term-visa/long-term-visa-travel-health-insurance-mfa-consular-department/) | Required | — | full stay, valid-in-country insurer |
+| Germany | [Freelance Visa (National D)](/visas/germany/freelance-visa-national-d/embassy-london/) | Required | — | travel insurance not accepted |
+| Greece | [Digital Nomad Visa](/visas/greece/digital-nomad-visa/national-visa-type-d/) | Required | — | full stay |
+| Iceland | [Residence Permit (legitimate and special purpose)](/visas/iceland/residence-permit-legitimate-and-special-purpose/residence-permit-requirements-directorate-of-immigration/) | Required | 2,000,000 ISK | valid-in-country insurer |
+| Ireland | [Non-EEA Student Registration](/visas/ireland/non-eea-student-registration/private-medical-insurance-for-study-immigration-service-delivery/) | Required | 25,000 EUR | full stay |
+| Italy | [Self-Employment Visa](/visas/italy/self-employment-visa/short-term-schengen-san-francisco/) | Required | 30,000 | — |
+| Japan | [Digital Nomad Visa](/visas/japan/digital-nomad-visa/designated-activities-mofa/) | Required | 10,000,000 JPY | — |
+| Kazakhstan | [Neo Nomad Visa](/visas/kazakhstan/neo-nomad-visa/neo-nomad-visa-b12-1-egov-kazakhstan/) | Required | — | full stay |
+| Latvia | [Long-Term Visa for Remote Work](/visas/latvia/long-term-visa-for-remote-work/remote-work-long-stay-visa-pmlp/) | Required | 42,600 EUR | valid-in-country insurer |
+| Lithuania | [National (long-term) Visa D](/visas/lithuania/national-long-term-visa-d/national-long-term-d-visa-temporary-residence-permit-mfa-consular-information/) | Required | 5,792 EUR | full stay |
+| Luxembourg | [Pupil/Student Authorisation to Stay (third-country)](/visas/luxembourg/pupil-student-authorisation-to-stay-third-country/third-country-pupil-authorisation-to-stay-over-3-months-guichet/) | Required | — | valid-in-country insurer, comprehensive |
+| Maldives | [Resident Visa (spouse of a Maldivian)](/visas/maldives/resident-visa-spouse-of-a-maldivian/resident-visa-first-time-applicants-maldives-immigration/) | Required | — | — |
+| Malta | [Nomad Residence Permit](/visas/malta/nomad-residence-permit/residency-malta-agency/) | Required | — | — |
+| Mauritius | [Premium Visa](/visas/mauritius/premium-visa/premium-visa-economic-development-board/) | Required | — | — |
+| Montenegro | [Digital Nomad Temporary Residence](/visas/montenegro/digital-nomad-temporary-residence/temporary-residence-permit-for-digital-nomads-government-of-montenegro/) | Required | — | — |
+| New Zealand | [Fee Paying Student Visa](/visas/new-zealand/fee-paying-student-visa/fee-paying-student-visa-immigration-new-zealand/) | Required | — | full stay |
+| Panama | [Short-Stay Visa as Remote Worker](/visas/panama/short-stay-visa-as-remote-worker/visa-de-corta-estancia-como-trabajador-remoto-snm/) | Required | — | full stay, valid-in-country insurer |
+| Poland | [National Visa (Type D)](/visas/poland/national-visa-type-d/d-type-national-visa-gov-pl-nicosia/) | Required | 30,000 EUR | full stay |
+| Portugal | [D7 Visa (Passive Income)](/visas/portugal/d7-visa-passive-income/residency-visa-vistos-mfa/) | Required | — | full stay |
+| Portugal | [Temporary Stay Visa for Remote Work (E11)](/visas/portugal/temporary-stay-visa-for-remote-work-e11/vfs-global-china/) | Required | — | — |
+| Romania | [Digital Nomad Visa](/visas/romania/digital-nomad-visa/long-stay-visa-for-digital-nomads-eviza-mae/) | Required | 30,000 EUR | full stay |
+| San Marino | [Elective Residence Permit](/visas/san-marino/elective-residence-permit/stay-permits-and-residence-department-of-foreign-affairs/) | Required | — | — |
+| Slovakia | [National (Long-Stay) Visa](/visas/slovakia/national-long-stay-visa/national-visa-documents-ministry-of-foreign-and-european-affairs/) | Required | — | full stay, valid-in-country insurer |
+| Slovenia | [Long-Stay Visa (Type D)](/visas/slovenia/long-stay-visa-type-d/long-stay-visa-d-checklist-ministry-of-foreign-affairs/) | Required | 30,000 EUR | full stay |
+| South Korea | [Workation (Digital Nomad) Visa (F-1-D)](/visas/south-korea/workation-digital-nomad-visa-f-1-d/f-1-d-pilot-program-mofa-los-angeles/) | Required | 100,000,000 KRW | — |
+| Spain | [Digital Nomad Visa](/visas/spain/digital-nomad-visa/consulate-via-bls-london/) | Required | — | valid-in-country insurer, comprehensive, unlimited, public-health-equivalent, no deductible/copay |
+| Spain | [Non-Lucrative Visa](/visas/spain/non-lucrative-visa/consulate-los-angeles/) | Required | — | valid-in-country insurer, comprehensive, unlimited, public-health-equivalent, no deductible/copay, travel insurance not accepted |
+| Sri Lanka | [Digital Nomad Visa](/visas/sri-lanka/digital-nomad-visa/digital-nomad-visa-category-department-of-immigration-and-emigration/) | Required | — | valid-in-country insurer |
+| Sweden | [Residence Permit for Studies](/visas/sweden/residence-permit-for-studies/residence-permit-for-higher-education-studies-under-one-year-migrationsverket/) | Required | — | full stay, comprehensive |
+| Taiwan | [Digital Nomad Visitor Visa](/visas/taiwan/digital-nomad-visitor-visa/digital-nomad-visitor-visa-bureau-of-consular-affairs/) | Required | — | full stay |
+| Thailand | [Digital Nomad Visa (DTV)](/visas/thailand/digital-nomad-visa-dtv/thai-e-visa/) | Not required | — | not required |
+| Turkey | [Short-Term Residence Permit](/visas/turkey/short-term-residence-permit/residence-permit-pmm-general-information/) | Required | — | full stay |
+| United Arab Emirates | [Residence for Virtual Work](/visas/united-arab-emirates/residence-for-virtual-work/virtual-work-residence-gdrfa-dubai/) | Required | — | — |
+| Uruguay | [Working Holiday](/visas/uruguay/working-holiday/working-holiday-for-foreign-citizens-gub-uy/) | Required | — | comprehensive |
+
+## How we compile this
+
+Each requirement is taken from an official authority source (a ministry, consulate, immigration department or official gazette). We store the exact document, hash it, and encode only the requirements the source states verbatim. A rule engine then compares those requirements to insurance product facts and returns a status (GREEN, YELLOW, RED, UNKNOWN, or NOT_REQUIRED). See the [methodology](/methodology/) for the full logic and the [compliance checker](/ui/) to test a specific policy.
+
+## Use or cite this data
+
+You are welcome to cite these figures or link to this page. Please attribute VisaFact and link to <https://visafact.org/visa-insurance-requirements/>. Requirements change, so each row links to the route page where you can see the source and verification date.
+
+## Frequently asked questions
+
+**Which visas need health insurance?**  
+Most long-stay and digital-nomad routes do: 53 of the 54 routes here require it. A few (for example Thailand's DTV) do not list insurance as a required document.
+
+**Is there a standard minimum amount?**  
+No. Minimums differ by country and many routes state no figure at all. Where an amount is stated it ranges from EUR 5,792 upward, and Spain requires unlimited cover.
+
+**Is travel insurance enough?**  
+It depends on the route. Some accept travel medical insurance; others (such as Spain and Germany) require comprehensive health insurance and reject travel policies. Check the specific route.
+
+## Disclaimer
+
+Not legal advice. This is an evidence-based snapshot; always confirm current requirements with the official authority before you apply.

--- a/hugo.toml
+++ b/hugo.toml
@@ -47,34 +47,38 @@ canonifyURLs = true
     pageRef = "visas"
     weight = 2
   [[menu.main]]
+    name = "Compare"
+    pageRef = "visa-insurance-requirements"
+    weight = 3
+  [[menu.main]]
     name = "Blog"
     pageRef = "posts"
-    weight = 3
+    weight = 4
   [[menu.main]]
     name = "Guides"
     pageRef = "guides"
-    weight = 4
+    weight = 5
   [[menu.main]]
     name = "Traps"
     pageRef = "traps"
-    weight = 5
+    weight = 6
   [[menu.main]]
     name = "Methodology"
     pageRef = "methodology"
-    weight = 6
+    weight = 7
   [[menu.main]]
     name = "About"
     pageRef = "about"
-    weight = 7
+    weight = 8
   [[menu.main]]
     name = "Contact"
     pageRef = "contact"
-    weight = 8
+    weight = 9
   [[menu.main]]
     name = "Disclaimer"
     pageRef = "disclaimer"
-    weight = 9
+    weight = 10
   [[menu.main]]
     name = "Affiliate"
     pageRef = "affiliate-disclosure"
-    weight = 10
+    weight = 11

--- a/tools/build_requirements_table.py
+++ b/tools/build_requirements_table.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Generate the linkable 'visa insurance requirements by country' comparison page.
+
+Reads every data/visas/**/visa_facts.json and emits
+content/visa-insurance-requirements/_index.md: a single comprehensive,
+evidence-based comparison table + citable summary stats. Re-run when routes
+change. Route links point to the generated hub pages (slug rules mirror
+build_content_hubs.slugify), validated by check_internal_links.py.
+"""
+import json
+import re
+import glob
+import os
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+OUT = os.path.join(ROOT, "content", "visa-insurance-requirements", "_index.md")
+SNAPSHOT = os.environ.get("SNAPSHOT_ID", "2026-06-13")
+
+
+def slugify(value: str) -> str:
+    value = value.lower()
+    value = re.sub(r"[^a-z0-9]+", "-", value).strip("-")
+    return value or "unknown"
+
+
+def fmt_amount(val, ccy):
+    try:
+        n = "{:,}".format(int(val))
+    except Exception:
+        n = str(val)
+    return f"{n} {ccy}".strip()
+
+
+def load_routes():
+    rows = []
+    for f in glob.glob(os.path.join(ROOT, "data", "visas", "**", "visa_facts.json"), recursive=True):
+        d = json.load(open(f, encoding="utf-8"))
+        reqs = {r["key"]: r for r in d.get("requirements", [])}
+        mandatory = reqs.get("insurance.mandatory", {}).get("value", True)
+        minc = reqs.get("insurance.min_coverage")
+        min_str = fmt_amount(minc["value"], minc.get("currency", "")) if minc else "—"
+        tags = []
+        if reqs.get("insurance.must_cover_full_period", {}).get("value"):
+            tags.append("full stay")
+        if reqs.get("insurance.eu_licensed_insurer", {}).get("value"):
+            tags.append("EU-licensed insurer")
+        if any(k.startswith("insurance.authorized_in") for k in reqs):
+            tags.append("valid-in-country insurer")
+        if reqs.get("insurance.comprehensive", {}).get("value"):
+            tags.append("comprehensive")
+        if reqs.get("insurance.unlimited_coverage", {}).get("value"):
+            tags.append("unlimited")
+        if reqs.get("insurance.covers_public_health_system_risks", {}).get("value"):
+            tags.append("public-health-equivalent")
+        if reqs.get("insurance.no_deductible", {}).get("value") or reqs.get("insurance.no_copayment", {}).get("value"):
+            tags.append("no deductible/copay")
+        if reqs.get("insurance.travel_insurance_accepted", {}).get("value") is False:
+            tags.append("travel insurance not accepted")
+        hub = "/visas/{}/{}/{}/".format(
+            slugify(d["country"]), slugify(d["visa_name"]), slugify(d["route"]))
+        rows.append({
+            "country": d["country"],
+            "visa": d["visa_name"],
+            "required": bool(mandatory),
+            "min": min_str if mandatory else "—",
+            "tags": ", ".join(tags) if (mandatory and tags) else ("—" if mandatory else "not required"),
+            "hub": hub,
+        })
+    rows.sort(key=lambda r: (r["country"], r["visa"]))
+    return rows
+
+
+def main():
+    rows = load_routes()
+    countries = sorted({r["country"] for r in rows})
+    n_routes = len(rows)
+    n_countries = len(countries)
+    n_required = sum(1 for r in rows if r["required"])
+    n_not = n_routes - n_required
+    n_min = sum(1 for r in rows if r["required"] and r["min"] != "—")
+    n_full = sum(1 for r in rows if "full stay" in r["tags"])
+    n_terr = sum(1 for r in rows if "valid-in-country insurer" in r["tags"] or "EU-licensed insurer" in r["tags"])
+
+    lines = []
+    lines.append("---")
+    lines.append('title: "Visa health insurance requirements by country (2026, evidence-based)"')
+    lines.append('description: "A comprehensive, source-backed comparison of health insurance requirements for {} long-stay and digital-nomad visa routes across {} countries."'.format(n_routes, n_countries))
+    lines.append("date: 2026-06-16")
+    lines.append("lastmod: 2026-06-16")
+    lines.append("---")
+    lines.append("")
+    lines.append("This page compares the official health-insurance requirements for **{} long-stay, digital-nomad and residence visa routes across {} countries**. Every entry is built from a primary government source, stored as a byte-exact snapshot and verified with a SHA-256 hash. Where an official source does not state a detail, we mark it UNKNOWN rather than guess.".format(n_routes, n_countries))
+    lines.append("")
+    lines.append("## Key findings")
+    lines.append("")
+    lines.append("- **{} of {} routes require health insurance**; {} do not list it as a required document.".format(n_required, n_routes, n_not))
+    lines.append("- **{} routes specify a minimum coverage amount.** Stated minimums range from EUR 5,792 (Lithuania national D visa) upward; Spain's digital-nomad and non-lucrative visas instead require *unlimited* cover from an insurer authorized in Spain.".format(n_min))
+    lines.append("- **{} routes restrict the insurer or territory** — the policy must be valid in the destination, or issued by a locally-authorized or EU-licensed insurer.".format(n_terr))
+    lines.append("- **{} routes require the policy to cover the full period of stay**, which rules out subscriptions that can lapse mid-stay.".format(n_full))
+    lines.append("- Stated amounts appear in several currencies (EUR, USD, GBP, JPY, KRW, ISK), so a like-for-like comparison needs currency conversion.")
+    lines.append("")
+    lines.append("## Requirements by country")
+    lines.append("")
+    lines.append("| Country | Visa / route | Insurance | Min. coverage | Key conditions |")
+    lines.append("| --- | --- | --- | --- | --- |")
+    for r in rows:
+        req = "Required" if r["required"] else "Not required"
+        lines.append("| {} | [{}]({}) | {} | {} | {} |".format(
+            r["country"], r["visa"], r["hub"], req, r["min"], r["tags"]))
+    lines.append("")
+    lines.append("## How we compile this")
+    lines.append("")
+    lines.append("Each requirement is taken from an official authority source (a ministry, consulate, immigration department or official gazette). We store the exact document, hash it, and encode only the requirements the source states verbatim. A rule engine then compares those requirements to insurance product facts and returns a status (GREEN, YELLOW, RED, UNKNOWN, or NOT_REQUIRED). See the [methodology](/methodology/) for the full logic and the [compliance checker](/ui/) to test a specific policy.")
+    lines.append("")
+    lines.append("## Use or cite this data")
+    lines.append("")
+    lines.append("You are welcome to cite these figures or link to this page. Please attribute VisaFact and link to <https://visafact.org/visa-insurance-requirements/>. Requirements change, so each row links to the route page where you can see the source and verification date.")
+    lines.append("")
+    lines.append("## Frequently asked questions")
+    lines.append("")
+    lines.append("**Which visas need health insurance?**  ")
+    lines.append("Most long-stay and digital-nomad routes do: {} of the {} routes here require it. A few (for example Thailand's DTV) do not list insurance as a required document.".format(n_required, n_routes))
+    lines.append("")
+    lines.append("**Is there a standard minimum amount?**  ")
+    lines.append("No. Minimums differ by country and many routes state no figure at all. Where an amount is stated it ranges from EUR 5,792 upward, and Spain requires unlimited cover.")
+    lines.append("")
+    lines.append("**Is travel insurance enough?**  ")
+    lines.append("It depends on the route. Some accept travel medical insurance; others (such as Spain and Germany) require comprehensive health insurance and reject travel policies. Check the specific route.")
+    lines.append("")
+    lines.append("## Disclaimer")
+    lines.append("")
+    lines.append("Not legal advice. This is an evidence-based snapshot; always confirm current requirements with the official authority before you apply.")
+    lines.append("")
+
+    os.makedirs(os.path.dirname(OUT), exist_ok=True)
+    open(OUT, "w", encoding="utf-8").write("\n".join(lines))
+    print("Wrote {} ({} routes / {} countries)".format(OUT, n_routes, n_countries))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
A **linkable asset** to attract backlinks + AI citations (the authority lever for a new site) — and a sitewide internal-link hub.

- New page **`/visa-insurance-requirements/`**: a single comprehensive table comparing all **54 routes / 52 countries** — insurance required?, minimum amount, key conditions — plus citable summary stats (e.g. "53 of 54 require insurance", "19 restrict the insurer/territory"), a methodology note, a "cite with attribution" block, and an AEO FAQ.
- **Generated from the dataset** by `tools/build_requirements_table.py` (re-runnable as routes grow), so it stays accurate.
- Every table row links to its route page → strengthens internal linking + discovery.
- Added to the main menu as **"Compare"** (weights renumbered).
- Dated 2026-06-16 to avoid Hugo's UTC future-date skip.

## Verification
54 rows / 54 valid hub links · `check_internal_links` ✅ · `hugo` build ✅ · banned-words clean ✅ · in sitemap ✅ · "Compare" nav link resolves ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)