### PR TITLE
feat(seo): activate Microsoft UET tag (ti 97252523)

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -19,7 +19,7 @@ canonifyURLs = true
   [params.analytics]
     src = ""
     id = ""
-    bing_uet_tag = ""
+    bing_uet_tag = "97252523"
     [params.analytics.bing]
       SiteVerificationTag = "f105995883e543d0a55612178fb6c391"
   [params.gtm]


### PR DESCRIPTION
## What
Owner supplied the Microsoft Advertising **UET Tag ID `97252523`**. Sets `params.analytics.bing_uet_tag` to activate the conversion-tracking scaffold shipped in #363.

## Effect
The scaffold now loads the UET tag and fires affiliate-click conversion events sitewide:
- `click_genki` (genki.world/with/visafact)
- `click_safetywing` (safetywing.com)
- `click_feather` (feather-insurance.com)

Still gated on region consent via `vf_analytics_allowed()` (EU/UK requires cookie consent first).

## Verified
Built output contains `ti: "97252523"` and all three click events. `lint_content` + `hugo` pass.

## Owner next step
In Microsoft Advertising → create Event conversion goals `click_genki` / `click_safetywing` / `click_feather` (Secondary/observe) so the events are recorded as conversions, then the Bing Ads test can attribute affiliate clicks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)