### PR TITLE
🎨 Palette: Accessibility improvements for form and mobile menu

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -111,7 +111,7 @@
       </div>
       <button id="mobileMenuBtn"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
-        aria-label="Toggle menu">
+        aria-label="Toggle menu" aria-expanded="false" aria-controls="mobileMenu">
         <span class="material-symbols-outlined text-2xl">menu</span>
       </button>
       <nav class="hidden md:flex items-center gap-8">
@@ -183,12 +183,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -200,12 +200,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select an insurance product</option>
             </select>
@@ -1179,6 +1179,7 @@
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
+      btn.setAttribute("aria-expanded", String(!isOpen));
     });
 
     init().catch(err => {


### PR DESCRIPTION
This PR adds critical accessibility attributes to `ui/index.html` to improve usability with screen readers. Specifically:
- Labels for "I am applying for" and "I want to use" now have explicit `for` attributes targeting their respective `<select>` fields, solving the visual/semantic disconnect caused by the `flex-col` layout.
- Both `<select>` fields now include `aria-describedby` pointing to their respective hint texts (`visaHint` and `productHint`).
- The mobile menu toggle button now includes `aria-expanded="false"` and `aria-controls="mobileMenu"`.
- The JavaScript logic for the mobile menu toggle correctly updates the `aria-expanded` state.

All `ui_compliance_tests.ps1` tests pass.

---
*PR created automatically by Jules for task [18118290501703340142](https://jules.google.com/task/18118290501703340142) started by @W73QB*