### PR TITLE
🎨 Palette: Improve form and menu accessibility

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -109,7 +109,7 @@
         <span class="material-symbols-outlined text-primary text-3xl icon-filled">verified_user</span>
         <span class="text-text-primary dark:text-white text-xl font-bold tracking-tight">VisaFact</span>
       </div>
-      <button id="mobileMenuBtn"
+      <button id="mobileMenuBtn" aria-expanded="false" aria-controls="mobileMenu"
         class="md:hidden p-2 text-text-primary dark:text-white hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
         aria-label="Toggle menu">
         <span class="material-symbols-outlined text-2xl">menu</span>
@@ -183,12 +183,12 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
+          <label for="visaSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I am applying
             for</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">gavel</span>
-            <select id="visaSelect"
+            <select id="visaSelect" aria-describedby="visaHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select visa route (authority)</option>
             </select>
@@ -200,12 +200,12 @@
         </div>
 
         <div class="flex flex-col gap-3 group">
-          <label class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
+          <label for="productSelect" class="text-xs font-bold text-text-secondary dark:text-gray-400 uppercase tracking-wider">I want to
             use</label>
           <div class="relative">
             <span
               class="material-symbols-outlined absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 group-focus-within:text-primary transition-colors">health_and_safety</span>
-            <select id="productSelect"
+            <select id="productSelect" aria-describedby="productHint"
               class="vf-field w-full pl-12 pr-10 appearance-none cursor-pointer">
               <option value="">Select an insurance product</option>
             </select>
@@ -1178,6 +1178,7 @@
       const btn = $("mobileMenuBtn");
       const isOpen = !menu.classList.contains("hidden");
       menu.classList.toggle("hidden");
+      btn.setAttribute("aria-expanded", String(!isOpen));
       btn.querySelector("span").textContent = isOpen ? "menu" : "close";
     });
 


### PR DESCRIPTION
🎨 Palette: Improve form and menu accessibility

💡 **What:** Added missing `for` attributes to labels to properly link them with their corresponding `<select>` inputs (`visaSelect` and `productSelect`). Added `aria-describedby` attributes to the select inputs to link them with their help text hints. Added `aria-expanded` and `aria-controls` attributes to the mobile menu button and updated the javascript to dynamically set `aria-expanded`.
🎯 **Why:** To improve accessibility for screen readers and keyboard users. Proper label associations ensure screen readers announce the input context, while `aria-describedby` provides additional context. The menu updates ensure screen readers understand the state and target of the menu button.
♿ **Accessibility:**
- Ensures screen readers can correctly associate labels with form controls.
- Provides contextual help text via `aria-describedby`.
- Properly manages the interactive state of the mobile menu toggle.

---
*PR created automatically by Jules for task [14798593967634831613](https://jules.google.com/task/14798593967634831613) started by @W73QB*