### PR TITLE
🎨 Palette: Interactive Component Accessibility Improvements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-24 - Interactive Component Accessibility
+**Learning:** Icon-only toggles and form elements without explicit label associations require proper ARIA attributes to be fully accessible. Dynamic state requires syncing JavaScript (`aria-expanded`) and explicit target matching (`aria-controls`, `aria-describedby`, and `for`).
+**Action:** Always add ARIA attributes and explicitly link inputs, toggles, and elements that they control or are described by.

--- a/ui/index.html
+++ b/ui/index.html
@@ -111,7 +111,7 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+        aria-label="Toggle menu" aria-expanded="false" aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -183,12 +183,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -200,12 +200,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select an insurance product</option>
             </select>
@@ -1179,6 +1179,7 @@
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
+      btn.setAttribute("aria-expanded", String(!isOpen));
     });
 
     init().catch(err => {


### PR DESCRIPTION
Added ARIA accessibility improvements to the interactive components in `ui/index.html`. Specifically, added `aria-expanded` and `aria-controls` to the mobile menu button (and updated its click handler to dynamically toggle `aria-expanded`), and added `for` and `aria-describedby` attributes to explicitly link the "Visa" and "Product" form labels to their select dropdowns. Evaluated and confirmed visual/interactive correctness using Playwright. Recorded learnings in Palette journal.

---
*PR created automatically by Jules for task [453497727284970365](https://jules.google.com/task/453497727284970365) started by @W73QB*