### PR TITLE
🎨 Palette: Accessibility improvements for menu and forms

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-03-24 - Accessibility Enhancements
+**Learning:** Input labels in flex layouts require explicit `for` attributes for proper screen reader association. Form inputs need `aria-describedby` referencing hint texts. Mobile menu toggle buttons require `aria-expanded` and `aria-controls` to programmatically expose their state.
+**Action:** Ensure custom dropdowns/selects and toggle buttons implement comprehensive ARIA properties when native association falls short.

--- a/ui/index.html
+++ b/ui/index.html
@@ -111,7 +111,8 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+
+        aria-expanded="false" aria-controls="mobileMenu" aria-label="Toggle menu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -183,12 +184,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -200,12 +201,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select an insurance product</option>
             </select>
@@ -1179,6 +1180,7 @@
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
+      btn.setAttribute("aria-expanded", String(!isOpen));
     });
 
     init().catch(err => {


### PR DESCRIPTION
💡 What: Added aria properties to mobile menu toggle, bound to js state. Added semantic associations for form labels and hints using `for` and `aria-describedby`.
🎯 Why: Screen reader users previously could not tell if the mobile menu was open or what it controlled, and could not associate form inputs with their visual labels or hints.
♿ Accessibility: Improved screen reader announcements for the mobile navigation toggle and main form inputs.

---
*PR created automatically by Jules for task [1899483780973325273](https://jules.google.com/task/1899483780973325273) started by @W73QB*