### PR TITLE
🎨 Palette: Add dynamic ARIA attributes to mobile menu toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-26 - Dynamic ARIA attributes for mobile toggles
+**Learning:** Icon-only mobile menu toggles need dynamic `aria-expanded` mapped to their state and `aria-controls` for full accessibility.
+**Action:** Ensure that visual class changes on mobile toggle buttons are mapped to their corresponding ARIA attributes programmatically in the JavaScript logic.

--- a/ui/index.html
+++ b/ui/index.html
@@ -111,7 +111,7 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+        aria-label="Toggle menu" aria-expanded="false" aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -1179,6 +1179,7 @@
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
+      btn.setAttribute("aria-expanded", String(!isOpen));
     });
 
     init().catch(err => {


### PR DESCRIPTION
🎨 Palette: Dynamic ARIA attributes for mobile toggle

💡 **What:** Added `aria-expanded="false"` and `aria-controls="mobileMenu"` to the mobile menu button and updated its click listener to dynamically toggle the `aria-expanded` state.
🎯 **Why:** Icon-only mobile menu toggles without dynamic ARIA attributes leave screen reader users unaware of the menu's state (open/closed) and what element it controls.
♿ **Accessibility:** Screen readers will now announce when the mobile navigation menu is expanded or collapsed.

### Learnings
Recorded in `.jules/palette.md`:
* **Learning:** Icon-only mobile menu toggles need dynamic `aria-expanded` mapped to their state and `aria-controls` for full accessibility.
* **Action:** Ensure that visual class changes on mobile toggle buttons are mapped to their corresponding ARIA attributes programmatically in the JavaScript logic.

---
*PR created automatically by Jules for task [10340251940070185522](https://jules.google.com/task/10340251940070185522) started by @W73QB*