### PR TITLE
feat(affiliate): activate Feather paid affiliate link on Spain DNV/NLV posts

### DIFF
--- a/content/posts/spain-dnv-insurance/index.md
+++ b/content/posts/spain-dnv-insurance/index.md
@@ -118,7 +118,7 @@ Use [the compliance checker](/ui/) to check the current snapshot for this route,
 Spain's DNV requires a health policy from an insurer authorized in Spain, with unlimited cover, no deductible, no co-payment and no waiting period, covering the risks of the public health system; travel insurance is not accepted. In the current snapshot the products that show GREEN are:
 
 - [ASISA Health Residents](https://www.asisa.es/seguros-medicos/extranjeros/residencia) — official (non-affiliate) link. We do not earn a commission.
-- [Feather Expat Health Insurance](https://feather-insurance.com/en-es/health-insurance/expat/non-lucrative-visa) — a health policy from an insurer registered in Spain (DGSFP), documenting unlimited cover, no co-payments or deductibles, and no waiting periods.
+- [Feather Expat Health Insurance](https://feather-insurance.com/en-es/health-insurance/expat/non-lucrative-visa?utm_source=visafact) — a health policy from an insurer registered in Spain (DGSFP), documenting unlimited cover, no co-payments or deductibles, and no waiting periods. Paid link; we may earn a commission if you purchase through it.
 
 > Use the compliance checker to confirm the current GREEN products for this route before you buy.
 
@@ -126,7 +126,7 @@ Spain's DNV requires a health policy from an insurer authorized in Spain, with u
 
 Not legal advice. Compliance results are evidence-based snapshots.
 
-If an affiliate link is present, it appears only after results and does not change the compliance outcome. The ASISA and Feather links above are currently official links (non-affiliate).
+If an affiliate link is present, it appears only after results and does not change the compliance outcome. The Feather link above is a paid affiliate link; the ASISA link is an official (non-affiliate) link. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
 
 Last updated: 2026-06-18
 

--- a/content/posts/spain-nlv-insurance.md
+++ b/content/posts/spain-nlv-insurance.md
@@ -99,7 +99,7 @@ Use [the compliance checker](/ui/) with the current snapshot for this route:
 In the current snapshot, the products that show GREEN for this route are ASISA Health Residents and Feather Expat Health Insurance, because their documented terms (authorized in Spain, no deductible, no copayment, no waiting period, unlimited cover) satisfy every modeled requirement. Other Spanish health policies in the checker (DKV Visado, Sanitas Mas Salud) show RED because their documented waiting periods conflict with the no-waiting-period rule, and worldwide travel products show RED because travel insurance is not accepted for this route.
 
 - [ASISA Health Residents](https://www.asisa.es/seguros-medicos/extranjeros/residencia) — official (non-affiliate) link. We do not earn a commission.
-- [Feather Expat Health Insurance](https://feather-insurance.com/en-es/health-insurance/expat/non-lucrative-visa) — a health policy from an insurer registered in Spain (DGSFP), documenting unlimited cover, no co-payments or deductibles, and no waiting periods.
+- [Feather Expat Health Insurance](https://feather-insurance.com/en-es/health-insurance/expat/non-lucrative-visa?utm_source=visafact) — a health policy from an insurer registered in Spain (DGSFP), documenting unlimited cover, no co-payments or deductibles, and no waiting periods. Paid link; we may earn a commission if you purchase through it.
 
 > Use the compliance checker to see the current GREEN products for this route before you buy.
 
@@ -107,7 +107,7 @@ In the current snapshot, the products that show GREEN for this route are ASISA H
 
 Not legal advice. Compliance results are evidence-based snapshots.
 
-If an affiliate link is present, it appears only after results and does not change the compliance outcome. The ASISA link above is an official (non-affiliate) link.
+If an affiliate link is present, it appears only after results and does not change the compliance outcome. The Feather link above is a paid affiliate link; the ASISA link is an official (non-affiliate) link. See [affiliate disclosure](https://visafact.org/affiliate-disclosure/).
 
 Last updated: 2026-06-08
 


### PR DESCRIPTION
## What
Owner completed the Feather partner signup and supplied the tracked affiliate links. This swaps the Feather link on both Spain posts from the official (non-affiliate) URL to the tracked affiliate URL (`utm_source=visafact`) and flips the disclosure wording to "paid affiliate link".

- `content/posts/spain-dnv-insurance/index.md`
- `content/posts/spain-nlv-insurance.md`

ASISA remains an official (non-affiliate) link. Both disclosures now link the canonical `/affiliate-disclosure/` page.

## Why no offers.json entry
`offers.json` is keyed by product only and surfaces wherever a product is GREEN. `FEATHER_SPAIN_2026` is GREEN on Spain (correct) **plus ~21 non-Spain "lenient" routes**, so a global entry would show a Spain `/en-es` health link on e.g. a Colombia/Thailand route — a misleading geo-link. The Spain-specific posts carry monetization without that risk.

## Verification
- `lint_content.py` — pass (exit 0)
- `hugo` — clean build (exit 0)
- No banned words; disclosures link `/affiliate-disclosure/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)