### PR TITLE
🎨 Palette: Accessibility fixes for UI inputs and mobile menu

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-25 - Accessibility fixes for UI components
+**Learning:** Form `<label>` associations and input hints require explicit attributes (`for` and `aria-describedby`), especially when visual flex layouts decouple them. Mobile menu toggles also need synchronized `aria-expanded` attributes in their JS logic.
+**Action:** Add strict tests for proper ARIA/label relationships when introducing new semantic components.

--- a/ui/index.html
+++ b/ui/index.html
@@ -111,7 +111,7 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+        aria-label="Toggle menu" aria-expanded="false" aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -183,12 +183,13 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
             <select id="visaSelect"
+              aria-describedby="visaHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -200,12 +201,13 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
             <select id="productSelect"
+              aria-describedby="productHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select an insurance product</option>
             </select>
@@ -1179,6 +1181,7 @@
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
+      btn.setAttribute("aria-expanded", String(!isOpen));
     });
 
     init().catch(err => {


### PR DESCRIPTION
💡 What: The UX enhancement added: Explicit `<label>` to `<select>` associations (`for` attr), `aria-describedby` hint text connections, and dynamic `aria-expanded` toggle logic for the mobile menu.
🎯 Why: The user problem it solves: The visual flex-col layout decoupled text labels from interactive form elements, causing screen readers to lack context. The mobile menu toggle lacked state indication.
📸 Before/After: Visuals remained exactly identical, but accessibility tree mapping is now proper.
♿ Accessibility: Screen reader users can now focus the labels to activate the dropdowns, hear correct hint text when interacting with the form, and understand if the mobile menu is open or closed.

---
*PR created automatically by Jules for task [18347955208668742323](https://jules.google.com/task/18347955208668742323) started by @W73QB*