### PR TITLE
🎨 Palette: Improve accessibility of interactive elements in UI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-13 - Interactive elements and forms A11y
+**Learning:** The mobile menu toggle and form controls in the UI lacked essential ARIA attributes (`aria-expanded`, `aria-controls`, `for` attributes on labels, and `aria-describedby` for hints), limiting screen reader accessibility.
+**Action:** Always verify that interactive buttons include explicit state and control mappings, and form controls have correctly associated labels and descriptive text.

--- a/ui/index.html
+++ b/ui/index.html
@@ -111,6 +111,8 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
+        aria-expanded="false"
+        aria-controls="mobileMenu"
         aria-label="Toggle menu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
@@ -183,12 +185,13 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
             <select id="visaSelect"
+              aria-describedby="visaHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -200,12 +203,13 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
             <select id="productSelect"
+              aria-describedby="productHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select an insurance product</option>
             </select>
@@ -1176,9 +1180,16 @@
     $("mobileMenuBtn")?.addEventListener("click", () => {
       const menu = $("mobileMenu");
       const btn = $("mobileMenuBtn");
-      const isOpen = !menu.classList.contains("hidden");
-      menu.classList.toggle("hidden");
-      btn.querySelector("span").textContent = isOpen ? "menu" : "close";
+      const isHidden = menu.classList.contains("hidden");
+      if (isHidden) {
+        menu.classList.remove("hidden");
+        btn.setAttribute("aria-expanded", "true");
+        btn.querySelector("span").textContent = "close";
+      } else {
+        menu.classList.add("hidden");
+        btn.setAttribute("aria-expanded", "false");
+        btn.querySelector("span").textContent = "menu";
+      }
     });
 
     init().catch(err => {


### PR DESCRIPTION
🎨 Palette: Improve accessibility of interactive elements in UI

💡 What:
- Added `aria-expanded` and `aria-controls` to the mobile menu toggle button, dynamically managed by JS.
- Added explicit `for` attributes connecting the labels to the `visaSelect` and `productSelect` inputs.
- Added `aria-describedby` attributes to link the `<select>` inputs to their helper hint text.

🎯 Why:
To ensure the interface is fully accessible to screen readers, providing proper context for form fields and interactive states.

♿ Accessibility:
Fixes unlabelled forms and missing state announcements for interactive buttons.

---
*PR created automatically by Jules for task [18445886792678922115](https://jules.google.com/task/18445886792678922115) started by @W73QB*