### PR TITLE
fix(content): add required /ui/ and /visas/ links to Batch 1 posts

### DIFF
--- a/content/posts/spain-dnv-application-process.md
+++ b/content/posts/spain-dnv-application-process.md
@@ -71,7 +71,7 @@ VisaFact compares each authority requirement against insurance product evidence 
 
 ## Check in the engine
 
-Confirm whether a specific policy meets the Spain DNV rule for the current snapshot:
+Confirm in [the compliance checker](/ui/) whether a specific policy meets the Spain DNV rule for the current snapshot:
 
 {{< checker_cta visa="ES_DNV_BLS_LONDON_2026" snapshot="2026-06-13" >}}
 
@@ -83,6 +83,7 @@ For the Spain DNV, the products that show GREEN are health policies from an insu
 
 ## Related reading
 
+- [Spain DNV requirements (route page)](/visas/spain/digital-nomad-visa/consulate-via-bls-london/)
 - [Spain DNV insurance requirements](/posts/spain-dnv-insurance/)
 - [Spain Non-Lucrative Visa: application process](/posts/spain-nlv-application-process/)
 - ["No co-payment, no deductible": what Spain's insurance rule means](/posts/spain-visa-insurance-no-copay-deductible/)

--- a/content/posts/spain-nlv-application-process.md
+++ b/content/posts/spain-nlv-application-process.md
@@ -61,7 +61,7 @@ VisaFact compares each authority requirement against insurance product evidence 
 
 ## Check in the engine
 
-Confirm whether a specific policy meets the Spain NLV rule for the current snapshot:
+Confirm in [the compliance checker](/ui/) whether a specific policy meets the Spain NLV rule for the current snapshot:
 
 {{< checker_cta visa="ES_NLV_LA_2026" snapshot="2026-06-08" >}}
 
@@ -73,6 +73,7 @@ For the Spain NLV, the products that show GREEN are health policies from an insu
 
 ## Related reading
 
+- [Spain NLV requirements (route page)](/visas/spain/non-lucrative-visa/consulate-los-angeles/)
 - [Spain NLV insurance requirements](/posts/spain-nlv-insurance/)
 - [Spain Digital Nomad Visa: application process](/posts/spain-dnv-application-process/)
 - ["No co-payment, no deductible": what Spain's insurance rule means](/posts/spain-visa-insurance-no-copay-deductible/)

--- a/content/posts/spain-visa-insurance-no-copay-deductible.md
+++ b/content/posts/spain-visa-insurance-no-copay-deductible.md
@@ -52,7 +52,7 @@ In the current snapshot, the products that show GREEN for the Spain DNV are heal
 
 ## Check in the engine
 
-Confirm whether a specific policy meets the Spain rule for the current snapshot:
+Confirm in [the compliance checker](/ui/) whether a specific policy meets the Spain rule for the current snapshot:
 
 {{< checker_cta visa="ES_DNV_BLS_LONDON_2026" snapshot="2026-06-13" >}}
 
@@ -65,6 +65,7 @@ For the Spain DNV and NLV, the products that meet every term in the current snap
 
 ## Related reading
 
+- [Spain DNV requirements (route page)](/visas/spain/digital-nomad-visa/consulate-via-bls-london/)
 - [Spain DNV insurance requirements](/posts/spain-dnv-insurance/)
 - [Spain NLV insurance requirements](/posts/spain-nlv-insurance/)
 - [Spain Digital Nomad Visa: application process](/posts/spain-dnv-application-process/)

--- a/content/posts/travel-vs-health-insurance-visa.md
+++ b/content/posts/travel-vs-health-insurance-visa.md
@@ -56,7 +56,7 @@ VisaFact compares each route's authority requirements against insurance product 
 
 ## Check in the engine
 
-Compare a specific policy against a route, for example the Spain Digital Nomad Visa:
+Compare in [the compliance checker](/ui/) a specific policy against a route, for example the Spain Digital Nomad Visa:
 
 {{< checker_cta visa="ES_DNV_BLS_LONDON_2026" snapshot="2026-06-13" >}}
 
@@ -71,6 +71,7 @@ Always confirm the result for your exact route in the checker before you buy.
 
 ## Related reading
 
+- [Spain DNV requirements (route page)](/visas/spain/digital-nomad-visa/consulate-via-bls-london/)
 - [Visa insurance requirements by country](/visa-insurance-requirements/)
 - [Spain Digital Nomad Visa: application process](/posts/spain-dnv-application-process/)
 - ["No co-payment, no deductible": what Spain's insurance rule means](/posts/spain-visa-insurance-no-copay-deductible/)


### PR DESCRIPTION
## Why
The post-merge **Deploy Hugo site** for #374 failed `seo_audit_tests.ps1`: every `content/posts/*.md` must contain a literal `/ui/` link **and** at least one `/visas/` link. This gate is part of the full deploy pipeline but not the PR check, so it slipped through. The 4 Batch-1 posts used the `checker_cta` shortcode + `/visa-insurance-requirements/`, which don't match.

## Fix
- Added an explicit `[the compliance checker](/ui/)` link in each "Check in the engine" section.
- Added a `/visas/` route-page link in each "Related reading".

## Verified locally (the gates the PR check skips)
`seo_audit.py --config tools/seo_thresholds.json` ✅ · `seo_audit_tests.ps1` ✅ · `lint_content` ✅ · `check_internal_links` ✅ · `check_editorial_targets` ✅ · `hugo` ✅

Restores the deploy so the Batch-1 pages go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)